### PR TITLE
Retrospective Review: complete v1-v3 implementation

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,16 +1,20 @@
 ## Summary
-- describe the user-facing change in release-note language
-- keep this focused on shipped behavior, not implementation mechanics
+
+- What changed?
+- Why does it matter?
+
+## Testing
+
+- [ ] `go test ./...`
+- [ ] `go build ./...`
+- [ ] Other:
 
 ## Release Notes
-- list the 1-5 highest-signal user-visible changes
-- write these as human-readable bullets that can survive into GitHub-generated release notes
-- if the PR is mainly a fix, say what was broken and what is now correct
 
-## Verification
-- go test ./...
-- go build ./...
+- User-facing change:
+- Planning or workflow impact:
+- Follow-up work:
 
-## Maintainer Notes
-- if this PR changes `skills/plan/`, reinstall the local Plan skill before closeout:
-  - `plan skills install --scope local --agent codex --project .`
+## Planning
+
+- Related epic/spec/story:

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -11,6 +11,7 @@
 
 ## Release Notes
 
+<!-- This section is promoted into the published GitHub release body when this PR ships. -->
 - User-facing change:
 - Planning or workflow impact:
 - Follow-up work:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,29 +38,9 @@ jobs:
             echo "sha=${{ github.sha }}" >> "$GITHUB_OUTPUT"
           fi
 
-  verify:
-    runs-on: ubuntu-latest
-    needs: resolve
-
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          ref: ${{ needs.resolve.outputs.sha }}
-
-      - uses: actions/setup-go@v5
-        with:
-          go-version: '1.26'
-          cache: true
-
-      - name: Test
-        run: go test ./...
-
-      - name: Build
-        run: go build ./...
-
   build:
     runs-on: ubuntu-latest
-    needs: [resolve, verify]
+    needs: resolve
     strategy:
       fail-fast: false
       matrix:
@@ -121,7 +101,7 @@ jobs:
 
   release:
     runs-on: ubuntu-latest
-    needs: [resolve, verify, build]
+    needs: [resolve, build]
 
     steps:
       - uses: actions/download-artifact@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,6 +15,7 @@ on:
 
 permissions:
   contents: write
+  pull-requests: read
 
 jobs:
   resolve:
@@ -104,6 +105,14 @@ jobs:
     needs: [resolve, build]
 
     steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ needs.resolve.outputs.sha }}
+          fetch-depth: 0
+
+      - name: Fetch tags
+        run: git fetch --force --tags origin
+
       - uses: actions/download-artifact@v4
         with:
           path: dist
@@ -116,13 +125,178 @@ jobs:
           cd dist
           sha256sum plan_${{ needs.resolve.outputs.tag }}_*.* > "plan_${{ needs.resolve.outputs.tag }}_checksums.txt"
 
+      - name: Resolve previous tag
+        id: previous_tag
+        shell: bash
+        env:
+          TAG: ${{ needs.resolve.outputs.tag }}
+        run: |
+          set -euo pipefail
+          PREVIOUS_TAG="$(git tag --sort=-v:refname | awk -v tag="${TAG}" '$0==tag {found=1; next} found {print; exit}')"
+          echo "tag=${PREVIOUS_TAG}" >> "$GITHUB_OUTPUT"
+
+      - name: Build release notes
+        id: notes
+        uses: actions/github-script@v7
+        env:
+          RELEASE_TAG: ${{ needs.resolve.outputs.tag }}
+          RELEASE_SHA: ${{ needs.resolve.outputs.sha }}
+          PREVIOUS_TAG: ${{ steps.previous_tag.outputs.tag }}
+        with:
+          script: |
+            const fs = require("fs");
+            const path = require("path");
+
+            const tag = process.env.RELEASE_TAG;
+            const sha = process.env.RELEASE_SHA;
+            const previousTag = process.env.PREVIOUS_TAG || "";
+            const { owner, repo } = context.repo;
+
+            function normalize(text) {
+              return (text || "").replace(/\r\n/g, "\n").trim();
+            }
+
+            function escapeRegExp(text) {
+              return text.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+            }
+
+            function extractSection(body, heading) {
+              const normalized = normalize(body);
+              if (!normalized) {
+                return "";
+              }
+              const lines = normalized.split("\n");
+              const headingMatcher = new RegExp(`^##\\s+${escapeRegExp(heading)}\\s*$`, "i");
+              let start = -1;
+              for (let i = 0; i < lines.length; i += 1) {
+                if (headingMatcher.test(lines[i].trim())) {
+                  start = i + 1;
+                  break;
+                }
+              }
+              if (start === -1) {
+                return "";
+              }
+              let end = lines.length;
+              for (let i = start; i < lines.length; i += 1) {
+                if (/^##\s+/.test(lines[i].trim())) {
+                  end = i;
+                  break;
+                }
+              }
+              return lines.slice(start, end).join("\n").trim();
+            }
+
+            function asBullets(text) {
+              const normalized = normalize(text);
+              if (!normalized) {
+                return [];
+              }
+              return normalized
+                .split("\n")
+                .map((line) => line.trim())
+                .filter(Boolean)
+                .map((line) => {
+                  if (/^[-*]\s+/.test(line)) {
+                    return line.replace(/^\*\s+/, "- ");
+                  }
+                  return `- ${line}`;
+                });
+            }
+
+            let pr = null;
+            try {
+              const response = await github.request("GET /repos/{owner}/{repo}/commits/{commit_sha}/pulls", {
+                owner,
+                repo,
+                commit_sha: sha,
+                mediaType: {
+                  previews: ["groot"],
+                },
+              });
+              pr = response.data.find((candidate) => candidate.merged_at) || response.data[0] || null;
+            } catch (error) {
+              core.warning(`Unable to resolve pull request for ${sha}: ${error.message}`);
+            }
+
+            let summary = "";
+            let highlights = [];
+            let verification = [];
+            let capsulesDirection = "";
+
+            if (pr) {
+              summary = normalize(extractSection(pr.body, "Summary"));
+              highlights = asBullets(extractSection(pr.body, "Release Notes"));
+              if (highlights.length === 0) {
+                highlights = asBullets(extractSection(pr.body, "User-Facing Impact"));
+              }
+              if (highlights.length === 0) {
+                highlights = asBullets(extractSection(pr.body, "Summary"));
+              }
+              verification = asBullets(extractSection(pr.body, "Verification"));
+              capsulesDirection = normalize(extractSection(pr.body, "Capsules Direction"));
+            }
+
+            if (!summary) {
+              summary = `Release ${tag} for \`${sha.slice(0, 7)}\`.`;
+            }
+
+            if (highlights.length === 0 && previousTag) {
+              try {
+                const compare = await github.rest.repos.compareCommits({
+                  owner,
+                  repo,
+                  basehead: `${previousTag}...${sha}`,
+                });
+                highlights = compare.data.commits
+                  .map((commit) => commit.commit.message.split("\n")[0].trim())
+                  .filter(Boolean)
+                  .slice(0, 5)
+                  .map((line) => `- ${line}`);
+              } catch (error) {
+                core.warning(`Unable to build commit fallback changelog: ${error.message}`);
+              }
+            }
+
+            if (highlights.length === 0) {
+              highlights = [
+                "- Maintainer-facing release with no structured release notes captured for this tag.",
+              ];
+            }
+
+            const lines = [];
+            if (summary) {
+              lines.push("## Summary", "", summary, "");
+            }
+            if (highlights.length > 0) {
+              lines.push("## Highlights", "", ...highlights, "");
+            }
+            if (capsulesDirection) {
+              lines.push("## Capsules Direction", "", capsulesDirection, "");
+            }
+            if (pr) {
+              lines.push("## Pull Request", "", `- ${pr.title} ([#${pr.number}](${pr.html_url}))`, "");
+            }
+            if (verification.length > 0) {
+              lines.push("## Verification", "", ...verification, "");
+            }
+            if (previousTag) {
+              lines.push(`**Full Changelog**: https://github.com/${owner}/${repo}/compare/${previousTag}...${tag}`);
+            }
+
+            const body = `${lines.join("\n").replace(/\n{3,}/g, "\n\n").trim()}\n`;
+            fs.mkdirSync("dist", { recursive: true });
+            const notesPath = path.join("dist", "release-notes.md");
+            fs.writeFileSync(notesPath, body);
+            core.setOutput("path", notesPath);
+
       - name: Publish GitHub release
         uses: softprops/action-gh-release@v2
         with:
           tag_name: ${{ needs.resolve.outputs.tag }}
           name: ${{ needs.resolve.outputs.tag }}
           target_commitish: ${{ needs.resolve.outputs.sha }}
-          generate_release_notes: true
+          body_path: ${{ steps.notes.outputs.path }}
           files: |
             dist/plan_${{ needs.resolve.outputs.tag }}_*.tar.gz
             dist/plan_${{ needs.resolve.outputs.tag }}_*.zip

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,9 +38,29 @@ jobs:
             echo "sha=${{ github.sha }}" >> "$GITHUB_OUTPUT"
           fi
 
-  build:
+  verify:
     runs-on: ubuntu-latest
     needs: resolve
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ needs.resolve.outputs.sha }}
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version: '1.26'
+          cache: true
+
+      - name: Test
+        run: go test ./...
+
+      - name: Build
+        run: go build ./...
+
+  build:
+    runs-on: ubuntu-latest
+    needs: [resolve, verify]
     strategy:
       fail-fast: false
       matrix:
@@ -101,7 +121,7 @@ jobs:
 
   release:
     runs-on: ubuntu-latest
-    needs: [resolve, build]
+    needs: [resolve, verify, build]
 
     steps:
       - uses: actions/download-artifact@v4

--- a/.github/workflows/tag-main-release.yml
+++ b/.github/workflows/tag-main-release.yml
@@ -7,6 +7,7 @@ on:
 
 permissions:
   contents: write
+  pull-requests: read
 
 concurrency:
   group: tag-main-release
@@ -56,6 +57,7 @@ jobs:
     uses: ./.github/workflows/release.yml
     permissions:
       contents: write
+      pull-requests: read
     with:
       tag: ${{ needs.tag.outputs.tag }}
       sha: ${{ needs.tag.outputs.sha }}

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 examples/
 dist/
-plan
+/plan
 *.exe
 .DS_Store

--- a/.plan/.meta/migrations.json
+++ b/.plan/.meta/migrations.json
@@ -1,5 +1,6 @@
 {
   "schema_version": 1,
-  "last_run_at": "2026-04-16T05:33:06Z",
+  "known": [],
+  "last_run_at": "2026-04-16T06:05:01Z",
   "status": "current"
 }

--- a/.plan/specs/brain-interop-and-planning-imports.md
+++ b/.plan/specs/brain-interop-and-planning-imports.md
@@ -3,11 +3,11 @@ created_at: "2026-04-16T05:33:06Z"
 epic: brain-interop-and-planning-imports
 project: plan
 slug: brain-interop-and-planning-imports
-status: approved
+status: implementing
 target_version: v3
 title: Brain Interop and Planning Imports Spec
 type: spec
-updated_at: "2026-04-16T06:28:46Z"
+updated_at: "2026-04-16T07:05:13Z"
 ---
 
 # Brain Interop and Planning Imports Spec

--- a/.plan/specs/brain-interop-and-planning-imports.md
+++ b/.plan/specs/brain-interop-and-planning-imports.md
@@ -3,11 +3,11 @@ created_at: "2026-04-16T05:33:06Z"
 epic: brain-interop-and-planning-imports
 project: plan
 slug: brain-interop-and-planning-imports
-status: draft
+status: approved
 target_version: v3
 title: Brain Interop and Planning Imports Spec
 type: spec
-updated_at: "2026-04-16T05:33:06Z"
+updated_at: "2026-04-16T06:28:46Z"
 ---
 
 # Brain Interop and Planning Imports Spec
@@ -79,10 +79,9 @@ Without an interop story, users may need to re-create valuable planning work by 
 
 ## Story Breakdown
 
-- [ ] Define import candidate discovery
-- [ ] Define `brain` to `plan` mapping rules
-- [ ] Add provenance fields and links
-- [ ] Test import on real `brain` planning material
+- [ ] [Inspect brain workspaces for import candidates](../stories/inspect-brain-workspaces-for-import-candidates.md)
+- [ ] [Import brain planning notes into plan artifacts](../stories/import-brain-planning-notes-into-plan-artifacts.md)
+- [ ] [Preserve import provenance and review flow](../stories/preserve-import-provenance-and-review-flow.md)
 
 ## Resources
 

--- a/.plan/specs/brain-interop-and-planning-imports.md
+++ b/.plan/specs/brain-interop-and-planning-imports.md
@@ -3,11 +3,11 @@ created_at: "2026-04-16T05:33:06Z"
 epic: brain-interop-and-planning-imports
 project: plan
 slug: brain-interop-and-planning-imports
-status: implementing
+status: done
 target_version: v3
 title: Brain Interop and Planning Imports Spec
 type: spec
-updated_at: "2026-04-16T07:05:13Z"
+updated_at: "2026-04-16T07:09:59Z"
 ---
 
 # Brain Interop and Planning Imports Spec

--- a/.plan/specs/core-workspace-and-artifact-system.md
+++ b/.plan/specs/core-workspace-and-artifact-system.md
@@ -3,11 +3,11 @@ created_at: "2026-04-16T05:33:06Z"
 epic: core-workspace-and-artifact-system
 project: plan
 slug: core-workspace-and-artifact-system
-status: draft
+status: approved
 target_version: v1
 title: Core Workspace and Artifact System Spec
 type: spec
-updated_at: "2026-04-16T05:33:06Z"
+updated_at: "2026-04-16T05:46:33Z"
 ---
 
 # Core Workspace and Artifact System Spec
@@ -88,9 +88,9 @@ Right now the repo has early planning notes, but not a fully defined and durable
 
 ## Story Breakdown
 
-- [ ] Define final `.plan/` directory contract
-- [ ] Harden workspace metadata and migration reporting
-- [ ] Add tests for init, doctor, and update behavior
+- [ ] [Define .plan workspace contract](../stories/define-plan-workspace-contract.md)
+- [ ] [Harden workspace metadata and repair lifecycle](../stories/harden-workspace-metadata-and-repair-lifecycle.md)
+- [ ] [Expand workspace test coverage](../stories/expand-workspace-test-coverage.md)
 
 ## Resources
 

--- a/.plan/specs/dependency-graph-and-ready-work.md
+++ b/.plan/specs/dependency-graph-and-ready-work.md
@@ -3,11 +3,11 @@ created_at: "2026-04-16T05:33:06Z"
 epic: dependency-graph-and-ready-work
 project: plan
 slug: dependency-graph-and-ready-work
-status: draft
+status: approved
 target_version: v3
 title: Dependency Graph and Ready Work Spec
 type: spec
-updated_at: "2026-04-16T05:33:06Z"
+updated_at: "2026-04-16T06:28:46Z"
 ---
 
 # Dependency Graph and Ready Work Spec
@@ -79,10 +79,9 @@ Without dependency modeling, larger plans become manual sorting exercises and it
 
 ## Story Breakdown
 
-- [ ] Define first dependency representation
-- [ ] Add validation for dependency references
-- [ ] Add ready-work calculation and CLI output
-- [ ] Test blocked/ready transitions thoroughly
+- [ ] [Add dependency metadata to stories](../stories/add-dependency-metadata-to-stories.md)
+- [ ] [Compute ready and blocked work sets](../stories/compute-ready-and-blocked-work-sets.md)
+- [ ] [Expose ready-work CLI and status views](../stories/expose-ready-work-cli-and-status-views.md)
 
 ## Resources
 

--- a/.plan/specs/dependency-graph-and-ready-work.md
+++ b/.plan/specs/dependency-graph-and-ready-work.md
@@ -3,11 +3,11 @@ created_at: "2026-04-16T05:33:06Z"
 epic: dependency-graph-and-ready-work
 project: plan
 slug: dependency-graph-and-ready-work
-status: approved
+status: implementing
 target_version: v3
 title: Dependency Graph and Ready Work Spec
 type: spec
-updated_at: "2026-04-16T06:28:46Z"
+updated_at: "2026-04-16T06:57:04Z"
 ---
 
 # Dependency Graph and Ready Work Spec

--- a/.plan/specs/dependency-graph-and-ready-work.md
+++ b/.plan/specs/dependency-graph-and-ready-work.md
@@ -3,11 +3,11 @@ created_at: "2026-04-16T05:33:06Z"
 epic: dependency-graph-and-ready-work
 project: plan
 slug: dependency-graph-and-ready-work
-status: implementing
+status: done
 target_version: v3
 title: Dependency Graph and Ready Work Spec
 type: spec
-updated_at: "2026-04-16T06:57:04Z"
+updated_at: "2026-04-16T07:03:16Z"
 ---
 
 # Dependency Graph and Ready Work Spec

--- a/.plan/specs/plan-quality-and-verification-engine.md
+++ b/.plan/specs/plan-quality-and-verification-engine.md
@@ -3,11 +3,11 @@ created_at: "2026-04-16T05:33:06Z"
 epic: plan-quality-and-verification-engine
 project: plan
 slug: plan-quality-and-verification-engine
-status: implementing
+status: done
 target_version: v2
 title: Plan Quality and Verification Engine Spec
 type: spec
-updated_at: "2026-04-16T06:41:08Z"
+updated_at: "2026-04-16T06:47:46Z"
 ---
 
 # Plan Quality and Verification Engine Spec

--- a/.plan/specs/plan-quality-and-verification-engine.md
+++ b/.plan/specs/plan-quality-and-verification-engine.md
@@ -3,11 +3,11 @@ created_at: "2026-04-16T05:33:06Z"
 epic: plan-quality-and-verification-engine
 project: plan
 slug: plan-quality-and-verification-engine
-status: approved
+status: implementing
 target_version: v2
 title: Plan Quality and Verification Engine Spec
 type: spec
-updated_at: "2026-04-16T06:28:46Z"
+updated_at: "2026-04-16T06:41:08Z"
 ---
 
 # Plan Quality and Verification Engine Spec

--- a/.plan/specs/plan-quality-and-verification-engine.md
+++ b/.plan/specs/plan-quality-and-verification-engine.md
@@ -3,11 +3,11 @@ created_at: "2026-04-16T05:33:06Z"
 epic: plan-quality-and-verification-engine
 project: plan
 slug: plan-quality-and-verification-engine
-status: draft
+status: approved
 target_version: v2
 title: Plan Quality and Verification Engine Spec
 type: spec
-updated_at: "2026-04-16T05:33:06Z"
+updated_at: "2026-04-16T06:28:46Z"
 ---
 
 # Plan Quality and Verification Engine Spec
@@ -79,10 +79,9 @@ Without quality signals, `plan` risks producing formally correct files that stil
 
 ## Story Breakdown
 
-- [ ] Define first quality ruleset for specs
-- [ ] Define first quality ruleset for stories
-- [ ] Expose issues through a user-friendly CLI surface
-- [ ] Test warning and failure behavior against real sample plans
+- [ ] [Add spec quality rules for required planning sections](../stories/add-spec-quality-rules-for-required-planning-sections.md)
+- [ ] [Add story quality rules for execution readiness](../stories/add-story-quality-rules-for-execution-readiness.md)
+- [ ] [Expose plan check command and reporting](../stories/expose-plan-check-command-and-reporting.md)
 
 ## Resources
 

--- a/.plan/specs/power-user-local-workflows.md
+++ b/.plan/specs/power-user-local-workflows.md
@@ -3,11 +3,11 @@ created_at: "2026-04-16T05:33:06Z"
 epic: power-user-local-workflows
 project: plan
 slug: power-user-local-workflows
-status: draft
+status: approved
 target_version: v3
 title: Power-User Local Workflows Spec
 type: spec
-updated_at: "2026-04-16T05:33:06Z"
+updated_at: "2026-04-16T06:28:47Z"
 ---
 
 # Power-User Local Workflows Spec
@@ -77,9 +77,9 @@ As projects grow, users need stronger local conventions around multiple epics, v
 
 ## Story Breakdown
 
-- [ ] Define the first power-user workflow helpers worth shipping
-- [ ] Improve cross-epic and cross-version visibility
-- [ ] Validate advanced local flows on real project work
+- [ ] [Add filtered status views for large local plans](../stories/add-filtered-status-views-for-large-local-plans.md)
+- [ ] [Add advanced roadmap and story selection helpers](../stories/add-advanced-roadmap-and-story-selection-helpers.md)
+- [ ] [Document and test advanced local planning workflows](../stories/document-and-test-advanced-local-planning-workflows.md)
 
 ## Resources
 

--- a/.plan/specs/power-user-local-workflows.md
+++ b/.plan/specs/power-user-local-workflows.md
@@ -3,11 +3,11 @@ created_at: "2026-04-16T05:33:06Z"
 epic: power-user-local-workflows
 project: plan
 slug: power-user-local-workflows
-status: implementing
+status: done
 target_version: v3
 title: Power-User Local Workflows Spec
 type: spec
-updated_at: "2026-04-16T07:12:42Z"
+updated_at: "2026-04-16T07:16:12Z"
 ---
 
 # Power-User Local Workflows Spec

--- a/.plan/specs/power-user-local-workflows.md
+++ b/.plan/specs/power-user-local-workflows.md
@@ -3,11 +3,11 @@ created_at: "2026-04-16T05:33:06Z"
 epic: power-user-local-workflows
 project: plan
 slug: power-user-local-workflows
-status: approved
+status: implementing
 target_version: v3
 title: Power-User Local Workflows Spec
 type: spec
-updated_at: "2026-04-16T06:28:47Z"
+updated_at: "2026-04-16T07:12:42Z"
 ---
 
 # Power-User Local Workflows Spec

--- a/.plan/specs/roadmap-and-portfolio-planning.md
+++ b/.plan/specs/roadmap-and-portfolio-planning.md
@@ -3,11 +3,11 @@ created_at: "2026-04-16T05:33:06Z"
 epic: roadmap-and-portfolio-planning
 project: plan
 slug: roadmap-and-portfolio-planning
-status: implementing
+status: done
 target_version: v2
 title: Roadmap and Portfolio Planning Spec
 type: spec
-updated_at: "2026-04-16T06:31:36Z"
+updated_at: "2026-04-16T06:39:51Z"
 ---
 
 # Roadmap and Portfolio Planning Spec

--- a/.plan/specs/roadmap-and-portfolio-planning.md
+++ b/.plan/specs/roadmap-and-portfolio-planning.md
@@ -3,11 +3,11 @@ created_at: "2026-04-16T05:33:06Z"
 epic: roadmap-and-portfolio-planning
 project: plan
 slug: roadmap-and-portfolio-planning
-status: approved
+status: implementing
 target_version: v2
 title: Roadmap and Portfolio Planning Spec
 type: spec
-updated_at: "2026-04-16T06:28:46Z"
+updated_at: "2026-04-16T06:31:36Z"
 ---
 
 # Roadmap and Portfolio Planning Spec

--- a/.plan/specs/roadmap-and-portfolio-planning.md
+++ b/.plan/specs/roadmap-and-portfolio-planning.md
@@ -3,11 +3,11 @@ created_at: "2026-04-16T05:33:06Z"
 epic: roadmap-and-portfolio-planning
 project: plan
 slug: roadmap-and-portfolio-planning
-status: draft
+status: approved
 target_version: v2
 title: Roadmap and Portfolio Planning Spec
 type: spec
-updated_at: "2026-04-16T05:33:06Z"
+updated_at: "2026-04-16T06:28:46Z"
 ---
 
 # Roadmap and Portfolio Planning Spec
@@ -79,9 +79,9 @@ The core workflow handles individual pieces of work well, but there is not yet a
 
 ## Story Breakdown
 
-- [ ] Finalize roadmap markdown format
-- [ ] Add version-target mapping rules for epics
-- [ ] Add roadmap editing and summary helpers
+- [ ] [Define roadmap version structure and parsing](../stories/define-roadmap-version-structure-and-parsing.md)
+- [ ] [Add roadmap CLI helpers for version views](../stories/add-roadmap-cli-helpers-for-version-views.md)
+- [ ] [Surface roadmap progress in status output](../stories/surface-roadmap-progress-in-status-output.md)
 
 ## Resources
 

--- a/.plan/specs/skill-installer-and-release-delivery.md
+++ b/.plan/specs/skill-installer-and-release-delivery.md
@@ -3,11 +3,11 @@ created_at: "2026-04-16T05:33:06Z"
 epic: skill-installer-and-release-delivery
 project: plan
 slug: skill-installer-and-release-delivery
-status: implementing
+status: done
 target_version: v1
 title: Skill, Installer, and Release Delivery Spec
 type: spec
-updated_at: "2026-04-16T06:20:53Z"
+updated_at: "2026-04-16T06:24:54Z"
 ---
 
 # Skill, Installer, and Release Delivery Spec

--- a/.plan/specs/skill-installer-and-release-delivery.md
+++ b/.plan/specs/skill-installer-and-release-delivery.md
@@ -3,11 +3,11 @@ created_at: "2026-04-16T05:33:06Z"
 epic: skill-installer-and-release-delivery
 project: plan
 slug: skill-installer-and-release-delivery
-status: approved
+status: implementing
 target_version: v1
 title: Skill, Installer, and Release Delivery Spec
 type: spec
-updated_at: "2026-04-16T05:46:33Z"
+updated_at: "2026-04-16T06:20:53Z"
 ---
 
 # Skill, Installer, and Release Delivery Spec

--- a/.plan/specs/skill-installer-and-release-delivery.md
+++ b/.plan/specs/skill-installer-and-release-delivery.md
@@ -3,11 +3,11 @@ created_at: "2026-04-16T05:33:06Z"
 epic: skill-installer-and-release-delivery
 project: plan
 slug: skill-installer-and-release-delivery
-status: draft
+status: approved
 target_version: v1
 title: Skill, Installer, and Release Delivery Spec
 type: spec
-updated_at: "2026-04-16T05:33:06Z"
+updated_at: "2026-04-16T05:46:33Z"
 ---
 
 # Skill, Installer, and Release Delivery Spec
@@ -82,10 +82,9 @@ Without a real installer, skill install path, and release automation, every user
 
 ## Story Breakdown
 
-- [ ] Harden installer behavior and checksum validation
-- [ ] Harden skill installation and manifest behavior
-- [ ] Validate tag-and-release workflow from `main`
-- [ ] Tighten README and PR template for release-note-friendly changes
+- [ ] [Harden install and checksum flow](../stories/harden-install-and-checksum-flow.md)
+- [ ] [Harden skill installation behavior](../stories/harden-skill-installation-behavior.md)
+- [ ] [Validate release automation and maintainer docs](../stories/validate-release-automation-and-maintainer-docs.md)
 
 ## Resources
 

--- a/.plan/specs/spec-driven-planning-workflow.md
+++ b/.plan/specs/spec-driven-planning-workflow.md
@@ -3,11 +3,11 @@ created_at: "2026-04-16T05:33:06Z"
 epic: spec-driven-planning-workflow
 project: plan
 slug: spec-driven-planning-workflow
-status: approved
+status: done
 target_version: v1
 title: Spec-Driven Planning Workflow Spec
 type: spec
-updated_at: "2026-04-16T05:46:33Z"
+updated_at: "2026-04-16T06:18:17Z"
 ---
 
 # Spec-Driven Planning Workflow Spec

--- a/.plan/specs/spec-driven-planning-workflow.md
+++ b/.plan/specs/spec-driven-planning-workflow.md
@@ -3,11 +3,11 @@ created_at: "2026-04-16T05:33:06Z"
 epic: spec-driven-planning-workflow
 project: plan
 slug: spec-driven-planning-workflow
-status: draft
+status: approved
 target_version: v1
 title: Spec-Driven Planning Workflow Spec
 type: spec
-updated_at: "2026-04-16T05:33:06Z"
+updated_at: "2026-04-16T05:46:33Z"
 ---
 
 # Spec-Driven Planning Workflow Spec
@@ -84,10 +84,9 @@ Developers need a planning flow that is simple enough to use constantly and stri
 
 ## Story Breakdown
 
-- [ ] Finalize brainstorm note behavior
-- [ ] Harden epic promotion and spec seeding
-- [ ] Enforce spec approval gate for story creation
-- [ ] Improve status reporting across epics and stories
+- [ ] [Harden brainstorm capture](../stories/harden-brainstorm-capture.md)
+- [ ] [Improve epic promotion and spec seeding](../stories/improve-epic-promotion-and-spec-seeding.md)
+- [ ] [Enforce spec gate and story lifecycle](../stories/enforce-spec-gate-and-story-lifecycle.md)
 
 ## Resources
 

--- a/.plan/specs/workspace-adoption-update-and-migration.md
+++ b/.plan/specs/workspace-adoption-update-and-migration.md
@@ -3,11 +3,11 @@ created_at: "2026-04-16T05:33:06Z"
 epic: workspace-adoption-update-and-migration
 project: plan
 slug: workspace-adoption-update-and-migration
-status: implementing
+status: done
 target_version: v2
 title: Workspace Adoption, Update, and Migration Spec
 type: spec
-updated_at: "2026-04-16T06:50:14Z"
+updated_at: "2026-04-16T06:56:00Z"
 ---
 
 # Workspace Adoption, Update, and Migration Spec

--- a/.plan/specs/workspace-adoption-update-and-migration.md
+++ b/.plan/specs/workspace-adoption-update-and-migration.md
@@ -3,11 +3,11 @@ created_at: "2026-04-16T05:33:06Z"
 epic: workspace-adoption-update-and-migration
 project: plan
 slug: workspace-adoption-update-and-migration
-status: draft
+status: approved
 target_version: v2
 title: Workspace Adoption, Update, and Migration Spec
 type: spec
-updated_at: "2026-04-16T05:33:06Z"
+updated_at: "2026-04-16T06:28:46Z"
 ---
 
 # Workspace Adoption, Update, and Migration Spec
@@ -80,9 +80,9 @@ Fresh init alone is not enough for long-lived usage. The tool needs a clear answ
 
 ## Story Breakdown
 
-- [ ] Define adoption behavior for unmanaged repos
-- [ ] Expand doctor reporting around migration state
-- [ ] Add repair tests for partial and broken workspace cases
+- [ ] [Detect adoptable workspace states](../stories/detect-adoptable-workspace-states.md)
+- [ ] [Add adopt command for existing repos](../stories/add-adopt-command-for-existing-repos.md)
+- [ ] [Expand migration tracking and repair coverage](../stories/expand-migration-tracking-and-repair-coverage.md)
 
 ## Resources
 

--- a/.plan/specs/workspace-adoption-update-and-migration.md
+++ b/.plan/specs/workspace-adoption-update-and-migration.md
@@ -3,11 +3,11 @@ created_at: "2026-04-16T05:33:06Z"
 epic: workspace-adoption-update-and-migration
 project: plan
 slug: workspace-adoption-update-and-migration
-status: approved
+status: implementing
 target_version: v2
 title: Workspace Adoption, Update, and Migration Spec
 type: spec
-updated_at: "2026-04-16T06:28:46Z"
+updated_at: "2026-04-16T06:50:14Z"
 ---
 
 # Workspace Adoption, Update, and Migration Spec

--- a/.plan/stories/add-adopt-command-for-existing-repos.md
+++ b/.plan/stories/add-adopt-command-for-existing-repos.md
@@ -4,10 +4,10 @@ epic: workspace-adoption-update-and-migration
 project: plan
 slug: add-adopt-command-for-existing-repos
 spec: workspace-adoption-update-and-migration
-status: todo
+status: done
 title: Add adopt command for existing repos
 type: story
-updated_at: "2026-04-16T06:28:47Z"
+updated_at: "2026-04-16T06:52:33Z"
 ---
 
 # Add adopt command for existing repos

--- a/.plan/stories/add-adopt-command-for-existing-repos.md
+++ b/.plan/stories/add-adopt-command-for-existing-repos.md
@@ -1,0 +1,31 @@
+---
+created_at: "2026-04-16T06:28:47Z"
+epic: workspace-adoption-update-and-migration
+project: plan
+slug: add-adopt-command-for-existing-repos
+spec: workspace-adoption-update-and-migration
+status: todo
+title: Add adopt command for existing repos
+type: story
+updated_at: "2026-04-16T06:28:47Z"
+---
+
+# Add adopt command for existing repos
+
+Created: 2026-04-16T06:28:47Z
+
+## Description
+
+Create an explicit local-first adoption flow for repos that do not yet use plan.
+## Acceptance Criteria
+
+- [ ] Adopt creates only plan-managed surfaces and leaves non-plan repo files untouched.
+
+- [ ] Adopt produces a current workspace that doctor and update can manage afterward.
+## Verification
+
+- go test ./cmd ./internal/workspace
+## Resources
+
+- [Canonical Spec](../specs/workspace-adoption-update-and-migration.md)
+## Notes

--- a/.plan/stories/add-advanced-roadmap-and-story-selection-helpers.md
+++ b/.plan/stories/add-advanced-roadmap-and-story-selection-helpers.md
@@ -4,10 +4,10 @@ epic: power-user-local-workflows
 project: plan
 slug: add-advanced-roadmap-and-story-selection-helpers
 spec: power-user-local-workflows
-status: todo
+status: done
 title: Add advanced roadmap and story selection helpers
 type: story
-updated_at: "2026-04-16T06:28:47Z"
+updated_at: "2026-04-16T07:15:10Z"
 ---
 
 # Add advanced roadmap and story selection helpers

--- a/.plan/stories/add-advanced-roadmap-and-story-selection-helpers.md
+++ b/.plan/stories/add-advanced-roadmap-and-story-selection-helpers.md
@@ -1,0 +1,31 @@
+---
+created_at: "2026-04-16T06:28:47Z"
+epic: power-user-local-workflows
+project: plan
+slug: add-advanced-roadmap-and-story-selection-helpers
+spec: power-user-local-workflows
+status: todo
+title: Add advanced roadmap and story selection helpers
+type: story
+updated_at: "2026-04-16T06:28:47Z"
+---
+
+# Add advanced roadmap and story selection helpers
+
+Created: 2026-04-16T06:28:47Z
+
+## Description
+
+Add helpers that make next-step selection easier on larger repos with many active stories.
+## Acceptance Criteria
+
+- [ ] CLI helpers can narrow work by version, epic, or story state using local plan data.
+
+- [ ] Selection helpers remain local-first and grounded in markdown-backed state rather than hidden queues.
+## Verification
+
+- go test ./cmd ./internal/planning
+## Resources
+
+- [Canonical Spec](../specs/power-user-local-workflows.md)
+## Notes

--- a/.plan/stories/add-dependency-metadata-to-stories.md
+++ b/.plan/stories/add-dependency-metadata-to-stories.md
@@ -4,10 +4,10 @@ epic: dependency-graph-and-ready-work
 project: plan
 slug: add-dependency-metadata-to-stories
 spec: dependency-graph-and-ready-work
-status: todo
+status: done
 title: Add dependency metadata to stories
 type: story
-updated_at: "2026-04-16T06:28:47Z"
+updated_at: "2026-04-16T06:58:35Z"
 ---
 
 # Add dependency metadata to stories

--- a/.plan/stories/add-dependency-metadata-to-stories.md
+++ b/.plan/stories/add-dependency-metadata-to-stories.md
@@ -1,0 +1,31 @@
+---
+created_at: "2026-04-16T06:28:47Z"
+epic: dependency-graph-and-ready-work
+project: plan
+slug: add-dependency-metadata-to-stories
+spec: dependency-graph-and-ready-work
+status: todo
+title: Add dependency metadata to stories
+type: story
+updated_at: "2026-04-16T06:28:47Z"
+---
+
+# Add dependency metadata to stories
+
+Created: 2026-04-16T06:28:47Z
+
+## Description
+
+Let stories declare narrow blocker relationships without leaving the markdown-first model.
+## Acceptance Criteria
+
+- [ ] Stories can record blocker story slugs in an inspectable local metadata shape.
+
+- [ ] Dependency metadata stays simple enough for solo developers to maintain by hand when needed.
+## Verification
+
+- go test ./internal/planning
+## Resources
+
+- [Canonical Spec](../specs/dependency-graph-and-ready-work.md)
+## Notes

--- a/.plan/stories/add-filtered-status-views-for-large-local-plans.md
+++ b/.plan/stories/add-filtered-status-views-for-large-local-plans.md
@@ -1,0 +1,31 @@
+---
+created_at: "2026-04-16T06:28:47Z"
+epic: power-user-local-workflows
+project: plan
+slug: add-filtered-status-views-for-large-local-plans
+spec: power-user-local-workflows
+status: todo
+title: Add filtered status views for large local plans
+type: story
+updated_at: "2026-04-16T06:28:47Z"
+---
+
+# Add filtered status views for large local plans
+
+Created: 2026-04-16T06:28:47Z
+
+## Description
+
+Improve status output so larger local plans stay workable without abandoning the simple model.
+## Acceptance Criteria
+
+- [ ] Status commands can filter or narrow output by version, epic, or lifecycle slice.
+
+- [ ] Filtered views still keep the default status path clean for small repos.
+## Verification
+
+- go test ./cmd ./internal/planning
+## Resources
+
+- [Canonical Spec](../specs/power-user-local-workflows.md)
+## Notes

--- a/.plan/stories/add-filtered-status-views-for-large-local-plans.md
+++ b/.plan/stories/add-filtered-status-views-for-large-local-plans.md
@@ -4,10 +4,10 @@ epic: power-user-local-workflows
 project: plan
 slug: add-filtered-status-views-for-large-local-plans
 spec: power-user-local-workflows
-status: todo
+status: done
 title: Add filtered status views for large local plans
 type: story
-updated_at: "2026-04-16T06:28:47Z"
+updated_at: "2026-04-16T07:12:42Z"
 ---
 
 # Add filtered status views for large local plans

--- a/.plan/stories/add-roadmap-cli-helpers-for-version-views.md
+++ b/.plan/stories/add-roadmap-cli-helpers-for-version-views.md
@@ -4,10 +4,10 @@ epic: roadmap-and-portfolio-planning
 project: plan
 slug: add-roadmap-cli-helpers-for-version-views
 spec: roadmap-and-portfolio-planning
-status: todo
+status: done
 title: Add roadmap CLI helpers for version views
 type: story
-updated_at: "2026-04-16T06:28:47Z"
+updated_at: "2026-04-16T06:34:58Z"
 ---
 
 # Add roadmap CLI helpers for version views

--- a/.plan/stories/add-roadmap-cli-helpers-for-version-views.md
+++ b/.plan/stories/add-roadmap-cli-helpers-for-version-views.md
@@ -1,0 +1,31 @@
+---
+created_at: "2026-04-16T06:28:47Z"
+epic: roadmap-and-portfolio-planning
+project: plan
+slug: add-roadmap-cli-helpers-for-version-views
+spec: roadmap-and-portfolio-planning
+status: todo
+title: Add roadmap CLI helpers for version views
+type: story
+updated_at: "2026-04-16T06:28:47Z"
+---
+
+# Add roadmap CLI helpers for version views
+
+Created: 2026-04-16T06:28:47Z
+
+## Description
+
+Expose roadmap views that make version planning readable without hand-editing every query.
+## Acceptance Criteria
+
+- [ ] Roadmap commands can show version-scoped summaries and ordered epics from ROADMAP.md.
+
+- [ ] Version-focused views preserve the lightweight markdown-first roadmap model.
+## Verification
+
+- go test ./cmd ./internal/planning
+## Resources
+
+- [Canonical Spec](../specs/roadmap-and-portfolio-planning.md)
+## Notes

--- a/.plan/stories/add-spec-quality-rules-for-required-planning-sections.md
+++ b/.plan/stories/add-spec-quality-rules-for-required-planning-sections.md
@@ -1,0 +1,31 @@
+---
+created_at: "2026-04-16T06:28:47Z"
+epic: plan-quality-and-verification-engine
+project: plan
+slug: add-spec-quality-rules-for-required-planning-sections
+spec: plan-quality-and-verification-engine
+status: todo
+title: Add spec quality rules for required planning sections
+type: story
+updated_at: "2026-04-16T06:28:47Z"
+---
+
+# Add spec quality rules for required planning sections
+
+Created: 2026-04-16T06:28:47Z
+
+## Description
+
+Teach plan to flag draft specs that are structurally present but still too weak to execute well.
+## Acceptance Criteria
+
+- [ ] Spec checks flag missing or thin problem, goals, non-goals, constraints, and verification sections.
+
+- [ ] Quality findings are actionable and tied to the canonical spec structure users already see.
+## Verification
+
+- go test ./internal/planning
+## Resources
+
+- [Canonical Spec](../specs/plan-quality-and-verification-engine.md)
+## Notes

--- a/.plan/stories/add-spec-quality-rules-for-required-planning-sections.md
+++ b/.plan/stories/add-spec-quality-rules-for-required-planning-sections.md
@@ -4,10 +4,10 @@ epic: plan-quality-and-verification-engine
 project: plan
 slug: add-spec-quality-rules-for-required-planning-sections
 spec: plan-quality-and-verification-engine
-status: todo
+status: done
 title: Add spec quality rules for required planning sections
 type: story
-updated_at: "2026-04-16T06:28:47Z"
+updated_at: "2026-04-16T06:42:27Z"
 ---
 
 # Add spec quality rules for required planning sections

--- a/.plan/stories/add-story-quality-rules-for-execution-readiness.md
+++ b/.plan/stories/add-story-quality-rules-for-execution-readiness.md
@@ -4,10 +4,10 @@ epic: plan-quality-and-verification-engine
 project: plan
 slug: add-story-quality-rules-for-execution-readiness
 spec: plan-quality-and-verification-engine
-status: todo
+status: done
 title: Add story quality rules for execution readiness
 type: story
-updated_at: "2026-04-16T06:28:47Z"
+updated_at: "2026-04-16T06:44:46Z"
 ---
 
 # Add story quality rules for execution readiness

--- a/.plan/stories/add-story-quality-rules-for-execution-readiness.md
+++ b/.plan/stories/add-story-quality-rules-for-execution-readiness.md
@@ -1,0 +1,31 @@
+---
+created_at: "2026-04-16T06:28:47Z"
+epic: plan-quality-and-verification-engine
+project: plan
+slug: add-story-quality-rules-for-execution-readiness
+spec: plan-quality-and-verification-engine
+status: todo
+title: Add story quality rules for execution readiness
+type: story
+updated_at: "2026-04-16T06:28:47Z"
+---
+
+# Add story quality rules for execution readiness
+
+Created: 2026-04-16T06:28:47Z
+
+## Description
+
+Extend plan quality checks down to stories so execution units stay explicit and verification-aware.
+## Acceptance Criteria
+
+- [ ] Story checks flag missing acceptance criteria, missing verification steps, or empty execution descriptions.
+
+- [ ] Story readiness checks align with the enforced story lifecycle rules instead of duplicating them loosely.
+## Verification
+
+- go test ./internal/planning
+## Resources
+
+- [Canonical Spec](../specs/plan-quality-and-verification-engine.md)
+## Notes

--- a/.plan/stories/compute-ready-and-blocked-work-sets.md
+++ b/.plan/stories/compute-ready-and-blocked-work-sets.md
@@ -4,10 +4,10 @@ epic: dependency-graph-and-ready-work
 project: plan
 slug: compute-ready-and-blocked-work-sets
 spec: dependency-graph-and-ready-work
-status: todo
+status: done
 title: Compute ready and blocked work sets
 type: story
-updated_at: "2026-04-16T06:28:47Z"
+updated_at: "2026-04-16T07:01:10Z"
 ---
 
 # Compute ready and blocked work sets

--- a/.plan/stories/compute-ready-and-blocked-work-sets.md
+++ b/.plan/stories/compute-ready-and-blocked-work-sets.md
@@ -1,0 +1,31 @@
+---
+created_at: "2026-04-16T06:28:47Z"
+epic: dependency-graph-and-ready-work
+project: plan
+slug: compute-ready-and-blocked-work-sets
+spec: dependency-graph-and-ready-work
+status: todo
+title: Compute ready and blocked work sets
+type: story
+updated_at: "2026-04-16T06:28:47Z"
+---
+
+# Compute ready and blocked work sets
+
+Created: 2026-04-16T06:28:47Z
+
+## Description
+
+Derive which stories are ready now and which are blocked by unfinished dependencies.
+## Acceptance Criteria
+
+- [ ] Ready/blocked evaluation explains which blockers keep a story from moving.
+
+- [ ] Dependency evaluation respects current story lifecycle states and completed work.
+## Verification
+
+- go test ./internal/planning
+## Resources
+
+- [Canonical Spec](../specs/dependency-graph-and-ready-work.md)
+## Notes

--- a/.plan/stories/define-plan-workspace-contract.md
+++ b/.plan/stories/define-plan-workspace-contract.md
@@ -1,0 +1,36 @@
+---
+created_at: "2026-04-16T05:46:33Z"
+epic: core-workspace-and-artifact-system
+project: plan
+slug: define-plan-workspace-contract
+spec: core-workspace-and-artifact-system
+status: todo
+title: Define .plan workspace contract
+type: story
+updated_at: "2026-04-16T05:46:33Z"
+---
+
+# Define .plan workspace contract
+
+Created: 2026-04-16T05:46:33Z
+
+## Description
+
+Finalize the v1 `.plan/` layout and root artifact contract so the workspace model is stable and easy to explain.
+## Acceptance Criteria
+
+
+- [ ] Workspace layout is explicitly defined for PROJECT.md, ROADMAP.md, epics, specs, stories, and .meta
+
+- [ ] The contract stays local-first and markdown-first
+
+- [ ] The scope boundary between user-authored notes and tool-owned state is clear
+## Verification
+
+
+- go test ./internal/workspace ./cmd
+## Resources
+
+
+- [Canonical Spec](../specs/core-workspace-and-artifact-system.md)
+## Notes

--- a/.plan/stories/define-plan-workspace-contract.md
+++ b/.plan/stories/define-plan-workspace-contract.md
@@ -4,10 +4,10 @@ epic: core-workspace-and-artifact-system
 project: plan
 slug: define-plan-workspace-contract
 spec: core-workspace-and-artifact-system
-status: todo
+status: done
 title: Define .plan workspace contract
 type: story
-updated_at: "2026-04-16T05:46:33Z"
+updated_at: "2026-04-16T06:00:44Z"
 ---
 
 # Define .plan workspace contract

--- a/.plan/stories/define-roadmap-version-structure-and-parsing.md
+++ b/.plan/stories/define-roadmap-version-structure-and-parsing.md
@@ -4,10 +4,10 @@ epic: roadmap-and-portfolio-planning
 project: plan
 slug: define-roadmap-version-structure-and-parsing
 spec: roadmap-and-portfolio-planning
-status: todo
+status: done
 title: Define roadmap version structure and parsing
 type: story
-updated_at: "2026-04-16T06:28:47Z"
+updated_at: "2026-04-16T06:33:37Z"
 ---
 
 # Define roadmap version structure and parsing

--- a/.plan/stories/define-roadmap-version-structure-and-parsing.md
+++ b/.plan/stories/define-roadmap-version-structure-and-parsing.md
@@ -1,0 +1,31 @@
+---
+created_at: "2026-04-16T06:28:47Z"
+epic: roadmap-and-portfolio-planning
+project: plan
+slug: define-roadmap-version-structure-and-parsing
+spec: roadmap-and-portfolio-planning
+status: todo
+title: Define roadmap version structure and parsing
+type: story
+updated_at: "2026-04-16T06:28:47Z"
+---
+
+# Define roadmap version structure and parsing
+
+Created: 2026-04-16T06:28:47Z
+
+## Description
+
+Make ROADMAP.md version sections and summaries explicit so plan can read them reliably.
+## Acceptance Criteria
+
+- [ ] Roadmap parsing reads version goals, summaries, epic lists, and parking lot notes from markdown.
+
+- [ ] Parsing keeps version order stable and tolerates empty sections without data loss.
+## Verification
+
+- go test ./internal/planning
+## Resources
+
+- [Canonical Spec](../specs/roadmap-and-portfolio-planning.md)
+## Notes

--- a/.plan/stories/detect-adoptable-workspace-states.md
+++ b/.plan/stories/detect-adoptable-workspace-states.md
@@ -1,0 +1,31 @@
+---
+created_at: "2026-04-16T06:28:47Z"
+epic: workspace-adoption-update-and-migration
+project: plan
+slug: detect-adoptable-workspace-states
+spec: workspace-adoption-update-and-migration
+status: todo
+title: Detect adoptable workspace states
+type: story
+updated_at: "2026-04-16T06:28:47Z"
+---
+
+# Detect adoptable workspace states
+
+Created: 2026-04-16T06:28:47Z
+
+## Description
+
+Teach plan to distinguish a missing workspace from an existing repo that is safe to adopt.
+## Acceptance Criteria
+
+- [ ] Doctor reports adoptable, partial, missing, and broken states with clear repair guidance.
+
+- [ ] Detection stays limited to plan-managed surfaces and does not inspect unrelated repo files aggressively.
+## Verification
+
+- go test ./internal/workspace
+## Resources
+
+- [Canonical Spec](../specs/workspace-adoption-update-and-migration.md)
+## Notes

--- a/.plan/stories/detect-adoptable-workspace-states.md
+++ b/.plan/stories/detect-adoptable-workspace-states.md
@@ -4,10 +4,10 @@ epic: workspace-adoption-update-and-migration
 project: plan
 slug: detect-adoptable-workspace-states
 spec: workspace-adoption-update-and-migration
-status: todo
+status: done
 title: Detect adoptable workspace states
 type: story
-updated_at: "2026-04-16T06:28:47Z"
+updated_at: "2026-04-16T06:50:14Z"
 ---
 
 # Detect adoptable workspace states

--- a/.plan/stories/document-and-test-advanced-local-planning-workflows.md
+++ b/.plan/stories/document-and-test-advanced-local-planning-workflows.md
@@ -4,10 +4,10 @@ epic: power-user-local-workflows
 project: plan
 slug: document-and-test-advanced-local-planning-workflows
 spec: power-user-local-workflows
-status: todo
+status: done
 title: Document and test advanced local planning workflows
 type: story
-updated_at: "2026-04-16T06:28:47Z"
+updated_at: "2026-04-16T07:16:12Z"
 ---
 
 # Document and test advanced local planning workflows

--- a/.plan/stories/document-and-test-advanced-local-planning-workflows.md
+++ b/.plan/stories/document-and-test-advanced-local-planning-workflows.md
@@ -1,0 +1,31 @@
+---
+created_at: "2026-04-16T06:28:47Z"
+epic: power-user-local-workflows
+project: plan
+slug: document-and-test-advanced-local-planning-workflows
+spec: power-user-local-workflows
+status: todo
+title: Document and test advanced local planning workflows
+type: story
+updated_at: "2026-04-16T06:28:47Z"
+---
+
+# Document and test advanced local planning workflows
+
+Created: 2026-04-16T06:28:47Z
+
+## Description
+
+Capture the intended power-user path without forcing that complexity onto everyone.
+## Acceptance Criteria
+
+- [ ] Docs explain advanced local workflows in a way that preserves the simple default path.
+
+- [ ] Tests cover the new filtered and selection-oriented local workflow helpers.
+## Verification
+
+- go test ./...
+## Resources
+
+- [Canonical Spec](../specs/power-user-local-workflows.md)
+## Notes

--- a/.plan/stories/enforce-spec-gate-and-story-lifecycle.md
+++ b/.plan/stories/enforce-spec-gate-and-story-lifecycle.md
@@ -1,0 +1,37 @@
+---
+created_at: "2026-04-16T05:46:34Z"
+epic: spec-driven-planning-workflow
+project: plan
+slug: enforce-spec-gate-and-story-lifecycle
+spec: spec-driven-planning-workflow
+status: todo
+title: Enforce spec gate and story lifecycle
+type: story
+updated_at: "2026-04-16T05:46:34Z"
+---
+
+# Enforce spec gate and story lifecycle
+
+Created: 2026-04-16T05:46:34Z
+
+## Description
+
+
+Strengthen the transition from approved spec to execution-ready stories and status reporting.
+## Acceptance Criteria
+
+
+- [ ] Stories cannot be created from draft specs
+
+- [ ] Story artifacts include acceptance and verification expectations
+
+- [ ] Status reporting reflects epic and story progress cleanly
+## Verification
+
+
+- go test ./internal/planning ./cmd
+## Resources
+
+
+- [Canonical Spec](../specs/spec-driven-planning-workflow.md)
+## Notes

--- a/.plan/stories/enforce-spec-gate-and-story-lifecycle.md
+++ b/.plan/stories/enforce-spec-gate-and-story-lifecycle.md
@@ -4,10 +4,10 @@ epic: spec-driven-planning-workflow
 project: plan
 slug: enforce-spec-gate-and-story-lifecycle
 spec: spec-driven-planning-workflow
-status: todo
+status: done
 title: Enforce spec gate and story lifecycle
 type: story
-updated_at: "2026-04-16T05:46:34Z"
+updated_at: "2026-04-16T06:18:17Z"
 ---
 
 # Enforce spec gate and story lifecycle

--- a/.plan/stories/expand-migration-tracking-and-repair-coverage.md
+++ b/.plan/stories/expand-migration-tracking-and-repair-coverage.md
@@ -4,10 +4,10 @@ epic: workspace-adoption-update-and-migration
 project: plan
 slug: expand-migration-tracking-and-repair-coverage
 spec: workspace-adoption-update-and-migration
-status: todo
+status: done
 title: Expand migration tracking and repair coverage
 type: story
-updated_at: "2026-04-16T06:28:47Z"
+updated_at: "2026-04-16T06:56:00Z"
 ---
 
 # Expand migration tracking and repair coverage

--- a/.plan/stories/expand-migration-tracking-and-repair-coverage.md
+++ b/.plan/stories/expand-migration-tracking-and-repair-coverage.md
@@ -1,0 +1,31 @@
+---
+created_at: "2026-04-16T06:28:47Z"
+epic: workspace-adoption-update-and-migration
+project: plan
+slug: expand-migration-tracking-and-repair-coverage
+spec: workspace-adoption-update-and-migration
+status: todo
+title: Expand migration tracking and repair coverage
+type: story
+updated_at: "2026-04-16T06:28:47Z"
+---
+
+# Expand migration tracking and repair coverage
+
+Created: 2026-04-16T06:28:47Z
+
+## Description
+
+Strengthen migration state so repeated repair and upgrade flows remain inspectable over time.
+## Acceptance Criteria
+
+- [ ] Migration tracking records enough detail to explain what plan repaired or normalized.
+
+- [ ] Tests cover repeated adopt, doctor, and update flows without regressing idempotency.
+## Verification
+
+- go test ./internal/workspace ./cmd
+## Resources
+
+- [Canonical Spec](../specs/workspace-adoption-update-and-migration.md)
+## Notes

--- a/.plan/stories/expand-workspace-test-coverage.md
+++ b/.plan/stories/expand-workspace-test-coverage.md
@@ -1,0 +1,36 @@
+---
+created_at: "2026-04-16T05:46:33Z"
+epic: core-workspace-and-artifact-system
+project: plan
+slug: expand-workspace-test-coverage
+spec: core-workspace-and-artifact-system
+status: todo
+title: Expand workspace test coverage
+type: story
+updated_at: "2026-04-16T05:46:33Z"
+---
+
+# Expand workspace test coverage
+
+Created: 2026-04-16T05:46:33Z
+
+## Description
+
+Add focused tests around initialization, repair, and upgrade-safe behavior for the `.plan/` workspace.
+## Acceptance Criteria
+
+
+- [ ] Init coverage includes full v1 workspace layout
+
+- [ ] Repair coverage includes partial workspace states
+
+- [ ] Regression coverage protects the workspace contract from accidental drift
+## Verification
+
+
+- go test ./internal/workspace ./...
+## Resources
+
+
+- [Canonical Spec](../specs/core-workspace-and-artifact-system.md)
+## Notes

--- a/.plan/stories/expand-workspace-test-coverage.md
+++ b/.plan/stories/expand-workspace-test-coverage.md
@@ -4,10 +4,10 @@ epic: core-workspace-and-artifact-system
 project: plan
 slug: expand-workspace-test-coverage
 spec: core-workspace-and-artifact-system
-status: todo
+status: done
 title: Expand workspace test coverage
 type: story
-updated_at: "2026-04-16T05:46:33Z"
+updated_at: "2026-04-16T06:06:39Z"
 ---
 
 # Expand workspace test coverage

--- a/.plan/stories/expose-plan-check-command-and-reporting.md
+++ b/.plan/stories/expose-plan-check-command-and-reporting.md
@@ -4,10 +4,10 @@ epic: plan-quality-and-verification-engine
 project: plan
 slug: expose-plan-check-command-and-reporting
 spec: plan-quality-and-verification-engine
-status: todo
+status: done
 title: Expose plan check command and reporting
 type: story
-updated_at: "2026-04-16T06:28:47Z"
+updated_at: "2026-04-16T06:47:46Z"
 ---
 
 # Expose plan check command and reporting

--- a/.plan/stories/expose-plan-check-command-and-reporting.md
+++ b/.plan/stories/expose-plan-check-command-and-reporting.md
@@ -1,0 +1,31 @@
+---
+created_at: "2026-04-16T06:28:47Z"
+epic: plan-quality-and-verification-engine
+project: plan
+slug: expose-plan-check-command-and-reporting
+spec: plan-quality-and-verification-engine
+status: todo
+title: Expose plan check command and reporting
+type: story
+updated_at: "2026-04-16T06:28:47Z"
+---
+
+# Expose plan check command and reporting
+
+Created: 2026-04-16T06:28:47Z
+
+## Description
+
+Add a CLI surface that reports plan quality findings across the workspace in a user-facing way.
+## Acceptance Criteria
+
+- [ ] The check command can report findings for project, epic, spec, or story scopes with readable output.
+
+- [ ] Blocking findings produce a clear failing result while non-blocking guidance stays inspectable.
+## Verification
+
+- go test ./cmd ./internal/planning
+## Resources
+
+- [Canonical Spec](../specs/plan-quality-and-verification-engine.md)
+## Notes

--- a/.plan/stories/expose-ready-work-cli-and-status-views.md
+++ b/.plan/stories/expose-ready-work-cli-and-status-views.md
@@ -1,0 +1,31 @@
+---
+created_at: "2026-04-16T06:28:47Z"
+epic: dependency-graph-and-ready-work
+project: plan
+slug: expose-ready-work-cli-and-status-views
+spec: dependency-graph-and-ready-work
+status: todo
+title: Expose ready-work CLI and status views
+type: story
+updated_at: "2026-04-16T06:28:47Z"
+---
+
+# Expose ready-work CLI and status views
+
+Created: 2026-04-16T06:28:47Z
+
+## Description
+
+Add a user-facing view for dependency-aware work selection.
+## Acceptance Criteria
+
+- [ ] CLI output can show ready stories and blocked stories with blocking reasons.
+
+- [ ] Status views can surface dependency-aware progress without replacing the base story model.
+## Verification
+
+- go test ./cmd ./internal/planning
+## Resources
+
+- [Canonical Spec](../specs/dependency-graph-and-ready-work.md)
+## Notes

--- a/.plan/stories/expose-ready-work-cli-and-status-views.md
+++ b/.plan/stories/expose-ready-work-cli-and-status-views.md
@@ -4,10 +4,10 @@ epic: dependency-graph-and-ready-work
 project: plan
 slug: expose-ready-work-cli-and-status-views
 spec: dependency-graph-and-ready-work
-status: todo
+status: done
 title: Expose ready-work CLI and status views
 type: story
-updated_at: "2026-04-16T06:28:47Z"
+updated_at: "2026-04-16T07:03:16Z"
 ---
 
 # Expose ready-work CLI and status views

--- a/.plan/stories/harden-brainstorm-capture.md
+++ b/.plan/stories/harden-brainstorm-capture.md
@@ -1,0 +1,37 @@
+---
+created_at: "2026-04-16T05:46:33Z"
+epic: spec-driven-planning-workflow
+project: plan
+slug: harden-brainstorm-capture
+spec: spec-driven-planning-workflow
+status: todo
+title: Harden brainstorm capture
+type: story
+updated_at: "2026-04-16T05:46:33Z"
+---
+
+# Harden brainstorm capture
+
+Created: 2026-04-16T05:46:33Z
+
+## Description
+
+
+Improve brainstorm creation and idea capture so discovery work is easy to start and useful to promote.
+## Acceptance Criteria
+
+
+- [ ] Users can start brainstorms and append ideas without friction
+
+- [ ] Brainstorm notes stay clearly separate from canonical planning artifacts
+
+- [ ] Brainstorm content is shaped so promotion can seed better specs
+## Verification
+
+
+- go test ./internal/planning
+## Resources
+
+
+- [Canonical Spec](../specs/spec-driven-planning-workflow.md)
+## Notes

--- a/.plan/stories/harden-brainstorm-capture.md
+++ b/.plan/stories/harden-brainstorm-capture.md
@@ -4,10 +4,10 @@ epic: spec-driven-planning-workflow
 project: plan
 slug: harden-brainstorm-capture
 spec: spec-driven-planning-workflow
-status: todo
+status: done
 title: Harden brainstorm capture
 type: story
-updated_at: "2026-04-16T05:46:33Z"
+updated_at: "2026-04-16T06:11:21Z"
 ---
 
 # Harden brainstorm capture

--- a/.plan/stories/harden-install-and-checksum-flow.md
+++ b/.plan/stories/harden-install-and-checksum-flow.md
@@ -1,0 +1,37 @@
+---
+created_at: "2026-04-16T05:46:34Z"
+epic: skill-installer-and-release-delivery
+project: plan
+slug: harden-install-and-checksum-flow
+spec: skill-installer-and-release-delivery
+status: todo
+title: Harden install and checksum flow
+type: story
+updated_at: "2026-04-16T05:46:34Z"
+---
+
+# Harden install and checksum flow
+
+Created: 2026-04-16T05:46:34Z
+
+## Description
+
+
+Tighten the install path so release downloads and checksum verification are trustworthy and predictable.
+## Acceptance Criteria
+
+
+- [ ] Install script resolves the latest release correctly
+
+- [ ] Checksums are verified before install
+
+- [ ] Fallback source-build behavior is clearly bounded
+## Verification
+
+
+- go test ./... && go build ./...
+## Resources
+
+
+- [Canonical Spec](../specs/skill-installer-and-release-delivery.md)
+## Notes

--- a/.plan/stories/harden-install-and-checksum-flow.md
+++ b/.plan/stories/harden-install-and-checksum-flow.md
@@ -4,10 +4,10 @@ epic: skill-installer-and-release-delivery
 project: plan
 slug: harden-install-and-checksum-flow
 spec: skill-installer-and-release-delivery
-status: todo
+status: done
 title: Harden install and checksum flow
 type: story
-updated_at: "2026-04-16T05:46:34Z"
+updated_at: "2026-04-16T06:21:52Z"
 ---
 
 # Harden install and checksum flow

--- a/.plan/stories/harden-skill-installation-behavior.md
+++ b/.plan/stories/harden-skill-installation-behavior.md
@@ -1,0 +1,37 @@
+---
+created_at: "2026-04-16T05:46:34Z"
+epic: skill-installer-and-release-delivery
+project: plan
+slug: harden-skill-installation-behavior
+spec: skill-installer-and-release-delivery
+status: todo
+title: Harden skill installation behavior
+type: story
+updated_at: "2026-04-16T05:46:34Z"
+---
+
+# Harden skill installation behavior
+
+Created: 2026-04-16T05:46:34Z
+
+## Description
+
+
+Make skill install targets, copied bundles, and manifests reliable across supported agent roots.
+## Acceptance Criteria
+
+
+- [ ] Global and local skill target resolution is correct
+
+- [ ] Installed skill bundles include manifests and repair stale installs cleanly
+
+- [ ] Skill install behavior is covered by tests
+## Verification
+
+
+- go test ./internal/skills
+## Resources
+
+
+- [Canonical Spec](../specs/skill-installer-and-release-delivery.md)
+## Notes

--- a/.plan/stories/harden-skill-installation-behavior.md
+++ b/.plan/stories/harden-skill-installation-behavior.md
@@ -4,10 +4,10 @@ epic: skill-installer-and-release-delivery
 project: plan
 slug: harden-skill-installation-behavior
 spec: skill-installer-and-release-delivery
-status: todo
+status: done
 title: Harden skill installation behavior
 type: story
-updated_at: "2026-04-16T05:46:34Z"
+updated_at: "2026-04-16T06:23:55Z"
 ---
 
 # Harden skill installation behavior

--- a/.plan/stories/harden-workspace-metadata-and-repair-lifecycle.md
+++ b/.plan/stories/harden-workspace-metadata-and-repair-lifecycle.md
@@ -1,0 +1,37 @@
+---
+created_at: "2026-04-16T05:46:33Z"
+epic: core-workspace-and-artifact-system
+project: plan
+slug: harden-workspace-metadata-and-repair-lifecycle
+spec: core-workspace-and-artifact-system
+status: todo
+title: Harden workspace metadata and repair lifecycle
+type: story
+updated_at: "2026-04-16T05:46:33Z"
+---
+
+# Harden workspace metadata and repair lifecycle
+
+Created: 2026-04-16T05:46:33Z
+
+## Description
+
+
+Strengthen workspace metadata, doctor output, and update behavior so partial or stale workspaces can be understood and repaired safely.
+## Acceptance Criteria
+
+
+- [ ] Doctor reports current, missing, or broken state clearly
+
+- [ ] Update repairs tool-managed surfaces without damaging user-authored planning notes
+
+- [ ] Workspace metadata and migration state remain small and inspectable
+## Verification
+
+
+- go test ./internal/workspace
+## Resources
+
+
+- [Canonical Spec](../specs/core-workspace-and-artifact-system.md)
+## Notes

--- a/.plan/stories/harden-workspace-metadata-and-repair-lifecycle.md
+++ b/.plan/stories/harden-workspace-metadata-and-repair-lifecycle.md
@@ -4,10 +4,10 @@ epic: core-workspace-and-artifact-system
 project: plan
 slug: harden-workspace-metadata-and-repair-lifecycle
 spec: core-workspace-and-artifact-system
-status: todo
+status: done
 title: Harden workspace metadata and repair lifecycle
 type: story
-updated_at: "2026-04-16T05:46:33Z"
+updated_at: "2026-04-16T06:05:34Z"
 ---
 
 # Harden workspace metadata and repair lifecycle

--- a/.plan/stories/import-brain-planning-notes-into-plan-artifacts.md
+++ b/.plan/stories/import-brain-planning-notes-into-plan-artifacts.md
@@ -1,0 +1,31 @@
+---
+created_at: "2026-04-16T06:28:47Z"
+epic: brain-interop-and-planning-imports
+project: plan
+slug: import-brain-planning-notes-into-plan-artifacts
+spec: brain-interop-and-planning-imports
+status: todo
+title: Import brain planning notes into plan artifacts
+type: story
+updated_at: "2026-04-16T06:28:47Z"
+---
+
+# Import brain planning notes into plan artifacts
+
+Created: 2026-04-16T06:28:47Z
+
+## Description
+
+Map selected brain planning material into plan epics, specs, and stories.
+## Acceptance Criteria
+
+- [ ] Imported notes land under .plan using canonical plan metadata and file locations.
+
+- [ ] Import keeps plan responsible only for planning artifacts after creation.
+## Verification
+
+- go test ./internal/planning
+## Resources
+
+- [Canonical Spec](../specs/brain-interop-and-planning-imports.md)
+## Notes

--- a/.plan/stories/import-brain-planning-notes-into-plan-artifacts.md
+++ b/.plan/stories/import-brain-planning-notes-into-plan-artifacts.md
@@ -4,10 +4,10 @@ epic: brain-interop-and-planning-imports
 project: plan
 slug: import-brain-planning-notes-into-plan-artifacts
 spec: brain-interop-and-planning-imports
-status: todo
+status: done
 title: Import brain planning notes into plan artifacts
 type: story
-updated_at: "2026-04-16T06:28:47Z"
+updated_at: "2026-04-16T07:07:28Z"
 ---
 
 # Import brain planning notes into plan artifacts

--- a/.plan/stories/improve-epic-promotion-and-spec-seeding.md
+++ b/.plan/stories/improve-epic-promotion-and-spec-seeding.md
@@ -4,10 +4,10 @@ epic: spec-driven-planning-workflow
 project: plan
 slug: improve-epic-promotion-and-spec-seeding
 spec: spec-driven-planning-workflow
-status: todo
+status: done
 title: Improve epic promotion and spec seeding
 type: story
-updated_at: "2026-04-16T05:46:33Z"
+updated_at: "2026-04-16T06:14:19Z"
 ---
 
 # Improve epic promotion and spec seeding

--- a/.plan/stories/improve-epic-promotion-and-spec-seeding.md
+++ b/.plan/stories/improve-epic-promotion-and-spec-seeding.md
@@ -1,0 +1,37 @@
+---
+created_at: "2026-04-16T05:46:33Z"
+epic: spec-driven-planning-workflow
+project: plan
+slug: improve-epic-promotion-and-spec-seeding
+spec: spec-driven-planning-workflow
+status: todo
+title: Improve epic promotion and spec seeding
+type: story
+updated_at: "2026-04-16T05:46:33Z"
+---
+
+# Improve epic promotion and spec seeding
+
+Created: 2026-04-16T05:46:33Z
+
+## Description
+
+
+Make brainstorm promotion reliably create an epic and a useful seeded draft spec.
+## Acceptance Criteria
+
+
+- [ ] Promotion creates a linked epic and canonical spec
+
+- [ ] Seeded spec captures useful problem and goal material from the brainstorm
+
+- [ ] Source provenance back to the brainstorm remains visible
+## Verification
+
+
+- go test ./internal/planning
+## Resources
+
+
+- [Canonical Spec](../specs/spec-driven-planning-workflow.md)
+## Notes

--- a/.plan/stories/inspect-brain-workspaces-for-import-candidates.md
+++ b/.plan/stories/inspect-brain-workspaces-for-import-candidates.md
@@ -1,0 +1,31 @@
+---
+created_at: "2026-04-16T06:28:47Z"
+epic: brain-interop-and-planning-imports
+project: plan
+slug: inspect-brain-workspaces-for-import-candidates
+spec: brain-interop-and-planning-imports
+status: todo
+title: Inspect brain workspaces for import candidates
+type: story
+updated_at: "2026-04-16T06:28:47Z"
+---
+
+# Inspect brain workspaces for import candidates
+
+Created: 2026-04-16T06:28:47Z
+
+## Description
+
+Add a read-only inspection flow for planning material that already exists in brain workspaces.
+## Acceptance Criteria
+
+- [ ] Plan can detect importable planning notes from a local brain workspace without changing files.
+
+- [ ] Preview output stays focused on planning artifacts instead of brain memory or session data.
+## Verification
+
+- go test ./internal/planning
+## Resources
+
+- [Canonical Spec](../specs/brain-interop-and-planning-imports.md)
+## Notes

--- a/.plan/stories/inspect-brain-workspaces-for-import-candidates.md
+++ b/.plan/stories/inspect-brain-workspaces-for-import-candidates.md
@@ -4,10 +4,10 @@ epic: brain-interop-and-planning-imports
 project: plan
 slug: inspect-brain-workspaces-for-import-candidates
 spec: brain-interop-and-planning-imports
-status: todo
+status: done
 title: Inspect brain workspaces for import candidates
 type: story
-updated_at: "2026-04-16T06:28:47Z"
+updated_at: "2026-04-16T07:05:51Z"
 ---
 
 # Inspect brain workspaces for import candidates

--- a/.plan/stories/preserve-import-provenance-and-review-flow.md
+++ b/.plan/stories/preserve-import-provenance-and-review-flow.md
@@ -1,0 +1,31 @@
+---
+created_at: "2026-04-16T06:28:47Z"
+epic: brain-interop-and-planning-imports
+project: plan
+slug: preserve-import-provenance-and-review-flow
+spec: brain-interop-and-planning-imports
+status: todo
+title: Preserve import provenance and review flow
+type: story
+updated_at: "2026-04-16T06:28:47Z"
+---
+
+# Preserve import provenance and review flow
+
+Created: 2026-04-16T06:28:47Z
+
+## Description
+
+Keep import behavior inspectable so users can trust what came over from brain.
+## Acceptance Criteria
+
+- [ ] Imported artifacts retain visible provenance back to the source brain notes or workspace.
+
+- [ ] Users can review import candidates and resulting mappings before deeper execution work begins.
+## Verification
+
+- go test ./internal/planning ./cmd
+## Resources
+
+- [Canonical Spec](../specs/brain-interop-and-planning-imports.md)
+## Notes

--- a/.plan/stories/preserve-import-provenance-and-review-flow.md
+++ b/.plan/stories/preserve-import-provenance-and-review-flow.md
@@ -4,10 +4,10 @@ epic: brain-interop-and-planning-imports
 project: plan
 slug: preserve-import-provenance-and-review-flow
 spec: brain-interop-and-planning-imports
-status: todo
+status: done
 title: Preserve import provenance and review flow
 type: story
-updated_at: "2026-04-16T06:28:47Z"
+updated_at: "2026-04-16T07:09:59Z"
 ---
 
 # Preserve import provenance and review flow

--- a/.plan/stories/surface-roadmap-progress-in-status-output.md
+++ b/.plan/stories/surface-roadmap-progress-in-status-output.md
@@ -4,10 +4,10 @@ epic: roadmap-and-portfolio-planning
 project: plan
 slug: surface-roadmap-progress-in-status-output
 spec: roadmap-and-portfolio-planning
-status: todo
+status: done
 title: Surface roadmap progress in status output
 type: story
-updated_at: "2026-04-16T06:28:47Z"
+updated_at: "2026-04-16T06:39:51Z"
 ---
 
 # Surface roadmap progress in status output

--- a/.plan/stories/surface-roadmap-progress-in-status-output.md
+++ b/.plan/stories/surface-roadmap-progress-in-status-output.md
@@ -1,0 +1,31 @@
+---
+created_at: "2026-04-16T06:28:47Z"
+epic: roadmap-and-portfolio-planning
+project: plan
+slug: surface-roadmap-progress-in-status-output
+spec: roadmap-and-portfolio-planning
+status: todo
+title: Surface roadmap progress in status output
+type: story
+updated_at: "2026-04-16T06:28:47Z"
+---
+
+# Surface roadmap progress in status output
+
+Created: 2026-04-16T06:28:47Z
+
+## Description
+
+Connect roadmap version data to overall project status so users can see what is active and what is parked.
+## Acceptance Criteria
+
+- [ ] Status output can group or summarize epics by target version without losing current epic/story progress.
+
+- [ ] Roadmap-aware status stays readable for both small repos and multi-version plans.
+## Verification
+
+- go test ./cmd ./internal/planning
+## Resources
+
+- [Canonical Spec](../specs/roadmap-and-portfolio-planning.md)
+## Notes

--- a/.plan/stories/validate-release-automation-and-maintainer-docs.md
+++ b/.plan/stories/validate-release-automation-and-maintainer-docs.md
@@ -1,0 +1,37 @@
+---
+created_at: "2026-04-16T05:46:34Z"
+epic: skill-installer-and-release-delivery
+project: plan
+slug: validate-release-automation-and-maintainer-docs
+spec: skill-installer-and-release-delivery
+status: todo
+title: Validate release automation and maintainer docs
+type: story
+updated_at: "2026-04-16T05:46:34Z"
+---
+
+# Validate release automation and maintainer docs
+
+Created: 2026-04-16T05:46:34Z
+
+## Description
+
+
+Finish the release path so maintainers can reliably tag, publish, and communicate shipped changes.
+## Acceptance Criteria
+
+
+- [ ] CI covers test and build on pull requests
+
+- [ ] Tag-on-main release flow builds and publishes release artifacts
+
+- [ ] README and PR template support release-note-friendly maintenance
+## Verification
+
+
+- go test ./... && go build ./...
+## Resources
+
+
+- [Canonical Spec](../specs/skill-installer-and-release-delivery.md)
+## Notes

--- a/.plan/stories/validate-release-automation-and-maintainer-docs.md
+++ b/.plan/stories/validate-release-automation-and-maintainer-docs.md
@@ -4,10 +4,10 @@ epic: skill-installer-and-release-delivery
 project: plan
 slug: validate-release-automation-and-maintainer-docs
 spec: skill-installer-and-release-delivery
-status: todo
+status: done
 title: Validate release automation and maintainer docs
 type: story
-updated_at: "2026-04-16T05:46:34Z"
+updated_at: "2026-04-16T06:24:54Z"
 ---
 
 # Validate release automation and maintainer docs

--- a/README.md
+++ b/README.md
@@ -118,3 +118,16 @@ Preview install targets:
 ```bash
 plan skills targets --scope both --agent codex --project .
 ```
+
+## Release Flow
+
+- Pull requests run `go test ./...` and `go build ./...` in CI.
+- Every push to `main` tags the next patch release if `HEAD` is not already tagged.
+- The release workflow verifies the tagged commit, builds platform archives, and publishes a checksum file with the release assets.
+- `scripts/install.sh` only falls back to a source build when no published release can be resolved. Download or checksum failures stay hard failures.
+
+## Maintainers
+
+- Keep pull request titles and descriptions release-note-friendly. Generated GitHub release notes use merged PR metadata.
+- Include the verification commands you ran in the PR so the release notes have a clean audit trail.
+- Use `scripts/next-release-tag.sh` if you need to preview the next patch tag locally.

--- a/README.md
+++ b/README.md
@@ -163,6 +163,6 @@ plan skills targets --scope both --agent codex --project .
 
 ## Maintainers
 
-- Keep pull request titles and descriptions release-note-friendly. Generated GitHub release notes use merged PR metadata.
+- Keep pull request titles and descriptions release-note-friendly. The `## Release Notes` section in the PR template is the source of truth for published release changelogs.
 - Include the verification commands you ran in the PR so the release notes have a clean audit trail.
 - Use `scripts/next-release-tag.sh` if you need to preview the next patch tag locally.

--- a/README.md
+++ b/README.md
@@ -37,6 +37,18 @@ Supporting surfaces:
 - `ROADMAP.md`
 - optional future dependency and ready views
 
+Simple default path:
+
+1. brainstorm
+2. promote
+3. approve spec
+4. create stories
+5. execute
+
+Advanced path stays optional. When a repo grows, you can add roadmap versions,
+dependency blockers, ready-work views, Brain imports, and filtered status views
+without changing the base model.
+
 ## Workspace
 
 ```text
@@ -81,6 +93,29 @@ plan spec status --project . newsletter-system --set approved
 plan story create --project . newsletter-system "Build template editor"
 plan status --project .
 ```
+
+## Advanced Local Workflows
+
+These stay optional. If you do not need them, ignore them.
+
+- adopt an existing repo into a managed workspace:
+  `plan adopt --project .`
+- run structural planning checks:
+  `plan check --project .`
+- inspect version slices of the roadmap:
+  `plan roadmap versions --project . --version v2`
+- filter status for larger plans:
+  `plan status --project . --version v3 --epic power-user-local-workflows --story-status todo`
+- surface ready and blocked work:
+  `plan ready --project .`
+- narrow story lists by roadmap version:
+  `plan story list --project . --version v3`
+- inspect or import planning notes from a local Brain workspace:
+  `plan import brain inspect --workspace ../brain`
+  `plan import brain apply --project . --workspace ../brain --epic planning-and-brainstorming-ux`
+
+The rule stays the same: use the advanced surfaces only when the simple default
+stops being enough.
 
 ## Install
 

--- a/README.md
+++ b/README.md
@@ -49,7 +49,26 @@ my-project/
     specs/
     stories/
     .meta/
+      workspace.json
+      migrations.json
 ```
+
+User-authored planning material lives in:
+
+- `.plan/PROJECT.md`
+- `.plan/ROADMAP.md`
+- `.plan/brainstorms/`
+- `.plan/epics/`
+- `.plan/specs/`
+- `.plan/stories/`
+
+Tool-owned state lives only in:
+
+- `.plan/.meta/workspace.json`
+- `.plan/.meta/migrations.json`
+
+`plan update` may repair or normalize tool-owned state. It must not rewrite
+user-authored planning notes.
 
 ## Quick Start
 

--- a/README.md
+++ b/README.md
@@ -158,7 +158,7 @@ plan skills targets --scope both --agent codex --project .
 
 - Pull requests run `go test ./...` and `go build ./...` in CI.
 - Every push to `main` tags the next patch release if `HEAD` is not already tagged.
-- The release workflow verifies the tagged commit, builds platform archives, and publishes a checksum file with the release assets.
+- The release workflow builds platform archives and publishes a checksum file with the release assets.
 - `scripts/install.sh` only falls back to a source build when no published release can be resolved. Download or checksum failures stay hard failures.
 
 ## Maintainers

--- a/cmd/adopt.go
+++ b/cmd/adopt.go
@@ -1,0 +1,32 @@
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+)
+
+func newAdoptCommand() *cobra.Command {
+	return &cobra.Command{
+		Use:   "adopt",
+		Short: "Adopt an existing repo into a managed .plan workspace",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			result, err := workspaceManager().Adopt()
+			if err != nil {
+				return err
+			}
+			out := cmd.OutOrStdout()
+			fmt.Fprintf(out, "Adopted plan workspace at %s\n", result.Info.PlanDir)
+			for _, item := range result.Created {
+				fmt.Fprintf(out, "  created %s\n", item)
+			}
+			for _, item := range result.Updated {
+				fmt.Fprintf(out, "  updated %s\n", item)
+			}
+			if len(result.Created) == 0 && len(result.Updated) == 0 {
+				fmt.Fprintln(out, "  no changes")
+			}
+			return nil
+		},
+	}
+}

--- a/cmd/adopt_test.go
+++ b/cmd/adopt_test.go
@@ -1,0 +1,52 @@
+package cmd
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"plan/internal/workspace"
+)
+
+func TestAdoptCommandCreatesManagedWorkspace(t *testing.T) {
+	root := t.TempDir()
+	readmePath := filepath.Join(root, "README.md")
+	const readme = "# existing repo\n"
+	if err := os.WriteFile(readmePath, []byte(readme), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	var buf bytes.Buffer
+	command := newRootCmd()
+	command.SetOut(&buf)
+	command.SetErr(&buf)
+	command.SetArgs([]string{"--project", root, "adopt"})
+	if err := command.Execute(); err != nil {
+		t.Fatalf("expected adopt command to succeed: %v\n%s", err, buf.String())
+	}
+
+	output := buf.String()
+	if !strings.Contains(output, "Adopted plan workspace") {
+		t.Fatalf("expected adopt output:\n%s", output)
+	}
+	if _, err := os.Stat(filepath.Join(root, ".plan", ".meta", "workspace.json")); err != nil {
+		t.Fatalf("expected workspace metadata after adopt: %v", err)
+	}
+	raw, err := os.ReadFile(readmePath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(raw) != readme {
+		t.Fatalf("expected adopt to leave repo files alone:\n%s", raw)
+	}
+
+	report, err := workspace.New(root).Doctor()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if report.WorkspaceStatus != "current" {
+		t.Fatalf("expected adopted workspace to be current: %+v", report)
+	}
+}

--- a/cmd/brainstorm.go
+++ b/cmd/brainstorm.go
@@ -3,6 +3,8 @@ package cmd
 import (
 	"fmt"
 
+	"plan/internal/planning"
+
 	"github.com/spf13/cobra"
 )
 
@@ -12,12 +14,18 @@ func newBrainstormCommand() *cobra.Command {
 		Short: "Manage brainstorm notes",
 	}
 
+	var focusQuestion string
+	var seedIdeas []string
 	start := &cobra.Command{
 		Use:   "start <topic>",
 		Short: "Start a new brainstorm",
 		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			note, err := planningManager().CreateBrainstorm(args[0])
+			note, err := planningManager().CreateBrainstormWithInput(planning.BrainstormCreateInput{
+				Topic:         args[0],
+				FocusQuestion: focusQuestion,
+				Ideas:         seedIdeas,
+			})
 			if err != nil {
 				return err
 			}
@@ -25,9 +33,12 @@ func newBrainstormCommand() *cobra.Command {
 			return nil
 		},
 	}
+	start.Flags().StringVar(&focusQuestion, "focus", "", "focus question to seed into the brainstorm")
+	start.Flags().StringArrayVar(&seedIdeas, "idea", nil, "initial idea to capture; repeatable")
 
 	var ideaBody string
 	var ideaStdin bool
+	var section string
 	idea := &cobra.Command{
 		Use:   "idea <brainstorm-slug>",
 		Short: "Append an idea to a brainstorm",
@@ -40,7 +51,7 @@ func newBrainstormCommand() *cobra.Command {
 			if body == "" {
 				return fmt.Errorf("idea body is required")
 			}
-			note, err := planningManager().AddIdea(args[0], body)
+			note, err := planningManager().AddBrainstormEntry(args[0], section, body)
 			if err != nil {
 				return err
 			}
@@ -50,6 +61,7 @@ func newBrainstormCommand() *cobra.Command {
 	}
 	idea.Flags().StringVarP(&ideaBody, "body", "b", "", "idea body")
 	idea.Flags().BoolVar(&ideaStdin, "stdin", false, "read idea body from stdin")
+	idea.Flags().StringVar(&section, "section", "ideas", "brainstorm section: ideas, focus-question, desired-outcome, constraints, open-questions, raw-notes")
 
 	show := &cobra.Command{
 		Use:   "show <brainstorm-slug>",

--- a/cmd/check.go
+++ b/cmd/check.go
@@ -1,0 +1,79 @@
+package cmd
+
+import (
+	"fmt"
+	"io"
+
+	"plan/internal/planning"
+
+	"github.com/spf13/cobra"
+)
+
+func newCheckCommand() *cobra.Command {
+	return &cobra.Command{
+		Use:   "check [project|epic|spec|story] [slug]",
+		Short: "Run plan quality checks",
+		Args:  cobra.RangeArgs(0, 2),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			input, scopeLabel, err := resolveCheckScope(args)
+			if err != nil {
+				return err
+			}
+			report, err := planningManager().Check(input)
+			if err != nil {
+				return err
+			}
+			printCheckReport(cmd.OutOrStdout(), report, scopeLabel)
+			if report.HasErrors() {
+				return fmt.Errorf("plan check found %d blocking issue(s)", report.ErrorCount())
+			}
+			return nil
+		},
+	}
+}
+
+func resolveCheckScope(args []string) (planning.CheckInput, string, error) {
+	if len(args) == 0 {
+		return planning.CheckInput{}, "project", nil
+	}
+	if len(args) != 2 {
+		return planning.CheckInput{}, "", fmt.Errorf("scope and slug must be provided together")
+	}
+	switch args[0] {
+	case "project":
+		return planning.CheckInput{}, "project", nil
+	case "epic":
+		return planning.CheckInput{EpicSlug: args[1]}, "epic:" + args[1], nil
+	case "spec":
+		return planning.CheckInput{SpecSlug: args[1]}, "spec:" + args[1], nil
+	case "story":
+		return planning.CheckInput{StorySlug: args[1]}, "story:" + args[1], nil
+	default:
+		return planning.CheckInput{}, "", fmt.Errorf("unsupported check scope %q", args[0])
+	}
+}
+
+func printCheckReport(out io.Writer, report *planning.CheckReport, scopeLabel string) {
+	fmt.Fprintf(out, "check_scope: %s\n", scopeLabel)
+	fmt.Fprintf(out, "findings: %d total, %d blocking, %d guidance\n",
+		len(report.Findings),
+		report.ErrorCount(),
+		report.WarningCount(),
+	)
+	if len(report.Findings) == 0 {
+		fmt.Fprintln(out, "status: ok")
+		return
+	}
+	for _, finding := range report.Findings {
+		fmt.Fprintf(out, "- [%s] %s %s :: %s\n",
+			finding.Severity,
+			finding.ArtifactType,
+			finding.ArtifactPath,
+			finding.Section,
+		)
+		fmt.Fprintf(out, "  %s\n", finding.Message)
+		if finding.Suggestion != "" {
+			fmt.Fprintf(out, "  fix: %s\n", finding.Suggestion)
+		}
+	}
+}

--- a/cmd/check_test.go
+++ b/cmd/check_test.go
@@ -1,0 +1,224 @@
+package cmd
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"plan/internal/notes"
+	"plan/internal/planning"
+	"plan/internal/workspace"
+)
+
+func TestCheckCommandSupportsProjectEpicSpecAndStoryScopes(t *testing.T) {
+	root := t.TempDir()
+	ws := workspace.New(root)
+	if _, err := ws.Init(); err != nil {
+		t.Fatal(err)
+	}
+	manager := planning.New(ws)
+	createHealthyPlanFixture(t, root, manager)
+
+	tests := []struct {
+		name  string
+		args  []string
+		scope string
+	}{
+		{name: "project", args: []string{"check"}, scope: "check_scope: project"},
+		{name: "epic", args: []string{"check", "epic", "billing"}, scope: "check_scope: epic:billing"},
+		{name: "spec", args: []string{"check", "spec", "billing"}, scope: "check_scope: spec:billing"},
+		{name: "story", args: []string{"check", "story", "implement-invoices"}, scope: "check_scope: story:implement-invoices"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			var buf bytes.Buffer
+			command := newRootCmd()
+			command.SetOut(&buf)
+			command.SetErr(&buf)
+			command.SetArgs(append([]string{"--project", root}, tc.args...))
+			if err := command.Execute(); err != nil {
+				t.Fatalf("expected scope %s to pass, got error: %v\n%s", tc.name, err, buf.String())
+			}
+			output := buf.String()
+			if !strings.Contains(output, tc.scope) {
+				t.Fatalf("expected scope label in output:\n%s", output)
+			}
+			if !strings.Contains(output, "status: ok") {
+				t.Fatalf("expected ok status in output:\n%s", output)
+			}
+		})
+	}
+}
+
+func TestCheckCommandFailsOnBlockingFindings(t *testing.T) {
+	root := t.TempDir()
+	ws := workspace.New(root)
+	if _, err := ws.Init(); err != nil {
+		t.Fatal(err)
+	}
+	manager := planning.New(ws)
+	createHealthyPlanFixture(t, root, manager)
+
+	storyPath := root + "/.plan/stories/implement-invoices.md"
+	body := strings.Join([]string{
+		"# Implement invoices",
+		"",
+		"Created: now",
+		"",
+		"## Description",
+		"",
+		"Create the invoice generation path for paid plans.",
+		"",
+		"## Acceptance Criteria",
+		"",
+		"- [ ] Generate invoices from line items",
+		"",
+		"## Verification",
+		"",
+	}, "\n")
+	if _, err := notes.Update(storyPath, notes.UpdateInput{Body: &body}); err != nil {
+		t.Fatal(err)
+	}
+
+	var buf bytes.Buffer
+	command := newRootCmd()
+	command.SetOut(&buf)
+	command.SetErr(&buf)
+	command.SetArgs([]string{"--project", root, "check", "story", "implement-invoices"})
+	err := command.Execute()
+	if err == nil {
+		t.Fatalf("expected blocking findings to fail command:\n%s", buf.String())
+	}
+	output := buf.String()
+	if !strings.Contains(output, "[error] story .plan/stories/implement-invoices.md :: Verification") {
+		t.Fatalf("expected blocking story finding in output:\n%s", output)
+	}
+}
+
+func TestCheckCommandShowsWarningsWithoutFailing(t *testing.T) {
+	root := t.TempDir()
+	ws := workspace.New(root)
+	if _, err := ws.Init(); err != nil {
+		t.Fatal(err)
+	}
+	manager := planning.New(ws)
+	createHealthyPlanFixture(t, root, manager)
+
+	storyPath := root + "/.plan/stories/implement-invoices.md"
+	body := strings.Join([]string{
+		"# Implement invoices",
+		"",
+		"Created: now",
+		"",
+		"## Description",
+		"",
+		"Invoices.",
+		"",
+		"## Acceptance Criteria",
+		"",
+		"- [ ] Generate invoices from line items",
+		"",
+		"## Verification",
+		"",
+		"- Run focused billing tests",
+		"",
+	}, "\n")
+	if _, err := notes.Update(storyPath, notes.UpdateInput{Body: &body}); err != nil {
+		t.Fatal(err)
+	}
+
+	var buf bytes.Buffer
+	command := newRootCmd()
+	command.SetOut(&buf)
+	command.SetErr(&buf)
+	command.SetArgs([]string{"--project", root, "check", "story", "implement-invoices"})
+	if err := command.Execute(); err != nil {
+		t.Fatalf("expected warning-only check to pass: %v\n%s", err, buf.String())
+	}
+	output := buf.String()
+	if !strings.Contains(output, "[warn] story .plan/stories/implement-invoices.md :: Description") {
+		t.Fatalf("expected warning in output:\n%s", output)
+	}
+}
+
+func createHealthyPlanFixture(t *testing.T, root string, manager *planning.Manager) {
+	t.Helper()
+	if _, err := manager.CreateEpic("Billing", ""); err != nil {
+		t.Fatal(err)
+	}
+	specBody := strings.Join([]string{
+		"# Billing Spec",
+		"",
+		"Created: now",
+		"",
+		"## Why",
+		"",
+		"Billing drives plan monetization.",
+		"",
+		"## Problem",
+		"",
+		"Teams cannot generate invoices from the current billing data, which blocks manual reconciliation and delays payments.",
+		"",
+		"## Goals",
+		"",
+		"- generate invoices from line items",
+		"- keep invoice data consistent with billing periods",
+		"",
+		"## Non-Goals",
+		"",
+		"- building tax automation",
+		"- redesigning subscription management",
+		"",
+		"## Constraints",
+		"",
+		"- keep the implementation local-first",
+		"- reuse the current billing schema",
+		"",
+		"## Solution Shape",
+		"",
+		"Add a billing pipeline that emits invoice records and exposes them for export.",
+		"",
+		"## Flows",
+		"",
+		"1. User closes a billing cycle.",
+		"2. The system generates invoice records.",
+		"",
+		"## Data / Interfaces",
+		"",
+		"- invoice record output",
+		"",
+		"## Risks / Open Questions",
+		"",
+		"- How should failed exports retry?",
+		"",
+		"## Rollout",
+		"",
+		"- dogfood with the local workspace first",
+		"",
+		"## Verification",
+		"",
+		"- run focused billing tests",
+		"- generate a sample invoice export locally",
+		"",
+	}, "\n")
+	if _, err := manager.UpdateSpec("billing", notes.UpdateInput{
+		Body: &specBody,
+		Metadata: map[string]any{
+			"status":         "approved",
+			"target_version": "v2",
+		},
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := manager.CreateStory(
+		"billing",
+		"Implement invoices",
+		"Create the invoice generation path for paid plans.",
+		[]string{"Generate invoices from line items"},
+		[]string{"Run focused billing tests"},
+		nil,
+	); err != nil {
+		t.Fatal(err)
+	}
+}

--- a/cmd/doctor.go
+++ b/cmd/doctor.go
@@ -38,6 +38,12 @@ func newDoctorCommand() *cobra.Command {
 					fmt.Printf("  - %s\n", item)
 				}
 			}
+			if len(report.Guidance) > 0 {
+				fmt.Println("guidance:")
+				for _, item := range report.Guidance {
+					fmt.Printf("  - %s\n", item)
+				}
+			}
 			return nil
 		},
 	}

--- a/cmd/doctor.go
+++ b/cmd/doctor.go
@@ -24,10 +24,17 @@ func newDoctorCommand() *cobra.Command {
 			if report.SchemaVersion != 0 {
 				fmt.Printf("schema_version: %d\n", report.SchemaVersion)
 			}
+			fmt.Printf("workspace_status: %s\n", report.WorkspaceStatus)
 			fmt.Printf("migration_status: %s\n", report.MigrationStatus)
 			if len(report.Missing) > 0 {
 				fmt.Println("missing:")
 				for _, item := range report.Missing {
+					fmt.Printf("  - %s\n", item)
+				}
+			}
+			if len(report.Broken) > 0 {
+				fmt.Println("broken:")
+				for _, item := range report.Broken {
 					fmt.Printf("  - %s\n", item)
 				}
 			}

--- a/cmd/import.go
+++ b/cmd/import.go
@@ -1,0 +1,97 @@
+package cmd
+
+import (
+	"fmt"
+	"io"
+
+	"plan/internal/planning"
+
+	"github.com/spf13/cobra"
+)
+
+func newImportCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "import",
+		Short: "Import planning material from external local workspaces",
+	}
+	cmd.AddCommand(newImportBrainCommand())
+	return cmd
+}
+
+func newImportBrainCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "brain",
+		Short: "Inspect or import planning notes from a Brain workspace",
+	}
+
+	var workspacePath string
+	inspect := &cobra.Command{
+		Use:   "inspect",
+		Short: "Inspect importable planning notes in a Brain workspace",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			preview, err := planning.InspectBrainWorkspace(workspacePath)
+			if err != nil {
+				return err
+			}
+			printBrainImportPreview(cmd.OutOrStdout(), preview)
+			return nil
+		},
+	}
+	inspect.Flags().StringVar(&workspacePath, "workspace", ".", "path to a Brain repo root or .brain directory")
+
+	var brainstorms []string
+	var epics []string
+	var specs []string
+	var stories []string
+	apply := &cobra.Command{
+		Use:   "apply",
+		Short: "Import selected planning notes from a Brain workspace",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			result, err := planningManager().ImportBrainPlanning(planning.BrainImportSelection{
+				WorkspacePath: workspacePath,
+				Brainstorms:   brainstorms,
+				Epics:         epics,
+				Specs:         specs,
+				Stories:       stories,
+			})
+			if err != nil {
+				return err
+			}
+			out := cmd.OutOrStdout()
+			fmt.Fprintf(out, "brain_workspace: %s\n", result.WorkspacePath)
+			if len(result.Imported) == 0 {
+				fmt.Fprintln(out, "imported: none")
+				return nil
+			}
+			fmt.Fprintf(out, "imported: %d\n", len(result.Imported))
+			for _, item := range result.Imported {
+				fmt.Fprintf(out, "  - %s %s -> %s\n", item.Type, item.SourcePath, item.DestinationPath)
+			}
+			fmt.Fprintln(out, "review: inspect imported notes before execution work")
+			return nil
+		},
+	}
+	apply.Flags().StringVar(&workspacePath, "workspace", ".", "path to a Brain repo root or .brain directory")
+	apply.Flags().StringArrayVar(&brainstorms, "brainstorm", nil, "brainstorm slug to import; repeatable")
+	apply.Flags().StringArrayVar(&epics, "epic", nil, "epic slug to import; repeatable")
+	apply.Flags().StringArrayVar(&specs, "spec", nil, "spec slug to import; repeatable")
+	apply.Flags().StringArrayVar(&stories, "story", nil, "story slug to import; repeatable")
+
+	cmd.AddCommand(inspect, apply)
+	return cmd
+}
+
+func printBrainImportPreview(out io.Writer, preview *planning.BrainImportPreview) {
+	fmt.Fprintf(out, "brain_workspace: %s\n", preview.WorkspacePath)
+	printBrainImportCandidates(out, "brainstorms", preview.Brainstorms)
+	printBrainImportCandidates(out, "epics", preview.Epics)
+	printBrainImportCandidates(out, "specs", preview.Specs)
+	printBrainImportCandidates(out, "stories", preview.Stories)
+}
+
+func printBrainImportCandidates(out io.Writer, label string, items []planning.BrainImportCandidate) {
+	fmt.Fprintf(out, "%s: %d\n", label, len(items))
+	for _, item := range items {
+		fmt.Fprintf(out, "  - %s %s (%s)\n", item.Type, item.Slug, item.Path)
+	}
+}

--- a/cmd/import_test.go
+++ b/cmd/import_test.go
@@ -1,0 +1,63 @@
+package cmd
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"plan/internal/workspace"
+)
+
+func TestBrainImportInspectCommandPrintsPlanningCandidates(t *testing.T) {
+	var buf bytes.Buffer
+	command := newRootCmd()
+	command.SetOut(&buf)
+	command.SetErr(&buf)
+	command.SetArgs([]string{"import", "brain", "inspect", "--workspace", "../examples/brain"})
+	if err := command.Execute(); err != nil {
+		t.Fatalf("expected inspect command to succeed: %v\n%s", err, buf.String())
+	}
+
+	output := buf.String()
+	if !strings.Contains(output, "brain_workspace:") {
+		t.Fatalf("expected workspace header in output:\n%s", output)
+	}
+	if !strings.Contains(output, "brainstorms:") || !strings.Contains(output, "epics:") || !strings.Contains(output, "specs:") || !strings.Contains(output, "stories:") {
+		t.Fatalf("expected planning candidate groups in output:\n%s", output)
+	}
+	if strings.Contains(output, "context/") {
+		t.Fatalf("expected inspect output to avoid brain context surfaces:\n%s", output)
+	}
+}
+
+func TestBrainImportApplyCommandPrintsMappings(t *testing.T) {
+	root := t.TempDir()
+	if _, err := workspace.New(root).Init(); err != nil {
+		t.Fatal(err)
+	}
+
+	var buf bytes.Buffer
+	command := newRootCmd()
+	command.SetOut(&buf)
+	command.SetErr(&buf)
+	command.SetArgs([]string{
+		"--project", root,
+		"import", "brain", "apply",
+		"--workspace", "../examples/brain",
+		"--epic", "planning-and-brainstorming-ux",
+	})
+	if err := command.Execute(); err != nil {
+		t.Fatalf("expected apply command to succeed: %v\n%s", err, buf.String())
+	}
+
+	output := buf.String()
+	if !strings.Contains(output, "imported: 1") {
+		t.Fatalf("expected import count in output:\n%s", output)
+	}
+	if !strings.Contains(output, ".brain/planning/epics/planning-and-brainstorming-ux.md -> .plan/epics/planning-and-brainstorming-ux.md") {
+		t.Fatalf("expected source-to-destination mapping in output:\n%s", output)
+	}
+	if !strings.Contains(output, "review: inspect imported notes before execution work") {
+		t.Fatalf("expected review guidance in output:\n%s", output)
+	}
+}

--- a/cmd/import_test.go
+++ b/cmd/import_test.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"bytes"
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -9,11 +10,13 @@ import (
 )
 
 func TestBrainImportInspectCommandPrintsPlanningCandidates(t *testing.T) {
+	workspacePath := brainFixturePath(t)
+
 	var buf bytes.Buffer
 	command := newRootCmd()
 	command.SetOut(&buf)
 	command.SetErr(&buf)
-	command.SetArgs([]string{"import", "brain", "inspect", "--workspace", "../examples/brain"})
+	command.SetArgs([]string{"import", "brain", "inspect", "--workspace", workspacePath})
 	if err := command.Execute(); err != nil {
 		t.Fatalf("expected inspect command to succeed: %v\n%s", err, buf.String())
 	}
@@ -35,6 +38,7 @@ func TestBrainImportApplyCommandPrintsMappings(t *testing.T) {
 	if _, err := workspace.New(root).Init(); err != nil {
 		t.Fatal(err)
 	}
+	workspacePath := brainFixturePath(t)
 
 	var buf bytes.Buffer
 	command := newRootCmd()
@@ -43,7 +47,7 @@ func TestBrainImportApplyCommandPrintsMappings(t *testing.T) {
 	command.SetArgs([]string{
 		"--project", root,
 		"import", "brain", "apply",
-		"--workspace", "../examples/brain",
+		"--workspace", workspacePath,
 		"--epic", "planning-and-brainstorming-ux",
 	})
 	if err := command.Execute(); err != nil {
@@ -60,4 +64,14 @@ func TestBrainImportApplyCommandPrintsMappings(t *testing.T) {
 	if !strings.Contains(output, "review: inspect imported notes before execution work") {
 		t.Fatalf("expected review guidance in output:\n%s", output)
 	}
+}
+
+func brainFixturePath(t *testing.T) string {
+	t.Helper()
+
+	path, err := filepath.Abs(filepath.Join("..", "testdata", "brain-workspace"))
+	if err != nil {
+		t.Fatalf("resolve brain fixture path: %v", err)
+	}
+	return path
 }

--- a/cmd/ready.go
+++ b/cmd/ready.go
@@ -3,11 +3,15 @@ package cmd
 import (
 	"fmt"
 
+	"plan/internal/planning"
+
 	"github.com/spf13/cobra"
 )
 
 func newReadyCommand() *cobra.Command {
-	return &cobra.Command{
+	var versionFilter string
+	var epicFilter string
+	cmd := &cobra.Command{
 		Use:   "ready",
 		Short: "Show ready and dependency-blocked stories",
 		RunE: func(cmd *cobra.Command, args []string) error {
@@ -16,20 +20,25 @@ func newReadyCommand() *cobra.Command {
 				return err
 			}
 			out := cmd.OutOrStdout()
-			if len(work.Ready) == 0 {
+			filteredReady := filterStoriesForDisplay(work.Ready, versionFilter, epicFilter)
+			filteredBlocked := filterBlockedStoriesForDisplay(work.Blocked, versionFilter, epicFilter)
+			if versionFilter != "" || epicFilter != "" {
+				fmt.Fprintf(out, "filters: %s\n", formatStatusFilters(versionFilter, epicFilter, ""))
+			}
+			if len(filteredReady) == 0 {
 				fmt.Fprintln(out, "ready: none")
 			} else {
-				fmt.Fprintf(out, "ready: %d\n", len(work.Ready))
-				for _, story := range work.Ready {
+				fmt.Fprintf(out, "ready: %d\n", len(filteredReady))
+				for _, story := range filteredReady {
 					fmt.Fprintf(out, "  - %s [%s] epic=%s\n", story.Title, story.Status, story.Epic)
 				}
 			}
-			if len(work.Blocked) == 0 {
+			if len(filteredBlocked) == 0 {
 				fmt.Fprintln(out, "blocked: none")
 				return nil
 			}
-			fmt.Fprintf(out, "blocked: %d\n", len(work.Blocked))
-			for _, item := range work.Blocked {
+			fmt.Fprintf(out, "blocked: %d\n", len(filteredBlocked))
+			for _, item := range filteredBlocked {
 				fmt.Fprintf(out, "  - %s [%s] epic=%s\n", item.Story.Title, item.Story.Status, item.Story.Epic)
 				for _, reason := range item.Reasons {
 					fmt.Fprintf(out, "    %s\n", reason)
@@ -38,4 +47,18 @@ func newReadyCommand() *cobra.Command {
 			return nil
 		},
 	}
+	cmd.Flags().StringVar(&versionFilter, "version", "", "filter by target roadmap version")
+	cmd.Flags().StringVar(&epicFilter, "epic", "", "filter by epic slug")
+	return cmd
+}
+
+func filterBlockedStoriesForDisplay(items []planning.BlockedStory, versionFilter, epicFilter string) []planning.BlockedStory {
+	var out []planning.BlockedStory
+	for _, item := range items {
+		if !storyMatchesFilters(item.Story, versionFilter, epicFilter) {
+			continue
+		}
+		out = append(out, item)
+	}
+	return out
 }

--- a/cmd/ready.go
+++ b/cmd/ready.go
@@ -1,0 +1,41 @@
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+)
+
+func newReadyCommand() *cobra.Command {
+	return &cobra.Command{
+		Use:   "ready",
+		Short: "Show ready and dependency-blocked stories",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			work, err := planningManager().ReadyWork()
+			if err != nil {
+				return err
+			}
+			out := cmd.OutOrStdout()
+			if len(work.Ready) == 0 {
+				fmt.Fprintln(out, "ready: none")
+			} else {
+				fmt.Fprintf(out, "ready: %d\n", len(work.Ready))
+				for _, story := range work.Ready {
+					fmt.Fprintf(out, "  - %s [%s] epic=%s\n", story.Title, story.Status, story.Epic)
+				}
+			}
+			if len(work.Blocked) == 0 {
+				fmt.Fprintln(out, "blocked: none")
+				return nil
+			}
+			fmt.Fprintf(out, "blocked: %d\n", len(work.Blocked))
+			for _, item := range work.Blocked {
+				fmt.Fprintf(out, "  - %s [%s] epic=%s\n", item.Story.Title, item.Story.Status, item.Story.Epic)
+				for _, reason := range item.Reasons {
+					fmt.Fprintf(out, "    %s\n", reason)
+				}
+			}
+			return nil
+		},
+	}
+}

--- a/cmd/ready_test.go
+++ b/cmd/ready_test.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 	"testing"
 
+	"plan/internal/notes"
 	"plan/internal/planning"
 	"plan/internal/workspace"
 )
@@ -73,5 +74,60 @@ func TestReadyCommandPrintsReadyAndBlockedStories(t *testing.T) {
 	}
 	if !strings.Contains(output, "story status is blocked") {
 		t.Fatalf("expected manual blocked reason in output:\n%s", output)
+	}
+}
+
+func TestReadyCommandSupportsVersionAndEpicFilters(t *testing.T) {
+	root := t.TempDir()
+	ws := workspace.New(root)
+	if _, err := ws.Init(); err != nil {
+		t.Fatal(err)
+	}
+	manager := planning.New(ws)
+
+	for _, title := range []string{"Billing", "Exports"} {
+		if _, err := manager.CreateEpic(title, ""); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if _, err := manager.UpdateSpec("billing", notes.UpdateInput{
+		Metadata: map[string]any{"status": "approved", "target_version": "v2"},
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := manager.UpdateSpec("exports", notes.UpdateInput{
+		Metadata: map[string]any{"status": "approved", "target_version": "v3"},
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := manager.CreateStory("billing", "Implement invoices", "Create invoice generation flow", []string{"Generate invoices"}, []string{"Run billing tests"}, nil); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := manager.CreateStory("exports", "Ship exports", "Create export flow", []string{"Export invoices"}, []string{"Run export tests"}, nil); err != nil {
+		t.Fatal(err)
+	}
+
+	prevProjectDir := projectDir
+	projectDir = root
+	defer func() { projectDir = prevProjectDir }()
+
+	var buf bytes.Buffer
+	command := newReadyCommand()
+	command.SetOut(&buf)
+	command.SetErr(&buf)
+	command.SetArgs([]string{"--version", "v2", "--epic", "billing"})
+	if err := command.Execute(); err != nil {
+		t.Fatal(err)
+	}
+
+	output := buf.String()
+	if !strings.Contains(output, "filters: version=v2, epic=billing") {
+		t.Fatalf("expected filter header in output:\n%s", output)
+	}
+	if strings.Contains(output, "Ship exports") {
+		t.Fatalf("expected filters to remove exports story:\n%s", output)
+	}
+	if !strings.Contains(output, "Implement invoices [todo] epic=billing") {
+		t.Fatalf("expected filtered ready story in output:\n%s", output)
 	}
 }

--- a/cmd/ready_test.go
+++ b/cmd/ready_test.go
@@ -1,0 +1,77 @@
+package cmd
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"plan/internal/planning"
+	"plan/internal/workspace"
+)
+
+func TestReadyCommandPrintsReadyAndBlockedStories(t *testing.T) {
+	root := t.TempDir()
+	ws := workspace.New(root)
+	if _, err := ws.Init(); err != nil {
+		t.Fatal(err)
+	}
+	manager := planning.New(ws)
+
+	if _, err := manager.CreateEpic("Billing", ""); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := manager.SetSpecStatus("billing", "approved"); err != nil {
+		t.Fatal(err)
+	}
+	for _, input := range []struct {
+		title string
+		body  string
+	}{
+		{title: "Implement invoices", body: "Create invoice generation flow"},
+		{title: "Ship exports", body: "Create export flow"},
+		{title: "Manual blocker", body: "Needs external review"},
+	} {
+		if _, err := manager.CreateStory(
+			"billing",
+			input.title,
+			input.body,
+			[]string{"Acceptance for " + input.title},
+			[]string{"Verify " + input.title},
+			nil,
+		); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if _, err := manager.UpdateStory("ship-exports", planning.StoryChanges{SetBlockers: []string{"implement-invoices"}}); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := manager.UpdateStory("manual-blocker", planning.StoryChanges{Status: "blocked"}); err != nil {
+		t.Fatal(err)
+	}
+
+	prevProjectDir := projectDir
+	projectDir = root
+	defer func() { projectDir = prevProjectDir }()
+
+	var buf bytes.Buffer
+	command := newReadyCommand()
+	command.SetOut(&buf)
+	command.SetErr(&buf)
+	if err := command.Execute(); err != nil {
+		t.Fatal(err)
+	}
+
+	output := buf.String()
+	if !strings.Contains(output, "ready: 1") || !strings.Contains(output, "Implement invoices [todo] epic=billing") {
+		t.Fatalf("expected ready story in output:\n%s", output)
+	}
+	if !strings.Contains(output, "blocked: 2") {
+		t.Fatalf("expected blocked summary in output:\n%s", output)
+	}
+	if !strings.Contains(output, "blocked by implement-invoices [todo]") {
+		t.Fatalf("expected dependency blocker reason in output:\n%s", output)
+	}
+	if !strings.Contains(output, "story status is blocked") {
+		t.Fatalf("expected manual blocked reason in output:\n%s", output)
+	}
+}

--- a/cmd/roadmap.go
+++ b/cmd/roadmap.go
@@ -2,7 +2,11 @@ package cmd
 
 import (
 	"fmt"
+	"io"
 	"os"
+	"strings"
+
+	"plan/internal/planning"
 
 	"github.com/spf13/cobra"
 )
@@ -66,6 +70,63 @@ func newRoadmapCommand() *cobra.Command {
 	edit.Flags().BoolVar(&useStdin, "stdin", false, "read replacement body from stdin")
 	edit.Flags().StringVar(&editor, "editor", "", "editor command")
 
-	cmd.AddCommand(show, edit)
+	var versionFilter string
+	versions := &cobra.Command{
+		Use:   "versions",
+		Short: "Show parsed roadmap versions and epics",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			roadmap, err := planningManager().ReadRoadmap()
+			if err != nil {
+				return err
+			}
+			return printRoadmapVersions(cmd.OutOrStdout(), roadmap, versionFilter)
+		},
+	}
+	versions.Flags().StringVar(&versionFilter, "version", "", "filter to a roadmap version key such as v1")
+
+	cmd.AddCommand(show, edit, versions)
 	return cmd
+}
+
+func printRoadmapVersions(out io.Writer, roadmap *planning.Roadmap, versionFilter string) error {
+	fmt.Fprintf(out, "%s\n\n", roadmap.Path)
+
+	filter := strings.TrimSpace(strings.ToLower(versionFilter))
+	var matched int
+	for _, version := range roadmap.Versions {
+		if filter != "" && strings.ToLower(version.Key) != filter {
+			continue
+		}
+		matched++
+		fmt.Fprintf(out, "%s: %s\n", version.Key, version.Title)
+		if version.Goal != "" {
+			fmt.Fprintf(out, "goal: %s\n", version.Goal)
+		}
+		if len(version.Epics) > 0 {
+			fmt.Fprintln(out, "epics:")
+			for _, epic := range version.Epics {
+				check := " "
+				if epic.Done {
+					check = "x"
+				}
+				fmt.Fprintf(out, "  - [%s] %s\n", check, epic.Title)
+			}
+		}
+		if len(version.Summary) > 0 {
+			fmt.Fprintln(out, "summary:")
+			for _, item := range version.Summary {
+				fmt.Fprintf(out, "  - %s\n", item)
+			}
+		}
+		fmt.Fprintln(out)
+	}
+
+	if matched > 0 {
+		return nil
+	}
+	if filter != "" {
+		return fmt.Errorf("roadmap version %q not found", versionFilter)
+	}
+	fmt.Fprintln(out, "versions: none")
+	return nil
 }

--- a/cmd/roadmap_test.go
+++ b/cmd/roadmap_test.go
@@ -1,0 +1,113 @@
+package cmd
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"plan/internal/workspace"
+)
+
+func TestRoadmapVersionsCommandPrintsParsedVersions(t *testing.T) {
+	root := t.TempDir()
+	ws := workspace.New(root)
+	if _, err := ws.Init(); err != nil {
+		t.Fatal(err)
+	}
+
+	body := `# Roadmap: plan
+
+## Overview
+
+Overview text.
+
+## v1: Local-First Core
+
+Goal: Ship the trustworthy foundation.
+
+- [ ] Core Workspace and Artifact System
+- [x] Spec-Driven Planning Workflow
+
+Summary:
+- establish .plan as the workspace
+- make the core loop work
+`
+	if err := os.WriteFile(filepath.Join(root, ".plan", "ROADMAP.md"), []byte(body), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	prevProjectDir := projectDir
+	projectDir = root
+	defer func() { projectDir = prevProjectDir }()
+
+	var buf bytes.Buffer
+	command := newRoadmapCommand()
+	command.SetOut(&buf)
+	command.SetErr(&buf)
+	command.SetArgs([]string{"versions"})
+	if err := command.Execute(); err != nil {
+		t.Fatal(err)
+	}
+
+	output := buf.String()
+	if !strings.Contains(output, ".plan/ROADMAP.md") {
+		t.Fatalf("expected roadmap path in output:\n%s", output)
+	}
+	if !strings.Contains(output, "v1: Local-First Core") {
+		t.Fatalf("expected version heading in output:\n%s", output)
+	}
+	if !strings.Contains(output, "goal: Ship the trustworthy foundation.") {
+		t.Fatalf("expected goal in output:\n%s", output)
+	}
+	if !strings.Contains(output, "  - [ ] Core Workspace and Artifact System") || !strings.Contains(output, "  - [x] Spec-Driven Planning Workflow") {
+		t.Fatalf("expected roadmap epic list in output:\n%s", output)
+	}
+	if !strings.Contains(output, "summary:") || !strings.Contains(output, "  - establish .plan as the workspace") {
+		t.Fatalf("expected roadmap summary in output:\n%s", output)
+	}
+}
+
+func TestRoadmapVersionsCommandFiltersVersion(t *testing.T) {
+	root := t.TempDir()
+	ws := workspace.New(root)
+	if _, err := ws.Init(); err != nil {
+		t.Fatal(err)
+	}
+
+	body := `# Roadmap: plan
+
+## v1: Core
+
+Goal: Ship core.
+
+## v2: Rigor
+
+Goal: Tighten planning.
+`
+	if err := os.WriteFile(filepath.Join(root, ".plan", "ROADMAP.md"), []byte(body), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	prevProjectDir := projectDir
+	projectDir = root
+	defer func() { projectDir = prevProjectDir }()
+
+	var buf bytes.Buffer
+	command := newRoadmapCommand()
+	command.SetOut(&buf)
+	command.SetErr(&buf)
+	command.SetArgs([]string{"versions", "--version", "v2"})
+	if err := command.Execute(); err != nil {
+		t.Fatal(err)
+	}
+
+	output := buf.String()
+	if strings.Contains(output, "v1: Core") {
+		t.Fatalf("expected version filter to remove v1 output:\n%s", output)
+	}
+	if !strings.Contains(output, "v2: Rigor") {
+		t.Fatalf("expected version filter to keep v2 output:\n%s", output)
+	}
+}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -16,6 +16,7 @@ func newRootCmd() *cobra.Command {
 	root.PersistentFlags().StringVar(&projectDir, "project", ".", "project root")
 
 	root.AddCommand(
+		newAdoptCommand(),
 		newCheckCommand(),
 		newInitCommand(),
 		newDoctorCommand(),

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -18,6 +18,7 @@ func newRootCmd() *cobra.Command {
 	root.AddCommand(
 		newAdoptCommand(),
 		newCheckCommand(),
+		newImportCommand(),
 		newInitCommand(),
 		newDoctorCommand(),
 		newUpdateCommand(),

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -16,6 +16,7 @@ func newRootCmd() *cobra.Command {
 	root.PersistentFlags().StringVar(&projectDir, "project", ".", "project root")
 
 	root.AddCommand(
+		newCheckCommand(),
 		newInitCommand(),
 		newDoctorCommand(),
 		newUpdateCommand(),

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -26,6 +26,7 @@ func newRootCmd() *cobra.Command {
 		newSpecCommand(),
 		newStoryCommand(),
 		newRoadmapCommand(),
+		newReadyCommand(),
 		newStatusCommand(),
 		newSkillsCommand(),
 	)

--- a/cmd/status.go
+++ b/cmd/status.go
@@ -34,6 +34,10 @@ func printStatus(out io.Writer, status *planning.ProjectStatus) {
 		status.InProgressStories,
 		status.BlockedStories,
 	)
+	if hasRoadmapVersionAssignments(status) {
+		printVersionStatus(out, status)
+		return
+	}
 	if len(status.Epics) == 0 {
 		fmt.Fprintln(out, "epics: none")
 		return
@@ -48,5 +52,68 @@ func printStatus(out io.Writer, status *planning.ProjectStatus) {
 			epic.InProgressStories,
 			epic.BlockedStories,
 		)
+	}
+}
+
+func hasRoadmapVersionAssignments(status *planning.ProjectStatus) bool {
+	for _, version := range status.Versions {
+		if len(version.Epics) > 0 {
+			return true
+		}
+	}
+	return false
+}
+
+func printVersionStatus(out io.Writer, status *planning.ProjectStatus) {
+	if status.RoadmapPath != "" {
+		fmt.Fprintf(out, "roadmap: %s\n", status.RoadmapPath)
+	}
+	fmt.Fprintln(out, "versions:")
+	for _, version := range status.Versions {
+		fmt.Fprintf(out, "  %s: %s (%d stories, %d done, %d in_progress, %d blocked)\n",
+			version.Key,
+			version.Title,
+			version.TotalStories,
+			version.DoneStories,
+			version.InProgressStories,
+			version.BlockedStories,
+		)
+		if version.Goal != "" {
+			fmt.Fprintf(out, "    goal: %s\n", version.Goal)
+		}
+		if len(version.Epics) == 0 {
+			fmt.Fprintln(out, "    epics: none")
+			continue
+		}
+		for _, epic := range version.Epics {
+			fmt.Fprintf(out, "    - %s [%s] (%d/%d done, %d in progress, %d blocked)\n",
+				epic.Title,
+				epic.SpecStatus,
+				epic.DoneStories,
+				epic.TotalStories,
+				epic.InProgressStories,
+				epic.BlockedStories,
+			)
+		}
+	}
+	if len(status.UnassignedEpics) == 0 {
+		if status.ParkingLotCount > 0 {
+			fmt.Fprintf(out, "parking_lot: %d item(s)\n", status.ParkingLotCount)
+		}
+		return
+	}
+	fmt.Fprintln(out, "unassigned_epics:")
+	for _, epic := range status.UnassignedEpics {
+		fmt.Fprintf(out, "  - %s [%s] (%d/%d done, %d in progress, %d blocked)\n",
+			epic.Title,
+			epic.SpecStatus,
+			epic.DoneStories,
+			epic.TotalStories,
+			epic.InProgressStories,
+			epic.BlockedStories,
+		)
+	}
+	if status.ParkingLotCount > 0 {
+		fmt.Fprintf(out, "parking_lot: %d item(s)\n", status.ParkingLotCount)
 	}
 }

--- a/cmd/status.go
+++ b/cmd/status.go
@@ -3,6 +3,8 @@ package cmd
 import (
 	"fmt"
 	"io"
+	"path/filepath"
+	"strings"
 
 	"plan/internal/planning"
 
@@ -10,7 +12,10 @@ import (
 )
 
 func newStatusCommand() *cobra.Command {
-	return &cobra.Command{
+	var versionFilter string
+	var epicFilter string
+	var storyStatusFilter string
+	cmd := &cobra.Command{
 		Use:   "status",
 		Short: "Show overall planning status",
 		RunE: func(cmd *cobra.Command, args []string) error {
@@ -18,11 +23,27 @@ func newStatusCommand() *cobra.Command {
 			if err != nil {
 				return err
 			}
+			if hasStatusFilters(versionFilter, epicFilter, storyStatusFilter) {
+				stories, err := planningManager().ListStories("", storyStatusFilter)
+				if err != nil {
+					return err
+				}
+				readyWork, err := planningManager().ReadyWork()
+				if err != nil {
+					return err
+				}
+				status = filterProjectStatus(status, stories, readyWork, versionFilter, epicFilter)
+				fmt.Fprintf(cmd.OutOrStdout(), "filters: %s\n", formatStatusFilters(versionFilter, epicFilter, storyStatusFilter))
+			}
 			out := cmd.OutOrStdout()
 			printStatus(out, status)
 			return nil
 		},
 	}
+	cmd.Flags().StringVar(&versionFilter, "version", "", "filter output to a roadmap version such as v2")
+	cmd.Flags().StringVar(&epicFilter, "epic", "", "filter output to an epic slug")
+	cmd.Flags().StringVar(&storyStatusFilter, "story-status", "", "filter output to stories with this lifecycle status")
+	return cmd
 }
 
 func printStatus(out io.Writer, status *planning.ProjectStatus) {
@@ -120,4 +141,158 @@ func printVersionStatus(out io.Writer, status *planning.ProjectStatus) {
 	if status.ParkingLotCount > 0 {
 		fmt.Fprintf(out, "parking_lot: %d item(s)\n", status.ParkingLotCount)
 	}
+}
+
+func hasStatusFilters(version, epic, storyStatus string) bool {
+	return strings.TrimSpace(version) != "" || strings.TrimSpace(epic) != "" || strings.TrimSpace(storyStatus) != ""
+}
+
+func formatStatusFilters(version, epic, storyStatus string) string {
+	var parts []string
+	if strings.TrimSpace(version) != "" {
+		parts = append(parts, "version="+version)
+	}
+	if strings.TrimSpace(epic) != "" {
+		parts = append(parts, "epic="+epic)
+	}
+	if strings.TrimSpace(storyStatus) != "" {
+		parts = append(parts, "story_status="+storyStatus)
+	}
+	return strings.Join(parts, ", ")
+}
+
+func filterProjectStatus(status *planning.ProjectStatus, stories []planning.StoryInfo, ready *planning.ReadyWork, versionFilter, epicFilter string) *planning.ProjectStatus {
+	versionFilter = strings.TrimSpace(versionFilter)
+	epicFilter = strings.TrimSpace(epicFilter)
+	filteredStories := filterStoriesForDisplay(stories, versionFilter, epicFilter)
+
+	copy := *status
+	copy.TotalStories = len(filteredStories)
+	copy.DoneStories = 0
+	copy.InProgressStories = 0
+	copy.BlockedStories = 0
+	for _, story := range filteredStories {
+		switch story.Status {
+		case "done":
+			copy.DoneStories++
+		case "in_progress":
+			copy.InProgressStories++
+		case "blocked":
+			copy.BlockedStories++
+		}
+	}
+
+	copy.ReadyStories = 0
+	copy.DependencyBlocked = 0
+	for _, story := range filterStoriesForDisplay(ready.Ready, versionFilter, epicFilter) {
+		copy.ReadyStories++
+		_ = story
+	}
+	for _, blocked := range ready.Blocked {
+		if storyMatchesFilters(blocked.Story, versionFilter, epicFilter) {
+			copy.DependencyBlocked++
+		}
+	}
+
+	copy.Epics = filterEpicsForDisplay(status.Epics, filteredStories, versionFilter, epicFilter)
+	copy.UnassignedEpics = filterEpicsForDisplay(status.UnassignedEpics, filteredStories, versionFilter, epicFilter)
+	copy.Versions = filterVersionsForDisplay(status.Versions, filteredStories, versionFilter, epicFilter)
+	return &copy
+}
+
+func filterStoriesForDisplay(stories []planning.StoryInfo, versionFilter, epicFilter string) []planning.StoryInfo {
+	var out []planning.StoryInfo
+	for _, story := range stories {
+		if !storyMatchesFilters(story, versionFilter, epicFilter) {
+			continue
+		}
+		out = append(out, story)
+	}
+	return out
+}
+
+func storyMatchesFilters(story planning.StoryInfo, versionFilter, epicFilter string) bool {
+	if strings.TrimSpace(versionFilter) != "" && story.TargetVersion != strings.TrimSpace(versionFilter) {
+		return false
+	}
+	if strings.TrimSpace(epicFilter) != "" && story.Epic != strings.TrimSpace(epicFilter) {
+		return false
+	}
+	return true
+}
+
+func filterEpicsForDisplay(epics []planning.EpicInfo, stories []planning.StoryInfo, versionFilter, epicFilter string) []planning.EpicInfo {
+	storyCounts := map[string][]planning.StoryInfo{}
+	for _, story := range stories {
+		storyCounts[story.Epic] = append(storyCounts[story.Epic], story)
+	}
+	var out []planning.EpicInfo
+	for _, epic := range epics {
+		epicSlug := slugFromRelPath(epic.Path)
+		if strings.TrimSpace(epicFilter) != "" && epicSlug != strings.TrimSpace(epicFilter) {
+			continue
+		}
+		epicStories := storyCounts[epicSlug]
+		if strings.TrimSpace(versionFilter) != "" {
+			matchesVersion := false
+			for _, story := range epicStories {
+				if story.TargetVersion == strings.TrimSpace(versionFilter) {
+					matchesVersion = true
+					break
+				}
+			}
+			if !matchesVersion {
+				continue
+			}
+		}
+		copy := epic
+		copy.TotalStories = len(epicStories)
+		copy.DoneStories = 0
+		copy.InProgressStories = 0
+		copy.BlockedStories = 0
+		for _, story := range epicStories {
+			switch story.Status {
+			case "done":
+				copy.DoneStories++
+			case "in_progress":
+				copy.InProgressStories++
+			case "blocked":
+				copy.BlockedStories++
+			}
+		}
+		out = append(out, copy)
+	}
+	return out
+}
+
+func filterVersionsForDisplay(versions []planning.VersionStatus, stories []planning.StoryInfo, versionFilter, epicFilter string) []planning.VersionStatus {
+	var out []planning.VersionStatus
+	for _, version := range versions {
+		if strings.TrimSpace(versionFilter) != "" && version.Key != strings.TrimSpace(versionFilter) {
+			continue
+		}
+		filteredEpics := filterEpicsForDisplay(version.Epics, stories, version.Key, epicFilter)
+		if strings.TrimSpace(versionFilter) == "" && len(filteredEpics) == 0 {
+			continue
+		}
+		copy := version
+		copy.Epics = filteredEpics
+		copy.TotalStories = 0
+		copy.DoneStories = 0
+		copy.InProgressStories = 0
+		copy.BlockedStories = 0
+		for _, epic := range copy.Epics {
+			copy.TotalStories += epic.TotalStories
+			copy.DoneStories += epic.DoneStories
+			copy.InProgressStories += epic.InProgressStories
+			copy.BlockedStories += epic.BlockedStories
+		}
+		out = append(out, copy)
+	}
+	return out
+}
+
+func slugFromRelPath(path string) string {
+	base := filepath.Base(path)
+	return strings.TrimSuffix(base, filepath.Ext(base))
 }

--- a/cmd/status.go
+++ b/cmd/status.go
@@ -34,6 +34,10 @@ func printStatus(out io.Writer, status *planning.ProjectStatus) {
 		status.InProgressStories,
 		status.BlockedStories,
 	)
+	fmt.Fprintf(out, "ready_work: %d ready, %d blocked_by_dependencies\n",
+		status.ReadyStories,
+		status.DependencyBlocked,
+	)
 	if hasRoadmapVersionAssignments(status) {
 		printVersionStatus(out, status)
 		return

--- a/cmd/status.go
+++ b/cmd/status.go
@@ -2,6 +2,9 @@ package cmd
 
 import (
 	"fmt"
+	"io"
+
+	"plan/internal/planning"
 
 	"github.com/spf13/cobra"
 )
@@ -15,28 +18,35 @@ func newStatusCommand() *cobra.Command {
 			if err != nil {
 				return err
 			}
-			fmt.Printf("project: %s\n", status.Project)
-			fmt.Printf("planning_model: %s\n", status.PlanningModel)
-			fmt.Printf("stories: %d total, %d done, %d in_progress, %d blocked\n",
-				status.TotalStories,
-				status.DoneStories,
-				status.InProgressStories,
-				status.BlockedStories,
-			)
-			if len(status.Epics) == 0 {
-				fmt.Println("epics: none")
-				return nil
-			}
-			fmt.Println("epics:")
-			for _, epic := range status.Epics {
-				fmt.Printf("  - %s [%s] (%d/%d stories done)\n",
-					epic.Title,
-					epic.SpecStatus,
-					epic.DoneStories,
-					epic.TotalStories,
-				)
-			}
+			out := cmd.OutOrStdout()
+			printStatus(out, status)
 			return nil
 		},
+	}
+}
+
+func printStatus(out io.Writer, status *planning.ProjectStatus) {
+	fmt.Fprintf(out, "project: %s\n", status.Project)
+	fmt.Fprintf(out, "planning_model: %s\n", status.PlanningModel)
+	fmt.Fprintf(out, "stories: %d total, %d done, %d in_progress, %d blocked\n",
+		status.TotalStories,
+		status.DoneStories,
+		status.InProgressStories,
+		status.BlockedStories,
+	)
+	if len(status.Epics) == 0 {
+		fmt.Fprintln(out, "epics: none")
+		return
+	}
+	fmt.Fprintln(out, "epics:")
+	for _, epic := range status.Epics {
+		fmt.Fprintf(out, "  - %s [%s] (%d/%d done, %d in progress, %d blocked)\n",
+			epic.Title,
+			epic.SpecStatus,
+			epic.DoneStories,
+			epic.TotalStories,
+			epic.InProgressStories,
+			epic.BlockedStories,
+		)
 	}
 }

--- a/cmd/status_test.go
+++ b/cmd/status_test.go
@@ -54,6 +54,9 @@ func TestStatusCommandPrintsEpicProgressCounts(t *testing.T) {
 	if !strings.Contains(output, "stories: 1 total, 0 done, 0 in_progress, 1 blocked") {
 		t.Fatalf("expected story summary in output:\n%s", output)
 	}
+	if !strings.Contains(output, "ready_work: 0 ready, 1 blocked_by_dependencies") {
+		t.Fatalf("expected ready-work summary in output:\n%s", output)
+	}
 	if !strings.Contains(output, "Billing [implementing] (0/1 done, 0 in progress, 1 blocked)") {
 		t.Fatalf("expected epic progress counts in output:\n%s", output)
 	}
@@ -104,6 +107,9 @@ func TestStatusCommandPrintsRoadmapVersionSummaries(t *testing.T) {
 	output := buf.String()
 	if !strings.Contains(output, "roadmap: .plan/ROADMAP.md") {
 		t.Fatalf("expected roadmap path in output:\n%s", output)
+	}
+	if !strings.Contains(output, "ready_work: 0 ready, 0 blocked_by_dependencies") {
+		t.Fatalf("expected ready-work summary in output:\n%s", output)
 	}
 	if !strings.Contains(output, "v2: Rigor (1 stories, 0 done, 1 in_progress, 0 blocked)") {
 		t.Fatalf("expected version summary in output:\n%s", output)

--- a/cmd/status_test.go
+++ b/cmd/status_test.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 	"testing"
 
+	"plan/internal/notes"
 	"plan/internal/planning"
 	"plan/internal/workspace"
 )
@@ -55,5 +56,59 @@ func TestStatusCommandPrintsEpicProgressCounts(t *testing.T) {
 	}
 	if !strings.Contains(output, "Billing [implementing] (0/1 done, 0 in progress, 1 blocked)") {
 		t.Fatalf("expected epic progress counts in output:\n%s", output)
+	}
+}
+
+func TestStatusCommandPrintsRoadmapVersionSummaries(t *testing.T) {
+	root := t.TempDir()
+	ws := workspace.New(root)
+	if _, err := ws.Init(); err != nil {
+		t.Fatal(err)
+	}
+	manager := planning.New(ws)
+
+	if _, err := manager.CreateEpic("Roadmap Work", ""); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := manager.UpdateSpec("roadmap-work", notes.UpdateInput{
+		Metadata: map[string]any{"status": "approved", "target_version": "v2"},
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := manager.CreateStory(
+		"roadmap-work",
+		"Ship roadmap parser",
+		"Parse version sections from roadmap",
+		[]string{"Version sections are parsed"},
+		[]string{"go test ./internal/planning"},
+		nil,
+	); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := manager.UpdateStory("ship-roadmap-parser", planning.StoryChanges{Status: "in_progress"}); err != nil {
+		t.Fatal(err)
+	}
+
+	prevProjectDir := projectDir
+	projectDir = root
+	defer func() { projectDir = prevProjectDir }()
+
+	var buf bytes.Buffer
+	command := newStatusCommand()
+	command.SetOut(&buf)
+	command.SetErr(&buf)
+	if err := command.Execute(); err != nil {
+		t.Fatal(err)
+	}
+
+	output := buf.String()
+	if !strings.Contains(output, "roadmap: .plan/ROADMAP.md") {
+		t.Fatalf("expected roadmap path in output:\n%s", output)
+	}
+	if !strings.Contains(output, "v2: Rigor (1 stories, 0 done, 1 in_progress, 0 blocked)") {
+		t.Fatalf("expected version summary in output:\n%s", output)
+	}
+	if !strings.Contains(output, "Roadmap Work [implementing] (0/1 done, 1 in progress, 0 blocked)") {
+		t.Fatalf("expected roadmap epic progress in output:\n%s", output)
 	}
 }

--- a/cmd/status_test.go
+++ b/cmd/status_test.go
@@ -118,3 +118,64 @@ func TestStatusCommandPrintsRoadmapVersionSummaries(t *testing.T) {
 		t.Fatalf("expected roadmap epic progress in output:\n%s", output)
 	}
 }
+
+func TestStatusCommandSupportsVersionEpicAndLifecycleFilters(t *testing.T) {
+	root := t.TempDir()
+	ws := workspace.New(root)
+	if _, err := ws.Init(); err != nil {
+		t.Fatal(err)
+	}
+	manager := planning.New(ws)
+
+	for _, title := range []string{"Billing", "Exports"} {
+		if _, err := manager.CreateEpic(title, ""); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if _, err := manager.UpdateSpec("billing", notes.UpdateInput{
+		Metadata: map[string]any{"status": "approved", "target_version": "v2"},
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := manager.UpdateSpec("exports", notes.UpdateInput{
+		Metadata: map[string]any{"status": "approved", "target_version": "v3"},
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := manager.CreateStory("billing", "Implement invoices", "Create invoice generation flow", []string{"Generate invoices"}, []string{"Run billing tests"}, nil); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := manager.CreateStory("exports", "Ship exports", "Create export flow", []string{"Export invoices"}, []string{"Run export tests"}, nil); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := manager.UpdateStory("ship-exports", planning.StoryChanges{Status: "in_progress"}); err != nil {
+		t.Fatal(err)
+	}
+
+	prevProjectDir := projectDir
+	projectDir = root
+	defer func() { projectDir = prevProjectDir }()
+
+	var buf bytes.Buffer
+	command := newStatusCommand()
+	command.SetOut(&buf)
+	command.SetErr(&buf)
+	command.SetArgs([]string{"--version", "v2", "--epic", "billing", "--story-status", "todo"})
+	if err := command.Execute(); err != nil {
+		t.Fatal(err)
+	}
+
+	output := buf.String()
+	if !strings.Contains(output, "filters: version=v2, epic=billing, story_status=todo") {
+		t.Fatalf("expected filter header in output:\n%s", output)
+	}
+	if !strings.Contains(output, "stories: 1 total, 0 done, 0 in_progress, 0 blocked") {
+		t.Fatalf("expected filtered story counts in output:\n%s", output)
+	}
+	if !strings.Contains(output, "v2: Rigor (1 stories, 0 done, 0 in_progress, 0 blocked)") {
+		t.Fatalf("expected filtered version summary in output:\n%s", output)
+	}
+	if strings.Contains(output, "Exports") {
+		t.Fatalf("expected epic filter to remove exports output:\n%s", output)
+	}
+}

--- a/cmd/status_test.go
+++ b/cmd/status_test.go
@@ -1,0 +1,59 @@
+package cmd
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"plan/internal/planning"
+	"plan/internal/workspace"
+)
+
+func TestStatusCommandPrintsEpicProgressCounts(t *testing.T) {
+	root := t.TempDir()
+	ws := workspace.New(root)
+	if _, err := ws.Init(); err != nil {
+		t.Fatal(err)
+	}
+	manager := planning.New(ws)
+
+	if _, err := manager.CreateEpic("Billing", ""); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := manager.SetSpecStatus("billing", "approved"); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := manager.CreateStory(
+		"billing",
+		"Implement invoices",
+		"Create invoice generation flow",
+		[]string{"Generate invoices from line items"},
+		[]string{"Run focused billing tests"},
+		nil,
+	); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := manager.UpdateStory("implement-invoices", planning.StoryChanges{Status: "blocked"}); err != nil {
+		t.Fatal(err)
+	}
+
+	prevProjectDir := projectDir
+	projectDir = root
+	defer func() { projectDir = prevProjectDir }()
+
+	var buf bytes.Buffer
+	command := newStatusCommand()
+	command.SetOut(&buf)
+	command.SetErr(&buf)
+	if err := command.Execute(); err != nil {
+		t.Fatal(err)
+	}
+
+	output := buf.String()
+	if !strings.Contains(output, "stories: 1 total, 0 done, 0 in_progress, 1 blocked") {
+		t.Fatalf("expected story summary in output:\n%s", output)
+	}
+	if !strings.Contains(output, "Billing [implementing] (0/1 done, 0 in progress, 1 blocked)") {
+		t.Fatalf("expected epic progress counts in output:\n%s", output)
+	}
+}

--- a/cmd/story.go
+++ b/cmd/story.go
@@ -27,7 +27,7 @@ func newStoryCommand() *cobra.Command {
 			if err != nil {
 				return err
 			}
-			fmt.Printf("Created story %s\n", note.Path)
+			fmt.Fprintf(cmd.OutOrStdout(), "Created story %s\n", note.Path)
 			return nil
 		},
 	}
@@ -54,7 +54,7 @@ func newStoryCommand() *cobra.Command {
 			if err != nil {
 				return err
 			}
-			fmt.Printf("Updated story %s\n", note.Path)
+			fmt.Fprintf(cmd.OutOrStdout(), "Updated story %s\n", note.Path)
 			return nil
 		},
 	}
@@ -65,6 +65,7 @@ func newStoryCommand() *cobra.Command {
 
 	var epicFilter string
 	var statusFilter string
+	var versionFilter string
 	list := &cobra.Command{
 		Use:   "list",
 		Short: "List stories",
@@ -74,17 +75,26 @@ func newStoryCommand() *cobra.Command {
 				return err
 			}
 			if len(items) == 0 {
-				fmt.Println("No stories found.")
+				fmt.Fprintln(cmd.OutOrStdout(), "No stories found.")
 				return nil
 			}
+			printed := 0
 			for _, item := range items {
-				fmt.Printf("%s [%s] epic=%s spec=%s\n", item.Title, item.Status, item.Epic, item.Spec)
+				if versionFilter != "" && item.TargetVersion != versionFilter {
+					continue
+				}
+				fmt.Fprintf(cmd.OutOrStdout(), "%s [%s] epic=%s spec=%s\n", item.Title, item.Status, item.Epic, item.Spec)
+				printed++
+			}
+			if printed == 0 {
+				fmt.Fprintln(cmd.OutOrStdout(), "No stories found.")
 			}
 			return nil
 		},
 	}
 	list.Flags().StringVar(&epicFilter, "epic", "", "filter by epic slug")
 	list.Flags().StringVar(&statusFilter, "status", "", "filter by story status")
+	list.Flags().StringVar(&versionFilter, "version", "", "filter by target roadmap version")
 
 	show := &cobra.Command{
 		Use:   "show <story-slug>",
@@ -95,7 +105,7 @@ func newStoryCommand() *cobra.Command {
 			if err != nil {
 				return err
 			}
-			fmt.Printf("%s\n\n%s", note.Path, note.Content)
+			fmt.Fprintf(cmd.OutOrStdout(), "%s\n\n%s", note.Path, note.Content)
 			return nil
 		},
 	}

--- a/cmd/story_test.go
+++ b/cmd/story_test.go
@@ -1,0 +1,63 @@
+package cmd
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"plan/internal/notes"
+	"plan/internal/planning"
+	"plan/internal/workspace"
+)
+
+func TestStoryListSupportsVersionFilter(t *testing.T) {
+	root := t.TempDir()
+	ws := workspace.New(root)
+	if _, err := ws.Init(); err != nil {
+		t.Fatal(err)
+	}
+	manager := planning.New(ws)
+
+	for _, title := range []string{"Billing", "Exports"} {
+		if _, err := manager.CreateEpic(title, ""); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if _, err := manager.UpdateSpec("billing", notes.UpdateInput{
+		Metadata: map[string]any{"status": "approved", "target_version": "v2"},
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := manager.UpdateSpec("exports", notes.UpdateInput{
+		Metadata: map[string]any{"status": "approved", "target_version": "v3"},
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := manager.CreateStory("billing", "Implement invoices", "Create invoice generation flow", []string{"Generate invoices"}, []string{"Run billing tests"}, nil); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := manager.CreateStory("exports", "Ship exports", "Create export flow", []string{"Export invoices"}, []string{"Run export tests"}, nil); err != nil {
+		t.Fatal(err)
+	}
+
+	prevProjectDir := projectDir
+	projectDir = root
+	defer func() { projectDir = prevProjectDir }()
+
+	var buf bytes.Buffer
+	command := newStoryCommand()
+	command.SetOut(&buf)
+	command.SetErr(&buf)
+	command.SetArgs([]string{"list", "--version", "v2"})
+	if err := command.Execute(); err != nil {
+		t.Fatal(err)
+	}
+
+	output := buf.String()
+	if !strings.Contains(output, "Implement invoices [todo] epic=billing spec=billing") {
+		t.Fatalf("expected billing story in filtered output:\n%s", output)
+	}
+	if strings.Contains(output, "Ship exports") {
+		t.Fatalf("expected version filter to remove exports story:\n%s", output)
+	}
+}

--- a/internal/notes/notes.go
+++ b/internal/notes/notes.go
@@ -171,7 +171,7 @@ func AppendUnderHeading(content, heading, entry string) string {
 			}
 			title := strings.ToLower(strings.TrimSpace(strings.TrimLeft(trimmed, "#")))
 			if inSection && level <= sectionLevel && !inserted {
-				out = append(out, "", strings.TrimRight(entry, "\n"))
+				out = appendEntryBlock(out, entry)
 				inserted = true
 				inSection = false
 			}
@@ -184,16 +184,23 @@ func AppendUnderHeading(content, heading, entry string) string {
 	}
 
 	if inSection && !inserted {
-		out = append(out, "", strings.TrimRight(entry, "\n"))
+		out = appendEntryBlock(out, entry)
 		inserted = true
 	}
 	if !inserted {
-		if len(out) > 0 {
+		if len(out) > 0 && strings.TrimSpace(out[len(out)-1]) != "" {
 			out = append(out, "")
 		}
 		out = append(out, "## "+heading, "", strings.TrimRight(entry, "\n"))
 	}
 	return strings.Join(out, "\n") + "\n"
+}
+
+func appendEntryBlock(lines []string, entry string) []string {
+	if len(lines) == 0 || strings.TrimSpace(lines[len(lines)-1]) != "" {
+		lines = append(lines, "")
+	}
+	return append(lines, strings.TrimRight(entry, "\n"))
 }
 
 func ExtractSection(content, heading string) string {

--- a/internal/notes/notes.go
+++ b/internal/notes/notes.go
@@ -100,7 +100,8 @@ func Update(path string, input UpdateInput) (*Note, error) {
 }
 
 func parse(raw []byte) (map[string]any, string, error) {
-	content := string(raw)
+	content := strings.ReplaceAll(string(raw), "\r\n", "\n")
+	content = strings.ReplaceAll(content, "\r", "\n")
 	meta := map[string]any{}
 	if !strings.HasPrefix(content, "---\n") {
 		return meta, strings.TrimLeft(content, "\n"), nil

--- a/internal/notes/notes_test.go
+++ b/internal/notes/notes_test.go
@@ -1,6 +1,7 @@
 package notes
 
 import (
+	"os"
 	"strings"
 	"testing"
 )
@@ -15,5 +16,41 @@ func TestAppendUnderHeadingUsesSingleBlankLineForEmptySection(t *testing.T) {
 	}
 	if !strings.Contains(updated, "## Ideas\n\n- First idea") {
 		t.Fatalf("expected inserted entry under ideas heading:\n%s", updated)
+	}
+}
+
+func TestReadParsesCRLFFrontmatter(t *testing.T) {
+	path := t.TempDir() + "/note.md"
+	raw := strings.Join([]string{
+		"---",
+		"title: Windows Note",
+		"type: story",
+		"status: todo",
+		"---",
+		"",
+		"## Outcome",
+		"",
+		"Verify CRLF frontmatter parsing.",
+		"",
+	}, "\r\n")
+	if err := os.WriteFile(path, []byte(raw), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	note, err := Read(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if note.Title != "Windows Note" {
+		t.Fatalf("expected title metadata, got %+v", note)
+	}
+	if note.Type != "story" {
+		t.Fatalf("expected type metadata, got %+v", note)
+	}
+	if note.Metadata["status"] != "todo" {
+		t.Fatalf("expected status metadata, got %+v", note.Metadata)
+	}
+	if !strings.Contains(note.Content, "Verify CRLF frontmatter parsing.") {
+		t.Fatalf("expected preserved note body, got:\n%s", note.Content)
 	}
 }

--- a/internal/notes/notes_test.go
+++ b/internal/notes/notes_test.go
@@ -1,0 +1,19 @@
+package notes
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestAppendUnderHeadingUsesSingleBlankLineForEmptySection(t *testing.T) {
+	content := "# Brainstorm\n\n## Ideas\n\n## Notes\n"
+
+	updated := AppendUnderHeading(content, "Ideas", "- First idea")
+
+	if strings.Contains(updated, "## Ideas\n\n\n- First idea") {
+		t.Fatalf("expected a single blank line before inserted entry:\n%s", updated)
+	}
+	if !strings.Contains(updated, "## Ideas\n\n- First idea") {
+		t.Fatalf("expected inserted entry under ideas heading:\n%s", updated)
+	}
+}

--- a/internal/planning/brain_import.go
+++ b/internal/planning/brain_import.go
@@ -7,6 +7,7 @@ import (
 	"sort"
 
 	"plan/internal/notes"
+	"plan/internal/workspace"
 )
 
 type BrainImportPreview struct {
@@ -22,6 +23,25 @@ type BrainImportCandidate struct {
 	Slug  string
 	Title string
 	Path  string
+}
+
+type BrainImportSelection struct {
+	WorkspacePath string
+	Brainstorms   []string
+	Epics         []string
+	Specs         []string
+	Stories       []string
+}
+
+type BrainImportResult struct {
+	WorkspacePath string
+	Imported      []BrainImportedArtifact
+}
+
+type BrainImportedArtifact struct {
+	Type            string
+	SourcePath      string
+	DestinationPath string
 }
 
 func InspectBrainWorkspace(path string) (*BrainImportPreview, error) {
@@ -103,4 +123,104 @@ func inspectBrainNoteDir(repoRoot, dir, noteType string) ([]BrainImportCandidate
 		return candidates[i].Title < candidates[j].Title
 	})
 	return candidates, nil
+}
+
+func (m *Manager) ImportBrainPlanning(selection BrainImportSelection) (*BrainImportResult, error) {
+	info, err := m.workspace.EnsureInitialized()
+	if err != nil {
+		return nil, err
+	}
+	repoRoot, brainDir, err := resolveBrainWorkspace(selection.WorkspacePath)
+	if err != nil {
+		return nil, err
+	}
+	result := &BrainImportResult{WorkspacePath: filepath.ToSlash(repoRoot)}
+
+	importGroups := []struct {
+		items    []string
+		noteType string
+		dir      string
+	}{
+		{items: selection.Brainstorms, noteType: "brainstorm", dir: filepath.Join(brainDir, "brainstorms")},
+		{items: selection.Epics, noteType: "epic", dir: filepath.Join(brainDir, "planning", "epics")},
+		{items: selection.Specs, noteType: "spec", dir: filepath.Join(brainDir, "planning", "specs")},
+		{items: selection.Stories, noteType: "story", dir: filepath.Join(brainDir, "planning", "stories")},
+	}
+	for _, group := range importGroups {
+		for _, slug := range normalizeStoryRefs(group.items) {
+			note, err := notes.Read(filepath.Join(group.dir, slug+".md"))
+			if err != nil {
+				return nil, err
+			}
+			imported, err := m.importBrainNote(info, repoRoot, note)
+			if err != nil {
+				return nil, err
+			}
+			result.Imported = append(result.Imported, imported)
+		}
+	}
+	return result, nil
+}
+
+func (m *Manager) importBrainNote(info *workspace.Info, repoRoot string, note *notes.Note) (BrainImportedArtifact, error) {
+	slug := slugFromPath(note.Path)
+	path, metadata, err := brainImportDestination(info, note, slug, repoRoot)
+	if err != nil {
+		return BrainImportedArtifact{}, err
+	}
+	created, err := notes.Create(path, note.Title, note.Type, note.Content, metadata)
+	if err != nil {
+		return BrainImportedArtifact{}, err
+	}
+	return BrainImportedArtifact{
+		Type:            note.Type,
+		SourcePath:      rel(repoRoot, note.Path),
+		DestinationPath: rel(info.ProjectDir, created.Path),
+	}, nil
+}
+
+func brainImportDestination(info *workspace.Info, note *notes.Note, slug, repoRoot string) (string, map[string]any, error) {
+	sourcePath := rel(repoRoot, note.Path)
+	metadata := map[string]any{
+		"project":                info.ProjectName,
+		"slug":                   slug,
+		"imported_from":          "brain",
+		"source_brain_path":      sourcePath,
+		"source_brain_workspace": filepath.ToSlash(repoRoot),
+	}
+	switch note.Type {
+	case "brainstorm":
+		status := stringValue(note.Metadata["brainstorm_status"])
+		if status == "" {
+			status = "active"
+		}
+		metadata["status"] = status
+		return filepath.Join(info.BrainstormsDir, slug+".md"), metadata, nil
+	case "epic":
+		specSlug := stringValue(note.Metadata["spec"])
+		if specSlug == "" {
+			specSlug = slug
+		}
+		metadata["spec"] = slugify(specSlug)
+		return filepath.Join(info.EpicsDir, slug+".md"), metadata, nil
+	case "spec":
+		status := stringValue(note.Metadata["status"])
+		if _, ok := validSpecStatuses[status]; !ok {
+			status = "draft"
+		}
+		metadata["status"] = status
+		metadata["epic"] = slugify(stringValue(note.Metadata["epic"]))
+		return filepath.Join(info.SpecsDir, slug+".md"), metadata, nil
+	case "story":
+		status := stringValue(note.Metadata["status"])
+		if _, ok := validStoryStatuses[status]; !ok {
+			status = "todo"
+		}
+		metadata["status"] = status
+		metadata["epic"] = slugify(stringValue(note.Metadata["epic"]))
+		metadata["spec"] = slugify(stringValue(note.Metadata["spec"]))
+		return filepath.Join(info.StoriesDir, slug+".md"), metadata, nil
+	default:
+		return "", nil, fmt.Errorf("unsupported brain note type %q", note.Type)
+	}
 }

--- a/internal/planning/brain_import.go
+++ b/internal/planning/brain_import.go
@@ -168,7 +168,8 @@ func (m *Manager) importBrainNote(info *workspace.Info, repoRoot string, note *n
 	if err != nil {
 		return BrainImportedArtifact{}, err
 	}
-	created, err := notes.Create(path, note.Title, note.Type, note.Content, metadata)
+	body := decorateImportedBrainBody(note.Content, path, note.Path)
+	created, err := notes.Create(path, note.Title, note.Type, body, metadata)
 	if err != nil {
 		return BrainImportedArtifact{}, err
 	}
@@ -185,6 +186,7 @@ func brainImportDestination(info *workspace.Info, note *notes.Note, slug, repoRo
 		"project":                info.ProjectName,
 		"slug":                   slug,
 		"imported_from":          "brain",
+		"review_required":        true,
 		"source_brain_path":      sourcePath,
 		"source_brain_workspace": filepath.ToSlash(repoRoot),
 	}
@@ -223,4 +225,14 @@ func brainImportDestination(info *workspace.Info, note *notes.Note, slug, repoRo
 	default:
 		return "", nil, fmt.Errorf("unsupported brain note type %q", note.Type)
 	}
+}
+
+func decorateImportedBrainBody(body, destinationPath, sourcePath string) string {
+	body = notes.AppendUnderHeading(body, "Resources",
+		fmt.Sprintf("- [Imported From Brain](%s)", relativeLinkPath(filepath.Dir(destinationPath), sourcePath)),
+	)
+	body = notes.AppendUnderHeading(body, "Notes",
+		"Imported from a Brain workspace. Review and normalize this artifact before relying on it for deeper execution work.",
+	)
+	return body
 }

--- a/internal/planning/brain_import.go
+++ b/internal/planning/brain_import.go
@@ -1,0 +1,106 @@
+package planning
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+
+	"plan/internal/notes"
+)
+
+type BrainImportPreview struct {
+	WorkspacePath string
+	Brainstorms   []BrainImportCandidate
+	Epics         []BrainImportCandidate
+	Specs         []BrainImportCandidate
+	Stories       []BrainImportCandidate
+}
+
+type BrainImportCandidate struct {
+	Type  string
+	Slug  string
+	Title string
+	Path  string
+}
+
+func InspectBrainWorkspace(path string) (*BrainImportPreview, error) {
+	repoRoot, brainDir, err := resolveBrainWorkspace(path)
+	if err != nil {
+		return nil, err
+	}
+	preview := &BrainImportPreview{WorkspacePath: filepath.ToSlash(repoRoot)}
+
+	if preview.Brainstorms, err = inspectBrainNoteDir(repoRoot, filepath.Join(brainDir, "brainstorms"), "brainstorm"); err != nil {
+		return nil, err
+	}
+	planningDir := filepath.Join(brainDir, "planning")
+	if preview.Epics, err = inspectBrainNoteDir(repoRoot, filepath.Join(planningDir, "epics"), "epic"); err != nil {
+		return nil, err
+	}
+	if preview.Specs, err = inspectBrainNoteDir(repoRoot, filepath.Join(planningDir, "specs"), "spec"); err != nil {
+		return nil, err
+	}
+	if preview.Stories, err = inspectBrainNoteDir(repoRoot, filepath.Join(planningDir, "stories"), "story"); err != nil {
+		return nil, err
+	}
+
+	return preview, nil
+}
+
+func resolveBrainWorkspace(path string) (string, string, error) {
+	if path == "" {
+		path = "."
+	}
+	abs, err := filepath.Abs(path)
+	if err != nil {
+		return "", "", err
+	}
+	brainDir := filepath.Join(abs, ".brain")
+	if stat, err := os.Stat(brainDir); err == nil && stat.IsDir() {
+		return abs, brainDir, nil
+	}
+	if filepath.Base(abs) == ".brain" {
+		if stat, err := os.Stat(abs); err == nil && stat.IsDir() {
+			return filepath.Dir(abs), abs, nil
+		}
+	}
+	return "", "", fmt.Errorf("brain workspace not found at %s", abs)
+}
+
+func inspectBrainNoteDir(repoRoot, dir, noteType string) ([]BrainImportCandidate, error) {
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, err
+	}
+	candidates := make([]BrainImportCandidate, 0, len(entries))
+	for _, entry := range entries {
+		if entry.IsDir() || filepath.Ext(entry.Name()) != ".md" {
+			continue
+		}
+		path := filepath.Join(dir, entry.Name())
+		note, err := notes.Read(path)
+		if err != nil {
+			return nil, err
+		}
+		if note.Type != noteType {
+			continue
+		}
+		candidates = append(candidates, BrainImportCandidate{
+			Type:  noteType,
+			Slug:  slugFromPath(path),
+			Title: note.Title,
+			Path:  rel(repoRoot, path),
+		})
+	}
+	sort.Slice(candidates, func(i, j int) bool {
+		if candidates[i].Type != candidates[j].Type {
+			return candidates[i].Type < candidates[j].Type
+		}
+		return candidates[i].Title < candidates[j].Title
+	})
+	return candidates, nil
+}

--- a/internal/planning/brain_import_test.go
+++ b/internal/planning/brain_import_test.go
@@ -1,8 +1,12 @@
 package planning
 
 import (
+	"path/filepath"
 	"strings"
 	"testing"
+
+	"plan/internal/notes"
+	"plan/internal/workspace"
 )
 
 func TestInspectBrainWorkspaceOnlyReturnsPlanningArtifacts(t *testing.T) {
@@ -42,5 +46,49 @@ func TestInspectBrainWorkspaceSupportsDotBrainPath(t *testing.T) {
 	}
 	if !strings.HasSuffix(preview.WorkspacePath, "examples/brain") {
 		t.Fatalf("expected repo root path in preview: %+v", preview)
+	}
+}
+
+func TestImportBrainPlanningCreatesCanonicalPlanArtifacts(t *testing.T) {
+	root := t.TempDir()
+	ws := workspace.New(root)
+	if _, err := ws.Init(); err != nil {
+		t.Fatal(err)
+	}
+	manager := New(ws)
+
+	result, err := manager.ImportBrainPlanning(BrainImportSelection{
+		WorkspacePath: "../../examples/brain",
+		Brainstorms:   []string{"mempalace-inspired-brain-improvements"},
+		Epics:         []string{"planning-and-brainstorming-ux"},
+		Specs:         []string{"planning-and-brainstorming-ux"},
+		Stories:       []string{"add-session-aware-memory-distillation"},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(result.Imported) != 4 {
+		t.Fatalf("expected four imported planning artifacts: %+v", result)
+	}
+
+	for _, item := range []struct {
+		path     string
+		noteType string
+	}{
+		{path: filepath.Join(root, ".plan", "brainstorms", "mempalace-inspired-brain-improvements.md"), noteType: "brainstorm"},
+		{path: filepath.Join(root, ".plan", "epics", "planning-and-brainstorming-ux.md"), noteType: "epic"},
+		{path: filepath.Join(root, ".plan", "specs", "planning-and-brainstorming-ux.md"), noteType: "spec"},
+		{path: filepath.Join(root, ".plan", "stories", "add-session-aware-memory-distillation.md"), noteType: "story"},
+	} {
+		note, err := notes.Read(item.path)
+		if err != nil {
+			t.Fatalf("expected imported %s note: %v", item.noteType, err)
+		}
+		if note.Type != item.noteType {
+			t.Fatalf("expected imported note type %s, got %s", item.noteType, note.Type)
+		}
+		if note.Metadata["imported_from"] != "brain" {
+			t.Fatalf("expected import provenance metadata: %+v", note.Metadata)
+		}
 	}
 }

--- a/internal/planning/brain_import_test.go
+++ b/internal/planning/brain_import_test.go
@@ -1,0 +1,46 @@
+package planning
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestInspectBrainWorkspaceOnlyReturnsPlanningArtifacts(t *testing.T) {
+	preview, err := InspectBrainWorkspace("../../examples/brain")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(preview.Brainstorms) == 0 || len(preview.Epics) == 0 || len(preview.Specs) == 0 || len(preview.Stories) == 0 {
+		t.Fatalf("expected planning candidates from brain workspace: %+v", preview)
+	}
+	for _, item := range preview.Epics {
+		if !strings.HasPrefix(item.Path, ".brain/planning/epics/") {
+			t.Fatalf("expected epic candidate path under planning epics: %+v", item)
+		}
+	}
+	for _, item := range preview.Specs {
+		if !strings.HasPrefix(item.Path, ".brain/planning/specs/") {
+			t.Fatalf("expected spec candidate path under planning specs: %+v", item)
+		}
+	}
+	for _, item := range preview.Stories {
+		if !strings.HasPrefix(item.Path, ".brain/planning/stories/") {
+			t.Fatalf("expected story candidate path under planning stories: %+v", item)
+		}
+	}
+	for _, item := range preview.Brainstorms {
+		if !strings.HasPrefix(item.Path, ".brain/brainstorms/") {
+			t.Fatalf("expected brainstorm candidate path under brain brainstorms: %+v", item)
+		}
+	}
+}
+
+func TestInspectBrainWorkspaceSupportsDotBrainPath(t *testing.T) {
+	preview, err := InspectBrainWorkspace("../../examples/brain/.brain")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.HasSuffix(preview.WorkspacePath, "examples/brain") {
+		t.Fatalf("expected repo root path in preview: %+v", preview)
+	}
+}

--- a/internal/planning/brain_import_test.go
+++ b/internal/planning/brain_import_test.go
@@ -92,3 +92,33 @@ func TestImportBrainPlanningCreatesCanonicalPlanArtifacts(t *testing.T) {
 		}
 	}
 }
+
+func TestImportBrainPlanningAddsVisibleProvenanceAndReviewGuidance(t *testing.T) {
+	root := t.TempDir()
+	ws := workspace.New(root)
+	if _, err := ws.Init(); err != nil {
+		t.Fatal(err)
+	}
+	manager := New(ws)
+
+	if _, err := manager.ImportBrainPlanning(BrainImportSelection{
+		WorkspacePath: "../../examples/brain",
+		Stories:       []string{"add-session-aware-memory-distillation"},
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	note, err := notes.Read(filepath.Join(root, ".plan", "stories", "add-session-aware-memory-distillation.md"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if note.Metadata["review_required"] != true {
+		t.Fatalf("expected review_required metadata on imported note: %+v", note.Metadata)
+	}
+	if !strings.Contains(note.Content, "Imported From Brain") {
+		t.Fatalf("expected visible provenance link in imported note:\n%s", note.Content)
+	}
+	if !strings.Contains(note.Content, "Review and normalize this artifact before relying on it for deeper execution work.") {
+		t.Fatalf("expected review guidance in imported note:\n%s", note.Content)
+	}
+}

--- a/internal/planning/brain_import_test.go
+++ b/internal/planning/brain_import_test.go
@@ -10,7 +10,7 @@ import (
 )
 
 func TestInspectBrainWorkspaceOnlyReturnsPlanningArtifacts(t *testing.T) {
-	preview, err := InspectBrainWorkspace("../../examples/brain")
+	preview, err := InspectBrainWorkspace(brainFixturePath(t))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -40,11 +40,11 @@ func TestInspectBrainWorkspaceOnlyReturnsPlanningArtifacts(t *testing.T) {
 }
 
 func TestInspectBrainWorkspaceSupportsDotBrainPath(t *testing.T) {
-	preview, err := InspectBrainWorkspace("../../examples/brain/.brain")
+	preview, err := InspectBrainWorkspace(filepath.Join(brainFixturePath(t), ".brain"))
 	if err != nil {
 		t.Fatal(err)
 	}
-	if !strings.HasSuffix(preview.WorkspacePath, "examples/brain") {
+	if !strings.HasSuffix(filepath.ToSlash(preview.WorkspacePath), "testdata/brain-workspace") {
 		t.Fatalf("expected repo root path in preview: %+v", preview)
 	}
 }
@@ -58,7 +58,7 @@ func TestImportBrainPlanningCreatesCanonicalPlanArtifacts(t *testing.T) {
 	manager := New(ws)
 
 	result, err := manager.ImportBrainPlanning(BrainImportSelection{
-		WorkspacePath: "../../examples/brain",
+		WorkspacePath: brainFixturePath(t),
 		Brainstorms:   []string{"mempalace-inspired-brain-improvements"},
 		Epics:         []string{"planning-and-brainstorming-ux"},
 		Specs:         []string{"planning-and-brainstorming-ux"},
@@ -102,7 +102,7 @@ func TestImportBrainPlanningAddsVisibleProvenanceAndReviewGuidance(t *testing.T)
 	manager := New(ws)
 
 	if _, err := manager.ImportBrainPlanning(BrainImportSelection{
-		WorkspacePath: "../../examples/brain",
+		WorkspacePath: brainFixturePath(t),
 		Stories:       []string{"add-session-aware-memory-distillation"},
 	}); err != nil {
 		t.Fatal(err)
@@ -121,4 +121,14 @@ func TestImportBrainPlanningAddsVisibleProvenanceAndReviewGuidance(t *testing.T)
 	if !strings.Contains(note.Content, "Review and normalize this artifact before relying on it for deeper execution work.") {
 		t.Fatalf("expected review guidance in imported note:\n%s", note.Content)
 	}
+}
+
+func brainFixturePath(t *testing.T) string {
+	t.Helper()
+
+	path, err := filepath.Abs(filepath.Join("..", "..", "testdata", "brain-workspace"))
+	if err != nil {
+		t.Fatalf("resolve brain fixture path: %v", err)
+	}
+	return path
 }

--- a/internal/planning/check.go
+++ b/internal/planning/check.go
@@ -1,0 +1,174 @@
+package planning
+
+import (
+	"fmt"
+	"path/filepath"
+	"strings"
+
+	"plan/internal/notes"
+	"plan/internal/workspace"
+)
+
+type CheckInput struct {
+	EpicSlug  string
+	SpecSlug  string
+	StorySlug string
+}
+
+type CheckReport struct {
+	Project  string
+	Findings []CheckFinding
+}
+
+type CheckFinding struct {
+	Severity      string
+	Rule          string
+	ArtifactType  string
+	ArtifactPath  string
+	ArtifactTitle string
+	Section       string
+	Message       string
+	Suggestion    string
+}
+
+func (r *CheckReport) HasErrors() bool {
+	for _, finding := range r.Findings {
+		if finding.Severity == "error" {
+			return true
+		}
+	}
+	return false
+}
+
+func (m *Manager) Check(input CheckInput) (*CheckReport, error) {
+	info, err := m.workspace.EnsureInitialized()
+	if err != nil {
+		return nil, err
+	}
+	report := &CheckReport{Project: info.ProjectName}
+
+	specs, err := m.specNotesForCheck(info, input)
+	if err != nil {
+		return nil, err
+	}
+	for _, spec := range specs {
+		report.Findings = append(report.Findings, checkSpecNote(rel(info.ProjectDir, spec.Path), spec)...)
+	}
+
+	return report, nil
+}
+
+func (m *Manager) specNotesForCheck(info *workspace.Info, input CheckInput) ([]*notes.Note, error) {
+	switch {
+	case strings.TrimSpace(input.SpecSlug) != "":
+		spec, err := notes.Read(filepath.Join(info.SpecsDir, slugify(input.SpecSlug)+".md"))
+		if err != nil {
+			return nil, err
+		}
+		return []*notes.Note{spec}, nil
+	case strings.TrimSpace(input.EpicSlug) != "":
+		spec, err := notes.Read(filepath.Join(info.SpecsDir, m.specSlugForEpic(input.EpicSlug)+".md"))
+		if err != nil {
+			return nil, err
+		}
+		return []*notes.Note{spec}, nil
+	default:
+		return readNotesInDir(info.SpecsDir)
+	}
+}
+
+type specSectionRule struct {
+	Heading    string
+	Key        string
+	Suggestion string
+}
+
+var requiredSpecSectionRules = []specSectionRule{
+	{
+		Heading:    "Problem",
+		Key:        "problem",
+		Suggestion: "Add a concrete problem statement under ## Problem that explains what is broken or missing today.",
+	},
+	{
+		Heading:    "Goals",
+		Key:        "goals",
+		Suggestion: "Expand ## Goals with the specific outcomes this spec must deliver.",
+	},
+	{
+		Heading:    "Non-Goals",
+		Key:        "non_goals",
+		Suggestion: "Use ## Non-Goals to define what this work will explicitly not do.",
+	},
+	{
+		Heading:    "Constraints",
+		Key:        "constraints",
+		Suggestion: "List the design or implementation limits under ## Constraints so tradeoffs stay clear.",
+	},
+	{
+		Heading:    "Verification",
+		Key:        "verification",
+		Suggestion: "Describe how this spec will be validated under ## Verification with explicit checks or test flows.",
+	},
+}
+
+func checkSpecNote(path string, spec *notes.Note) []CheckFinding {
+	var findings []CheckFinding
+	for _, rule := range requiredSpecSectionRules {
+		section := notes.ExtractSection(spec.Content, rule.Heading)
+		switch {
+		case strings.TrimSpace(section) == "":
+			findings = append(findings, CheckFinding{
+				Severity:      "error",
+				Rule:          fmt.Sprintf("spec.missing_%s", rule.Key),
+				ArtifactType:  "spec",
+				ArtifactPath:  path,
+				ArtifactTitle: spec.Title,
+				Section:       rule.Heading,
+				Message:       fmt.Sprintf("Missing required ## %s section content.", rule.Heading),
+				Suggestion:    rule.Suggestion,
+			})
+		case sectionLooksThin(section):
+			findings = append(findings, CheckFinding{
+				Severity:      "warn",
+				Rule:          fmt.Sprintf("spec.thin_%s", rule.Key),
+				ArtifactType:  "spec",
+				ArtifactPath:  path,
+				ArtifactTitle: spec.Title,
+				Section:       rule.Heading,
+				Message:       fmt.Sprintf("## %s is present but too thin to guide execution.", rule.Heading),
+				Suggestion:    rule.Suggestion,
+			})
+		}
+	}
+	return findings
+}
+
+func sectionLooksThin(content string) bool {
+	lines := strings.Split(strings.TrimSpace(content), "\n")
+	meaningfulLines := 0
+	totalWords := 0
+	for _, line := range lines {
+		trimmed := normalizeSectionLine(line)
+		if trimmed == "" {
+			continue
+		}
+		meaningfulLines++
+		totalWords += len(strings.Fields(trimmed))
+	}
+	if meaningfulLines == 0 {
+		return true
+	}
+	if meaningfulLines >= 2 && totalWords >= 6 {
+		return false
+	}
+	return totalWords < 6
+}
+
+func normalizeSectionLine(line string) string {
+	line = strings.TrimSpace(line)
+	line = strings.TrimPrefix(line, "- [ ] ")
+	line = strings.TrimPrefix(line, "- [x] ")
+	line = strings.TrimPrefix(line, "- ")
+	line = strings.TrimPrefix(line, "* ")
+	return strings.TrimSpace(line)
+}

--- a/internal/planning/check.go
+++ b/internal/planning/check.go
@@ -32,12 +32,27 @@ type CheckFinding struct {
 }
 
 func (r *CheckReport) HasErrors() bool {
+	return r.ErrorCount() > 0
+}
+
+func (r *CheckReport) ErrorCount() int {
+	count := 0
 	for _, finding := range r.Findings {
 		if finding.Severity == "error" {
-			return true
+			count++
 		}
 	}
-	return false
+	return count
+}
+
+func (r *CheckReport) WarningCount() int {
+	count := 0
+	for _, finding := range r.Findings {
+		if finding.Severity == "warn" {
+			count++
+		}
+	}
+	return count
 }
 
 func (m *Manager) Check(input CheckInput) (*CheckReport, error) {

--- a/internal/planning/check.go
+++ b/internal/planning/check.go
@@ -54,12 +54,21 @@ func (m *Manager) Check(input CheckInput) (*CheckReport, error) {
 	for _, spec := range specs {
 		report.Findings = append(report.Findings, checkSpecNote(rel(info.ProjectDir, spec.Path), spec)...)
 	}
+	stories, err := m.storyNotesForCheck(info, input)
+	if err != nil {
+		return nil, err
+	}
+	for _, story := range stories {
+		report.Findings = append(report.Findings, checkStoryNote(rel(info.ProjectDir, story.Path), story)...)
+	}
 
 	return report, nil
 }
 
 func (m *Manager) specNotesForCheck(info *workspace.Info, input CheckInput) ([]*notes.Note, error) {
 	switch {
+	case strings.TrimSpace(input.StorySlug) != "":
+		return nil, nil
 	case strings.TrimSpace(input.SpecSlug) != "":
 		spec, err := notes.Read(filepath.Join(info.SpecsDir, slugify(input.SpecSlug)+".md"))
 		if err != nil {
@@ -75,6 +84,44 @@ func (m *Manager) specNotesForCheck(info *workspace.Info, input CheckInput) ([]*
 	default:
 		return readNotesInDir(info.SpecsDir)
 	}
+}
+
+func (m *Manager) storyNotesForCheck(info *workspace.Info, input CheckInput) ([]*notes.Note, error) {
+	switch {
+	case strings.TrimSpace(input.StorySlug) != "":
+		story, err := notes.Read(filepath.Join(info.StoriesDir, slugify(input.StorySlug)+".md"))
+		if err != nil {
+			return nil, err
+		}
+		return []*notes.Note{story}, nil
+	case strings.TrimSpace(input.SpecSlug) != "":
+		return nil, nil
+	case strings.TrimSpace(input.EpicSlug) != "":
+		return m.readStoriesByFilter(info, func(story StoryInfo) bool {
+			return story.Epic == slugify(input.EpicSlug)
+		})
+	default:
+		return readNotesInDir(info.StoriesDir)
+	}
+}
+
+func (m *Manager) readStoriesByFilter(info *workspace.Info, keep func(StoryInfo) bool) ([]*notes.Note, error) {
+	stories, err := m.ListStories("", "")
+	if err != nil {
+		return nil, err
+	}
+	var out []*notes.Note
+	for _, story := range stories {
+		if !keep(story) {
+			continue
+		}
+		note, err := notes.Read(filepath.Join(info.ProjectDir, filepath.FromSlash(story.Path)))
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, note)
+	}
+	return out, nil
 }
 
 type specSectionRule struct {
@@ -139,6 +186,74 @@ func checkSpecNote(path string, spec *notes.Note) []CheckFinding {
 				Suggestion:    rule.Suggestion,
 			})
 		}
+	}
+	return findings
+}
+
+var requiredStorySectionRules = []specSectionRule{
+	{
+		Heading:    "Description",
+		Key:        "description",
+		Suggestion: "Describe the concrete implementation slice under ## Description so execution starts from a clear brief.",
+	},
+	{
+		Heading:    "Acceptance Criteria",
+		Key:        "acceptance_criteria",
+		Suggestion: "List the expected outcomes under ## Acceptance Criteria so the story has a clear finish line.",
+	},
+	{
+		Heading:    "Verification",
+		Key:        "verification",
+		Suggestion: "Add explicit checks under ## Verification so the story can be validated after implementation.",
+	},
+}
+
+func checkStoryNote(path string, story *notes.Note) []CheckFinding {
+	status := stringValue(story.Metadata["status"])
+	executionReady := storyBodyHasExecutionExpectations(story.Content)
+	var findings []CheckFinding
+	for _, rule := range requiredStorySectionRules {
+		section := notes.ExtractSection(story.Content, rule.Heading)
+		switch {
+		case strings.TrimSpace(section) == "":
+			message := fmt.Sprintf("Missing required ## %s section content.", rule.Heading)
+			if rule.Heading != "Description" && requiresExecutionExpectations(status) {
+				message = fmt.Sprintf("Story is %q but missing ## %s content required by the execution lifecycle.", status, rule.Heading)
+			}
+			findings = append(findings, CheckFinding{
+				Severity:      "error",
+				Rule:          fmt.Sprintf("story.missing_%s", rule.Key),
+				ArtifactType:  "story",
+				ArtifactPath:  path,
+				ArtifactTitle: story.Title,
+				Section:       rule.Heading,
+				Message:       message,
+				Suggestion:    rule.Suggestion,
+			})
+		case rule.Heading == "Description" && sectionLooksThin(section):
+			findings = append(findings, CheckFinding{
+				Severity:      "warn",
+				Rule:          "story.thin_description",
+				ArtifactType:  "story",
+				ArtifactPath:  path,
+				ArtifactTitle: story.Title,
+				Section:       rule.Heading,
+				Message:       "## Description is present but too thin to guide execution.",
+				Suggestion:    rule.Suggestion,
+			})
+		}
+	}
+	if requiresExecutionExpectations(status) && !executionReady {
+		findings = append(findings, CheckFinding{
+			Severity:      "error",
+			Rule:          "story.execution_expectations",
+			ArtifactType:  "story",
+			ArtifactPath:  path,
+			ArtifactTitle: story.Title,
+			Section:       "Acceptance Criteria / Verification",
+			Message:       fmt.Sprintf("Story is %q but does not satisfy the acceptance-and-verification requirements enforced by the story lifecycle.", status),
+			Suggestion:    "Restore both ## Acceptance Criteria and ## Verification before keeping the story in progress or done.",
+		})
 	}
 	return findings
 }

--- a/internal/planning/check_test.go
+++ b/internal/planning/check_test.go
@@ -1,6 +1,7 @@
 package planning
 
 import (
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -114,6 +115,120 @@ func TestCheckSpecFlagsThinRequiredSections(t *testing.T) {
 	assertHasFinding(t, report.Findings, "spec.thin_non_goals", "Non-Goals")
 	assertHasFinding(t, report.Findings, "spec.thin_constraints", "Constraints")
 	assertHasFinding(t, report.Findings, "spec.thin_verification", "Verification")
+}
+
+func TestCheckStoryFindsMissingExecutionSections(t *testing.T) {
+	root := t.TempDir()
+	ws := workspace.New(root)
+	if _, err := ws.Init(); err != nil {
+		t.Fatal(err)
+	}
+	manager := New(ws)
+
+	if _, err := manager.CreateEpic("Billing", ""); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := manager.SetSpecStatus("billing", "approved"); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := manager.CreateStory(
+		"billing",
+		"Implement invoices",
+		"Create invoice generation flow",
+		[]string{"Generate invoices from line items"},
+		[]string{"Run focused billing tests"},
+		nil,
+	); err != nil {
+		t.Fatal(err)
+	}
+	body := strings.Join([]string{
+		"# Implement invoices",
+		"",
+		"Created: now",
+		"",
+		"## Description",
+		"",
+		"## Acceptance Criteria",
+		"",
+		"## Verification",
+		"",
+	}, "\n")
+	storyPath := filepath.Join(root, ".plan", "stories", "implement-invoices.md")
+	if _, err := notes.Update(storyPath, notes.UpdateInput{Body: &body}); err != nil {
+		t.Fatal(err)
+	}
+
+	report, err := manager.Check(CheckInput{StorySlug: "implement-invoices"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !report.HasErrors() {
+		t.Fatalf("expected missing story sections to produce blocking findings: %+v", report.Findings)
+	}
+	for _, finding := range report.Findings {
+		if finding.ArtifactType != "story" {
+			t.Fatalf("expected story scope to only report story findings: %+v", report.Findings)
+		}
+	}
+	assertHasFinding(t, report.Findings, "story.missing_description", "Description")
+	assertHasFinding(t, report.Findings, "story.missing_acceptance_criteria", "Acceptance Criteria")
+	assertHasFinding(t, report.Findings, "story.missing_verification", "Verification")
+}
+
+func TestCheckStoryMatchesLifecycleExpectationsForStartedWork(t *testing.T) {
+	root := t.TempDir()
+	ws := workspace.New(root)
+	if _, err := ws.Init(); err != nil {
+		t.Fatal(err)
+	}
+	manager := New(ws)
+
+	if _, err := manager.CreateEpic("Billing", ""); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := manager.SetSpecStatus("billing", "approved"); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := manager.CreateStory(
+		"billing",
+		"Implement invoices",
+		"Create invoice generation flow",
+		[]string{"Generate invoices from line items"},
+		[]string{"Run focused billing tests"},
+		nil,
+	); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := manager.UpdateStory("implement-invoices", StoryChanges{Status: "in_progress"}); err != nil {
+		t.Fatal(err)
+	}
+	body := strings.Join([]string{
+		"# Implement invoices",
+		"",
+		"Created: now",
+		"",
+		"## Description",
+		"",
+		"Ship invoices.",
+		"",
+		"## Acceptance Criteria",
+		"",
+		"- [ ] Generate invoices from line items",
+		"",
+		"## Verification",
+		"",
+	}, "\n")
+	storyPath := filepath.Join(root, ".plan", "stories", "implement-invoices.md")
+	if _, err := notes.Update(storyPath, notes.UpdateInput{Body: &body}); err != nil {
+		t.Fatal(err)
+	}
+
+	report, err := manager.Check(CheckInput{StorySlug: "implement-invoices"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	assertHasFinding(t, report.Findings, "story.missing_verification", "Verification")
+	assertHasFinding(t, report.Findings, "story.execution_expectations", "Acceptance Criteria / Verification")
 }
 
 func assertHasFinding(t *testing.T, findings []CheckFinding, rule, section string) {

--- a/internal/planning/check_test.go
+++ b/internal/planning/check_test.go
@@ -1,0 +1,127 @@
+package planning
+
+import (
+	"strings"
+	"testing"
+
+	"plan/internal/notes"
+	"plan/internal/workspace"
+)
+
+func TestCheckSpecFindsMissingRequiredSections(t *testing.T) {
+	root := t.TempDir()
+	ws := workspace.New(root)
+	if _, err := ws.Init(); err != nil {
+		t.Fatal(err)
+	}
+	manager := New(ws)
+
+	if _, err := manager.CreateEpic("Billing", ""); err != nil {
+		t.Fatal(err)
+	}
+	body := strings.Join([]string{
+		"# Billing Spec",
+		"",
+		"Created: now",
+		"",
+		"## Why",
+		"",
+		"Keep billing reliable.",
+		"",
+		"## Problem",
+		"",
+		"## Goals",
+		"",
+		"## Non-Goals",
+		"",
+		"## Constraints",
+		"",
+		"## Verification",
+		"",
+	}, "\n")
+	if _, err := manager.UpdateSpec("billing", notes.UpdateInput{Body: &body}); err != nil {
+		t.Fatal(err)
+	}
+
+	report, err := manager.Check(CheckInput{SpecSlug: "billing"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !report.HasErrors() {
+		t.Fatalf("expected missing sections to produce blocking findings: %+v", report.Findings)
+	}
+	assertHasFinding(t, report.Findings, "spec.missing_problem", "Problem")
+	assertHasFinding(t, report.Findings, "spec.missing_goals", "Goals")
+	assertHasFinding(t, report.Findings, "spec.missing_non_goals", "Non-Goals")
+	assertHasFinding(t, report.Findings, "spec.missing_constraints", "Constraints")
+	assertHasFinding(t, report.Findings, "spec.missing_verification", "Verification")
+}
+
+func TestCheckSpecFlagsThinRequiredSections(t *testing.T) {
+	root := t.TempDir()
+	ws := workspace.New(root)
+	if _, err := ws.Init(); err != nil {
+		t.Fatal(err)
+	}
+	manager := New(ws)
+
+	if _, err := manager.CreateEpic("Billing", ""); err != nil {
+		t.Fatal(err)
+	}
+	body := strings.Join([]string{
+		"# Billing Spec",
+		"",
+		"Created: now",
+		"",
+		"## Why",
+		"",
+		"Keep billing reliable.",
+		"",
+		"## Problem",
+		"",
+		"Confusing invoices.",
+		"",
+		"## Goals",
+		"",
+		"- clarity",
+		"",
+		"## Non-Goals",
+		"",
+		"Not taxes.",
+		"",
+		"## Constraints",
+		"",
+		"Local only.",
+		"",
+		"## Verification",
+		"",
+		"Run tests.",
+		"",
+	}, "\n")
+	if _, err := manager.UpdateSpec("billing", notes.UpdateInput{Body: &body}); err != nil {
+		t.Fatal(err)
+	}
+
+	report, err := manager.Check(CheckInput{SpecSlug: "billing"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if report.HasErrors() {
+		t.Fatalf("expected thin sections to warn without blocking: %+v", report.Findings)
+	}
+	assertHasFinding(t, report.Findings, "spec.thin_problem", "Problem")
+	assertHasFinding(t, report.Findings, "spec.thin_goals", "Goals")
+	assertHasFinding(t, report.Findings, "spec.thin_non_goals", "Non-Goals")
+	assertHasFinding(t, report.Findings, "spec.thin_constraints", "Constraints")
+	assertHasFinding(t, report.Findings, "spec.thin_verification", "Verification")
+}
+
+func assertHasFinding(t *testing.T, findings []CheckFinding, rule, section string) {
+	t.Helper()
+	for _, finding := range findings {
+		if finding.Rule == rule && finding.Section == section && finding.Suggestion != "" {
+			return
+		}
+	}
+	t.Fatalf("expected finding %s for %s: %+v", rule, section, findings)
+}

--- a/internal/planning/manager.go
+++ b/internal/planning/manager.go
@@ -57,12 +57,13 @@ type EpicInfo struct {
 }
 
 type StoryInfo struct {
-	Path     string
-	Title    string
-	Status   string
-	Epic     string
-	Spec     string
-	Blockers []string
+	Path          string
+	Title         string
+	Status        string
+	Epic          string
+	Spec          string
+	TargetVersion string
+	Blockers      []string
 }
 
 type VersionStatus struct {
@@ -515,16 +516,22 @@ func (m *Manager) ListStories(filterEpic, filterStatus string) ([]StoryInfo, err
 	if err != nil {
 		return nil, err
 	}
+	specVersions, err := loadSpecTargetVersions(info)
+	if err != nil {
+		return nil, err
+	}
 	filterEpic = slugify(filterEpic)
 	out := make([]StoryInfo, 0, len(items))
 	for _, story := range items {
+		specSlug := stringValue(story.Metadata["spec"])
 		item := StoryInfo{
-			Path:     rel(info.ProjectDir, story.Path),
-			Title:    story.Title,
-			Status:   stringValue(story.Metadata["status"]),
-			Epic:     stringValue(story.Metadata["epic"]),
-			Spec:     stringValue(story.Metadata["spec"]),
-			Blockers: stringSliceValue(story.Metadata["blockers"]),
+			Path:          rel(info.ProjectDir, story.Path),
+			Title:         story.Title,
+			Status:        stringValue(story.Metadata["status"]),
+			Epic:          stringValue(story.Metadata["epic"]),
+			Spec:          specSlug,
+			TargetVersion: specVersions[specSlug],
+			Blockers:      stringSliceValue(story.Metadata["blockers"]),
 		}
 		if filterEpic != "" && item.Epic != filterEpic {
 			continue
@@ -969,6 +976,18 @@ func stringSliceValue(v any) []string {
 	default:
 		return nil
 	}
+}
+
+func loadSpecTargetVersions(info *workspace.Info) (map[string]string, error) {
+	specs, err := readNotesInDir(info.SpecsDir)
+	if err != nil {
+		return nil, err
+	}
+	out := make(map[string]string, len(specs))
+	for _, spec := range specs {
+		out[slugFromPath(spec.Path)] = stringValue(spec.Metadata["target_version"])
+	}
+	return out, nil
 }
 
 func deriveSpecStatus(current string, stories []StoryInfo) string {

--- a/internal/planning/manager.go
+++ b/internal/planning/manager.go
@@ -48,6 +48,7 @@ type EpicInfo struct {
 	Title             string
 	Spec              string
 	SpecStatus        string
+	TargetVersion     string
 	SourceBrainstorm  string
 	TotalStories      int
 	DoneStories       int
@@ -63,9 +64,24 @@ type StoryInfo struct {
 	Spec   string
 }
 
+type VersionStatus struct {
+	Key               string
+	Title             string
+	Goal              string
+	Epics             []EpicInfo
+	TotalStories      int
+	DoneStories       int
+	InProgressStories int
+	BlockedStories    int
+}
+
 type ProjectStatus struct {
 	Project           string
 	PlanningModel     string
+	RoadmapPath       string
+	Versions          []VersionStatus
+	UnassignedEpics   []EpicInfo
+	ParkingLotCount   int
 	Epics             []EpicInfo
 	TotalStories      int
 	DoneStories       int
@@ -283,16 +299,19 @@ func (m *Manager) ListEpics() ([]EpicInfo, error) {
 			specSlug = epicSlug
 		}
 		specStatus := "draft"
+		targetVersion := ""
 		if spec, err := notes.Read(filepath.Join(info.SpecsDir, specSlug+".md")); err == nil {
 			if status := stringValue(spec.Metadata["status"]); status != "" {
 				specStatus = status
 			}
+			targetVersion = stringValue(spec.Metadata["target_version"])
 		}
 		item := EpicInfo{
 			Path:             rel(info.ProjectDir, epic.Path),
 			Title:            epic.Title,
 			Spec:             specSlug,
 			SpecStatus:       specStatus,
+			TargetVersion:    targetVersion,
 			SourceBrainstorm: stringValue(epic.Metadata["source_brainstorm"]),
 		}
 		var epicStories []StoryInfo
@@ -539,7 +558,93 @@ func (m *Manager) Status() (*ProjectStatus, error) {
 			status.InProgressStories++
 		}
 	}
+	if roadmap, err := m.ReadRoadmap(); err == nil {
+		status.RoadmapPath = roadmap.Path
+		status.ParkingLotCount = len(roadmap.ParkingLot)
+		status.Versions, status.UnassignedEpics = buildVersionStatuses(epics, roadmap)
+	}
 	return status, nil
+}
+
+func buildVersionStatuses(epics []EpicInfo, roadmap *Roadmap) ([]VersionStatus, []EpicInfo) {
+	versionEpics := make(map[string][]EpicInfo)
+	var unassigned []EpicInfo
+	for _, epic := range epics {
+		key := strings.TrimSpace(epic.TargetVersion)
+		if key == "" {
+			unassigned = append(unassigned, epic)
+			continue
+		}
+		versionEpics[key] = append(versionEpics[key], epic)
+	}
+
+	versions := make([]VersionStatus, 0, len(roadmap.Versions))
+	for _, version := range roadmap.Versions {
+		status := VersionStatus{
+			Key:   strings.TrimSpace(version.Key),
+			Title: version.Title,
+			Goal:  version.Goal,
+			Epics: orderEpicsForVersion(versionEpics[strings.TrimSpace(version.Key)], version),
+		}
+		accumulateVersionCounts(&status)
+		versions = append(versions, status)
+		delete(versionEpics, status.Key)
+	}
+
+	extraKeys := make([]string, 0, len(versionEpics))
+	for key := range versionEpics {
+		extraKeys = append(extraKeys, key)
+	}
+	sort.Strings(extraKeys)
+	for _, key := range extraKeys {
+		status := VersionStatus{
+			Key:   key,
+			Title: key,
+			Epics: append([]EpicInfo(nil), versionEpics[key]...),
+		}
+		accumulateVersionCounts(&status)
+		versions = append(versions, status)
+	}
+
+	return versions, unassigned
+}
+
+func orderEpicsForVersion(epics []EpicInfo, version RoadmapVersion) []EpicInfo {
+	if len(epics) == 0 {
+		return nil
+	}
+	ordered := make([]EpicInfo, 0, len(epics))
+	used := make([]bool, len(epics))
+	for _, roadmapEpic := range version.Epics {
+		for idx, epic := range epics {
+			if used[idx] || epic.Title != roadmapEpic.Title {
+				continue
+			}
+			ordered = append(ordered, epic)
+			used[idx] = true
+			break
+		}
+	}
+	var extras []EpicInfo
+	for idx, epic := range epics {
+		if used[idx] {
+			continue
+		}
+		extras = append(extras, epic)
+	}
+	sort.Slice(extras, func(i, j int) bool {
+		return extras[i].Title < extras[j].Title
+	})
+	return append(ordered, extras...)
+}
+
+func accumulateVersionCounts(version *VersionStatus) {
+	for _, epic := range version.Epics {
+		version.TotalStories += epic.TotalStories
+		version.DoneStories += epic.DoneStories
+		version.InProgressStories += epic.InProgressStories
+		version.BlockedStories += epic.BlockedStories
+	}
 }
 
 func (m *Manager) createSpecForEpic(info *workspace.Info, epic *notes.Note) (*notes.Note, error) {

--- a/internal/planning/manager.go
+++ b/internal/planning/manager.go
@@ -88,6 +88,8 @@ type ProjectStatus struct {
 	DoneStories       int
 	BlockedStories    int
 	InProgressStories int
+	ReadyStories      int
+	DependencyBlocked int
 }
 
 type StoryChanges struct {
@@ -566,6 +568,10 @@ func (m *Manager) Status() (*ProjectStatus, error) {
 		case "in_progress":
 			status.InProgressStories++
 		}
+	}
+	if ready, err := m.ReadyWork(); err == nil {
+		status.ReadyStories = len(ready.Ready)
+		status.DependencyBlocked = len(ready.Blocked)
 	}
 	if roadmap, err := m.ReadRoadmap(); err == nil {
 		status.RoadmapPath = roadmap.Path

--- a/internal/planning/manager.go
+++ b/internal/planning/manager.go
@@ -44,13 +44,15 @@ type brainstormSectionSpec struct {
 }
 
 type EpicInfo struct {
-	Path             string
-	Title            string
-	Spec             string
-	SpecStatus       string
-	SourceBrainstorm string
-	TotalStories     int
-	DoneStories      int
+	Path              string
+	Title             string
+	Spec              string
+	SpecStatus        string
+	SourceBrainstorm  string
+	TotalStories      int
+	DoneStories       int
+	InProgressStories int
+	BlockedStories    int
 }
 
 type StoryInfo struct {
@@ -293,15 +295,23 @@ func (m *Manager) ListEpics() ([]EpicInfo, error) {
 			SpecStatus:       specStatus,
 			SourceBrainstorm: stringValue(epic.Metadata["source_brainstorm"]),
 		}
+		var epicStories []StoryInfo
 		for _, story := range stories {
 			if story.Epic != epicSlug {
 				continue
 			}
+			epicStories = append(epicStories, story)
 			item.TotalStories++
-			if story.Status == "done" {
+			switch story.Status {
+			case "done":
 				item.DoneStories++
+			case "in_progress":
+				item.InProgressStories++
+			case "blocked":
+				item.BlockedStories++
 			}
 		}
+		item.SpecStatus = deriveSpecStatus(item.SpecStatus, epicStories)
 		out = append(out, item)
 	}
 	sort.Slice(out, func(i, j int) bool {
@@ -375,6 +385,12 @@ func (m *Manager) CreateStory(epicSlug, title, description string, criteria, ver
 	if err != nil {
 		return nil, err
 	}
+	if len(trimmedItems(criteria)) == 0 {
+		return nil, fmt.Errorf("at least one acceptance criterion is required")
+	}
+	if len(trimmedItems(verification)) == 0 {
+		return nil, fmt.Errorf("at least one verification step is required")
+	}
 	epic, err := notes.Read(filepath.Join(info.EpicsDir, slugify(epicSlug)+".md"))
 	if err != nil {
 		return nil, err
@@ -411,11 +427,14 @@ func (m *Manager) CreateStory(epicSlug, title, description string, criteria, ver
 	resourceLinks := append([]string{
 		fmt.Sprintf("- [Canonical Spec](%s)", relativeLinkPath(filepath.Dir(story.Path), spec.Path)),
 	}, resources...)
-	updated, err := m.applyStoryUpdates(story.Path, StoryChanges{
+	body = composeStoryBody(story, StoryChanges{
 		AddCriteria:     criteria,
 		AddVerification: verification,
 		AddResources:    resourceLinks,
 	}, description)
+	updated, err := notes.Update(story.Path, notes.UpdateInput{
+		Body: &body,
+	})
 	if err != nil {
 		return nil, err
 	}
@@ -431,19 +450,31 @@ func (m *Manager) UpdateStory(storySlug string, changes StoryChanges) (*notes.No
 		return nil, fmt.Errorf("invalid story status %q", changes.Status)
 	}
 	path := filepath.Join(info.StoriesDir, slugify(storySlug)+".md")
-	note, err := m.applyStoryUpdates(path, changes, "")
+	note, err := notes.Read(path)
 	if err != nil {
 		return nil, err
 	}
+	body := composeStoryBody(note, changes, "")
+	nextStatus := stringValue(note.Metadata["status"])
 	if changes.Status != "" {
-		note, err = notes.Update(path, notes.UpdateInput{
-			Metadata: map[string]any{"status": changes.Status},
-		})
-		if err != nil {
-			return nil, err
-		}
+		nextStatus = changes.Status
 	}
-	return m.relNote(note, info.ProjectDir), nil
+	if requiresExecutionExpectations(nextStatus) && !storyBodyHasExecutionExpectations(body) {
+		return nil, fmt.Errorf("story %s needs acceptance criteria and verification steps before it can be marked %q", rel(info.ProjectDir, path), nextStatus)
+	}
+
+	input := notes.UpdateInput{Body: &body}
+	if changes.Status != "" {
+		input.Metadata = map[string]any{"status": changes.Status}
+	}
+	updated, err := notes.Update(path, input)
+	if err != nil {
+		return nil, err
+	}
+	if err := m.syncSpecStatusForStory(info, updated); err != nil {
+		return nil, err
+	}
+	return m.relNote(updated, info.ProjectDir), nil
 }
 
 func (m *Manager) ListStories(filterEpic, filterStatus string) ([]StoryInfo, error) {
@@ -577,27 +608,30 @@ func (m *Manager) seedSpecFromBrainstorm(info *workspace.Info, spec *notes.Note,
 	return updated, nil
 }
 
-func (m *Manager) applyStoryUpdates(path string, changes StoryChanges, description string) (*notes.Note, error) {
-	note, err := notes.Read(path)
-	if err != nil {
-		return nil, err
-	}
+func composeStoryBody(note *notes.Note, changes StoryChanges, description string) string {
 	body := note.Content
 	if strings.TrimSpace(description) != "" {
 		body = notes.AppendUnderHeading(body, "Description", strings.TrimSpace(description))
 	}
 	for _, item := range changes.AddCriteria {
+		if strings.TrimSpace(item) == "" {
+			continue
+		}
 		body = notes.AppendUnderHeading(body, "Acceptance Criteria", checklist(item))
 	}
 	for _, item := range changes.AddVerification {
+		if strings.TrimSpace(item) == "" {
+			continue
+		}
 		body = notes.AppendUnderHeading(body, "Verification", bullet(item))
 	}
 	for _, item := range changes.AddResources {
+		if strings.TrimSpace(item) == "" {
+			continue
+		}
 		body = notes.AppendUnderHeading(body, "Resources", bullet(item))
 	}
-	return notes.Update(path, notes.UpdateInput{
-		Body: ptr(body),
-	})
+	return body
 }
 
 func (m *Manager) specSlugForEpic(epicSlug string) string {
@@ -755,4 +789,86 @@ func formatBrainstormEntry(section brainstormSectionSpec, body string) string {
 		items = append(items, bullet(line))
 	}
 	return strings.Join(items, "\n")
+}
+
+func requiresExecutionExpectations(status string) bool {
+	switch status {
+	case "in_progress", "done":
+		return true
+	default:
+		return false
+	}
+}
+
+func storyBodyHasExecutionExpectations(body string) bool {
+	return notes.ExtractSection(body, "Acceptance Criteria") != "" && notes.ExtractSection(body, "Verification") != ""
+}
+
+func trimmedItems(items []string) []string {
+	var out []string
+	for _, item := range items {
+		if strings.TrimSpace(item) == "" {
+			continue
+		}
+		out = append(out, item)
+	}
+	return out
+}
+
+func deriveSpecStatus(current string, stories []StoryInfo) string {
+	if len(stories) == 0 {
+		return current
+	}
+
+	nextStatus := "approved"
+	allDone := true
+	anyStarted := false
+	for _, item := range stories {
+		switch item.Status {
+		case "done":
+			anyStarted = true
+		case "in_progress", "blocked":
+			anyStarted = true
+			allDone = false
+		default:
+			allDone = false
+		}
+	}
+	if allDone {
+		return "done"
+	}
+	if anyStarted {
+		return "implementing"
+	}
+	return nextStatus
+}
+
+func (m *Manager) syncSpecStatusForStory(info *workspace.Info, story *notes.Note) error {
+	epicSlug := stringValue(story.Metadata["epic"])
+	specSlug := stringValue(story.Metadata["spec"])
+	if epicSlug == "" || specSlug == "" {
+		return nil
+	}
+
+	stories, err := m.ListStories(epicSlug, "")
+	if err != nil {
+		return err
+	}
+	if len(stories) == 0 {
+		return nil
+	}
+
+	specPath := filepath.Join(info.SpecsDir, specSlug+".md")
+	spec, err := notes.Read(specPath)
+	if err != nil {
+		return err
+	}
+	nextStatus := deriveSpecStatus(stringValue(spec.Metadata["status"]), stories)
+	if stringValue(spec.Metadata["status"]) == nextStatus {
+		return nil
+	}
+	_, err = notes.Update(specPath, notes.UpdateInput{
+		Metadata: map[string]any{"status": nextStatus},
+	})
+	return err
 }

--- a/internal/planning/manager.go
+++ b/internal/planning/manager.go
@@ -57,11 +57,12 @@ type EpicInfo struct {
 }
 
 type StoryInfo struct {
-	Path   string
-	Title  string
-	Status string
-	Epic   string
-	Spec   string
+	Path     string
+	Title    string
+	Status   string
+	Epic     string
+	Spec     string
+	Blockers []string
 }
 
 type VersionStatus struct {
@@ -94,6 +95,7 @@ type StoryChanges struct {
 	AddCriteria     []string
 	AddVerification []string
 	AddResources    []string
+	SetBlockers     []string
 }
 
 type EpicBundle struct {
@@ -483,8 +485,14 @@ func (m *Manager) UpdateStory(storySlug string, changes StoryChanges) (*notes.No
 	}
 
 	input := notes.UpdateInput{Body: &body}
+	if changes.Status != "" || changes.SetBlockers != nil {
+		input.Metadata = map[string]any{}
+	}
 	if changes.Status != "" {
-		input.Metadata = map[string]any{"status": changes.Status}
+		input.Metadata["status"] = changes.Status
+	}
+	if changes.SetBlockers != nil {
+		input.Metadata["blockers"] = normalizeStoryRefs(changes.SetBlockers)
 	}
 	updated, err := notes.Update(path, input)
 	if err != nil {
@@ -509,11 +517,12 @@ func (m *Manager) ListStories(filterEpic, filterStatus string) ([]StoryInfo, err
 	out := make([]StoryInfo, 0, len(items))
 	for _, story := range items {
 		item := StoryInfo{
-			Path:   rel(info.ProjectDir, story.Path),
-			Title:  story.Title,
-			Status: stringValue(story.Metadata["status"]),
-			Epic:   stringValue(story.Metadata["epic"]),
-			Spec:   stringValue(story.Metadata["spec"]),
+			Path:     rel(info.ProjectDir, story.Path),
+			Title:    story.Title,
+			Status:   stringValue(story.Metadata["status"]),
+			Epic:     stringValue(story.Metadata["epic"]),
+			Spec:     stringValue(story.Metadata["spec"]),
+			Blockers: stringSliceValue(story.Metadata["blockers"]),
 		}
 		if filterEpic != "" && item.Epic != filterEpic {
 			continue
@@ -918,6 +927,42 @@ func trimmedItems(items []string) []string {
 		out = append(out, item)
 	}
 	return out
+}
+
+func normalizeStoryRefs(items []string) []string {
+	var out []string
+	seen := map[string]struct{}{}
+	for _, item := range items {
+		slug := slugify(item)
+		if slug == "" {
+			continue
+		}
+		if _, ok := seen[slug]; ok {
+			continue
+		}
+		seen[slug] = struct{}{}
+		out = append(out, slug)
+	}
+	return out
+}
+
+func stringSliceValue(v any) []string {
+	switch value := v.(type) {
+	case []string:
+		return append([]string(nil), value...)
+	case []any:
+		var out []string
+		for _, item := range value {
+			s, ok := item.(string)
+			if !ok || strings.TrimSpace(s) == "" {
+				continue
+			}
+			out = append(out, s)
+		}
+		return out
+	default:
+		return nil
+	}
 }
 
 func deriveSpecStatus(current string, stories []StoryInfo) string {

--- a/internal/planning/manager.go
+++ b/internal/planning/manager.go
@@ -228,6 +228,15 @@ func (m *Manager) PromoteBrainstorm(brainstormSlug string) (*EpicBundle, error) 
 	if err != nil {
 		return nil, err
 	}
+	epicAbs := filepath.Join(info.ProjectDir, filepath.FromSlash(bundle.Epic.Path))
+	epic, err := notes.Read(epicAbs)
+	if err != nil {
+		return nil, err
+	}
+	seededEpic, err := m.seedEpicFromBrainstorm(info, epic, brainstorm)
+	if err != nil {
+		return nil, err
+	}
 	specAbs := filepath.Join(info.ProjectDir, filepath.FromSlash(bundle.Spec.Path))
 	spec, err := notes.Read(specAbs)
 	if err != nil {
@@ -237,6 +246,16 @@ func (m *Manager) PromoteBrainstorm(brainstormSlug string) (*EpicBundle, error) 
 	if err != nil {
 		return nil, err
 	}
+	if _, err := notes.Update(brainstormPath, notes.UpdateInput{
+		Metadata: map[string]any{
+			"status": "promoted",
+			"epic":   slugFromPath(seededEpic.Path),
+			"spec":   slugFromPath(seeded.Path),
+		},
+	}); err != nil {
+		return nil, err
+	}
+	bundle.Epic = m.relNote(seededEpic, info.ProjectDir)
 	bundle.Spec = m.relNote(seeded, info.ProjectDir)
 	return bundle, nil
 }
@@ -501,11 +520,29 @@ func (m *Manager) createSpecForEpic(info *workspace.Info, epic *notes.Note) (*no
 	if err != nil {
 		return nil, err
 	}
-	return notes.Create(filepath.Join(info.SpecsDir, specSlug+".md"), epic.Title+" Spec", "spec", body, map[string]any{
+	metadata := map[string]any{
 		"project": info.ProjectName,
 		"slug":    specSlug,
 		"epic":    slugFromPath(epic.Path),
 		"status":  "draft",
+	}
+	if sourceBrainstorm := stringValue(epic.Metadata["source_brainstorm"]); sourceBrainstorm != "" {
+		metadata["source_brainstorm"] = sourceBrainstorm
+	}
+	return notes.Create(filepath.Join(info.SpecsDir, specSlug+".md"), epic.Title+" Spec", "spec", body, metadata)
+}
+
+func (m *Manager) seedEpicFromBrainstorm(info *workspace.Info, epic *notes.Note, brainstorm *notes.Note) (*notes.Note, error) {
+	body := epic.Content
+	if desiredOutcome := notes.ExtractSection(brainstorm.Content, "Desired Outcome"); desiredOutcome != "" {
+		body = notes.AppendUnderHeading(body, "Outcome", desiredOutcome)
+	}
+	if focus := notes.ExtractSection(brainstorm.Content, "Focus Question"); focus != "" {
+		body = notes.AppendUnderHeading(body, "Why Now", focus)
+	}
+	body = notes.AppendUnderHeading(body, "Resources", fmt.Sprintf("- [Source Brainstorm](%s)", relativeLinkPath(filepath.Dir(epic.Path), brainstorm.Path)))
+	return notes.Update(epic.Path, notes.UpdateInput{
+		Body: ptr(body),
 	})
 }
 
@@ -514,13 +551,25 @@ func (m *Manager) seedSpecFromBrainstorm(info *workspace.Info, spec *notes.Note,
 	if focus := notes.ExtractSection(brainstorm.Content, "Focus Question"); focus != "" {
 		body = notes.AppendUnderHeading(body, "Problem", focus)
 	}
+	if desiredOutcome := notes.ExtractSection(brainstorm.Content, "Desired Outcome"); desiredOutcome != "" {
+		body = notes.AppendUnderHeading(body, "Goals", desiredOutcome)
+	}
 	if ideas := notes.ExtractSection(brainstorm.Content, "Ideas"); ideas != "" {
 		body = notes.AppendUnderHeading(body, "Goals", ideas)
 	}
-	body = notes.AppendUnderHeading(body, "Story Breakdown", "- [ ] Break approved spec into execution-ready stories")
+	if constraints := notes.ExtractSection(brainstorm.Content, "Constraints"); constraints != "" {
+		body = notes.AppendUnderHeading(body, "Constraints", constraints)
+	}
+	if questions := notes.ExtractSection(brainstorm.Content, "Open Questions"); questions != "" {
+		body = notes.AppendUnderHeading(body, "Risks / Open Questions", questions)
+	}
+	body = notes.AppendUnderHeading(body, "Story Breakdown", "- [ ] Split approved spec into execution-ready stories")
 	body = notes.AppendUnderHeading(body, "Resources", fmt.Sprintf("- [Source Brainstorm](%s)", relativeLinkPath(filepath.Dir(spec.Path), brainstorm.Path)))
 	updated, err := notes.Update(spec.Path, notes.UpdateInput{
 		Body: ptr(body),
+		Metadata: map[string]any{
+			"source_brainstorm": rel(info.ProjectDir, brainstorm.Path),
+		},
 	})
 	if err != nil {
 		return nil, err

--- a/internal/planning/manager.go
+++ b/internal/planning/manager.go
@@ -32,6 +32,17 @@ type BrainstormInfo struct {
 	Title string
 }
 
+type BrainstormCreateInput struct {
+	Topic         string
+	FocusQuestion string
+	Ideas         []string
+}
+
+type brainstormSectionSpec struct {
+	Heading string
+	List    bool
+}
+
 type EpicInfo struct {
 	Path             string
 	Title            string
@@ -81,20 +92,34 @@ func New(workspaceManager *workspace.Manager) *Manager {
 }
 
 func (m *Manager) CreateBrainstorm(topic string) (*notes.Note, error) {
+	return m.CreateBrainstormWithInput(BrainstormCreateInput{Topic: topic})
+}
+
+func (m *Manager) CreateBrainstormWithInput(input BrainstormCreateInput) (*notes.Note, error) {
 	info, err := m.workspace.EnsureInitialized()
 	if err != nil {
 		return nil, err
 	}
+	if strings.TrimSpace(input.Topic) == "" {
+		return nil, fmt.Errorf("brainstorm topic is required")
+	}
 	body, err := templates.Render("brainstorm.md", map[string]any{
-		"Title": topic,
+		"Title": input.Topic,
 		"Now":   time.Now().UTC().Format(time.RFC3339),
 	})
 	if err != nil {
 		return nil, err
 	}
-	slug := slugify(topic)
+	if strings.TrimSpace(input.FocusQuestion) != "" {
+		body = notes.AppendUnderHeading(body, "Focus Question", strings.TrimSpace(input.FocusQuestion))
+	}
+	if block := formatBrainstormEntry(brainstormIdeasSection, strings.Join(input.Ideas, "\n")); block != "" {
+		body = notes.AppendUnderHeading(body, brainstormIdeasSection.Heading, block)
+	}
+
+	slug := slugify(input.Topic)
 	path := filepath.Join(info.BrainstormsDir, slug+".md")
-	note, err := notes.Create(path, topic, "brainstorm", body, map[string]any{
+	note, err := notes.Create(path, input.Topic, "brainstorm", body, map[string]any{
 		"slug":    slug,
 		"status":  "active",
 		"project": info.ProjectName,
@@ -118,6 +143,10 @@ func (m *Manager) ReadBrainstorm(slug string) (*notes.Note, error) {
 }
 
 func (m *Manager) AddIdea(brainstormSlug, body string) (*notes.Note, error) {
+	return m.AddBrainstormEntry(brainstormSlug, brainstormIdeasSection.Heading, body)
+}
+
+func (m *Manager) AddBrainstormEntry(brainstormSlug, section, body string) (*notes.Note, error) {
 	info, err := m.workspace.EnsureInitialized()
 	if err != nil {
 		return nil, err
@@ -130,9 +159,16 @@ func (m *Manager) AddIdea(brainstormSlug, body string) (*notes.Note, error) {
 	if note.Type != "brainstorm" {
 		return nil, fmt.Errorf("%s is not a brainstorm note", note.Path)
 	}
-	entry := fmt.Sprintf("- **%s** %s", time.Now().Format("15:04"), strings.TrimSpace(body))
+	spec, err := resolveBrainstormSection(section)
+	if err != nil {
+		return nil, err
+	}
+	entry := formatBrainstormEntry(spec, body)
+	if entry == "" {
+		return nil, fmt.Errorf("brainstorm entry is required")
+	}
 	updated, err := notes.Update(path, notes.UpdateInput{
-		Body: ptr(notes.AppendUnderHeading(note.Content, "Ideas", entry)),
+		Body: ptr(notes.AppendUnderHeading(note.Content, spec.Heading, entry)),
 	})
 	if err != nil {
 		return nil, err
@@ -624,4 +660,50 @@ func bullet(item string) string {
 		return item
 	}
 	return "- " + item
+}
+
+var brainstormIdeasSection = brainstormSectionSpec{
+	Heading: "Ideas",
+	List:    true,
+}
+
+func resolveBrainstormSection(value string) (brainstormSectionSpec, error) {
+	switch slugify(value) {
+	case "", "idea", "ideas":
+		return brainstormIdeasSection, nil
+	case "focus", "focus-question":
+		return brainstormSectionSpec{Heading: "Focus Question"}, nil
+	case "desired-outcome", "outcome":
+		return brainstormSectionSpec{Heading: "Desired Outcome"}, nil
+	case "constraints", "constraint":
+		return brainstormSectionSpec{Heading: "Constraints", List: true}, nil
+	case "open-questions", "questions", "question":
+		return brainstormSectionSpec{Heading: "Open Questions", List: true}, nil
+	case "raw-notes", "notes":
+		return brainstormSectionSpec{Heading: "Raw Notes"}, nil
+	default:
+		return brainstormSectionSpec{}, fmt.Errorf("unsupported brainstorm section %q", value)
+	}
+}
+
+func formatBrainstormEntry(section brainstormSectionSpec, body string) string {
+	body = strings.TrimSpace(body)
+	if body == "" {
+		return ""
+	}
+	if !section.List {
+		return body
+	}
+
+	var items []string
+	for _, line := range strings.Split(body, "\n") {
+		line = strings.TrimSpace(line)
+		line = strings.TrimPrefix(line, "- ")
+		line = strings.TrimPrefix(line, "* ")
+		if line == "" {
+			continue
+		}
+		items = append(items, bullet(line))
+	}
+	return strings.Join(items, "\n")
 }

--- a/internal/planning/manager_test.go
+++ b/internal/planning/manager_test.go
@@ -17,11 +17,15 @@ func TestPromoteBrainstormSeedsSpec(t *testing.T) {
 	}
 	manager := New(ws)
 
-	brainstorm, err := manager.CreateBrainstorm("Auth System")
+	brainstorm, err := manager.CreateBrainstormWithInput(BrainstormCreateInput{
+		Topic:         "Auth System",
+		FocusQuestion: "How do we make sign-in simpler without lowering trust?",
+		Ideas:         []string{"Support passwordless sign-in"},
+	})
 	if err != nil {
 		t.Fatal(err)
 	}
-	if _, err := manager.AddIdea("auth-system", "Support passwordless sign-in"); err != nil {
+	if _, err := manager.AddBrainstormEntry("auth-system", "open-questions", "How should account recovery work?"); err != nil {
 		t.Fatal(err)
 	}
 
@@ -40,6 +44,80 @@ func TestPromoteBrainstormSeedsSpec(t *testing.T) {
 	}
 	if !strings.Contains(bundle.Spec.Content, "Support passwordless sign-in") {
 		t.Fatalf("expected brainstorm idea in spec:\n%s", bundle.Spec.Content)
+	}
+	if strings.Contains(bundle.Spec.Content, "**") {
+		t.Fatalf("expected seeded spec content to avoid brainstorm timestamp noise:\n%s", bundle.Spec.Content)
+	}
+}
+
+func TestCreateBrainstormWithInputSeedsFocusAndIdeas(t *testing.T) {
+	root := t.TempDir()
+	ws := workspace.New(root)
+	if _, err := ws.Init(); err != nil {
+		t.Fatal(err)
+	}
+	manager := New(ws)
+
+	note, err := manager.CreateBrainstormWithInput(BrainstormCreateInput{
+		Topic:         "Release System",
+		FocusQuestion: "What keeps releases safe and boring?",
+		Ideas: []string{
+			"Add dry-run release validation",
+			"Publish checksums with each build",
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	raw, err := notes.Read(filepath.Join(root, ".plan", "brainstorms", "release-system.md"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if note.Path != ".plan/brainstorms/release-system.md" {
+		t.Fatalf("unexpected brainstorm path: %s", note.Path)
+	}
+	if got := notes.ExtractSection(raw.Content, "Focus Question"); got != "What keeps releases safe and boring?" {
+		t.Fatalf("unexpected focus question:\n%s", got)
+	}
+	ideas := notes.ExtractSection(raw.Content, "Ideas")
+	if !strings.Contains(ideas, "- Add dry-run release validation") || !strings.Contains(ideas, "- Publish checksums with each build") {
+		t.Fatalf("expected seeded brainstorm ideas:\n%s", ideas)
+	}
+	if strings.Contains(ideas, "**") {
+		t.Fatalf("expected brainstorm ideas without timestamp formatting:\n%s", ideas)
+	}
+}
+
+func TestAddBrainstormEntrySupportsSectionsAndMultilineBullets(t *testing.T) {
+	root := t.TempDir()
+	ws := workspace.New(root)
+	if _, err := ws.Init(); err != nil {
+		t.Fatal(err)
+	}
+	manager := New(ws)
+
+	if _, err := manager.CreateBrainstorm("Agent Workflow"); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := manager.AddIdea("agent-workflow", "Capture dependencies\nTrack verification upfront"); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := manager.AddBrainstormEntry("agent-workflow", "open-questions", "How strict should approval be?\nShould specs own rollout notes?"); err != nil {
+		t.Fatal(err)
+	}
+
+	raw, err := notes.Read(filepath.Join(root, ".plan", "brainstorms", "agent-workflow.md"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	ideas := notes.ExtractSection(raw.Content, "Ideas")
+	if !strings.Contains(ideas, "- Capture dependencies") || !strings.Contains(ideas, "- Track verification upfront") {
+		t.Fatalf("expected multiline idea capture to produce bullets:\n%s", ideas)
+	}
+	questions := notes.ExtractSection(raw.Content, "Open Questions")
+	if !strings.Contains(questions, "- How strict should approval be?") || !strings.Contains(questions, "- Should specs own rollout notes?") {
+		t.Fatalf("expected open questions bullets:\n%s", questions)
 	}
 }
 

--- a/internal/planning/manager_test.go
+++ b/internal/planning/manager_test.go
@@ -417,3 +417,84 @@ func TestUpdateStoryStoresNormalizedBlockerMetadata(t *testing.T) {
 	}
 	t.Fatal("expected updated story in listing")
 }
+
+func TestReadyWorkSeparatesReadyAndBlockedStories(t *testing.T) {
+	root := t.TempDir()
+	ws := workspace.New(root)
+	if _, err := ws.Init(); err != nil {
+		t.Fatal(err)
+	}
+	manager := New(ws)
+
+	if _, err := manager.CreateEpic("Billing", ""); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := manager.SetSpecStatus("billing", "approved"); err != nil {
+		t.Fatal(err)
+	}
+	for _, input := range []struct {
+		title string
+		body  string
+	}{
+		{title: "Implement invoices", body: "Create invoice generation flow"},
+		{title: "Ship exports", body: "Create export flow"},
+		{title: "Manual blocker", body: "Needs external review"},
+	} {
+		if _, err := manager.CreateStory(
+			"billing",
+			input.title,
+			input.body,
+			[]string{"Acceptance for " + input.title},
+			[]string{"Verify " + input.title},
+			nil,
+		); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if _, err := manager.UpdateStory("ship-exports", StoryChanges{SetBlockers: []string{"implement-invoices"}}); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := manager.UpdateStory("manual-blocker", StoryChanges{Status: "blocked"}); err != nil {
+		t.Fatal(err)
+	}
+
+	work, err := manager.ReadyWork()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(work.Ready) != 1 || work.Ready[0].Title != "Implement invoices" {
+		t.Fatalf("expected only invoices story to be ready: %+v", work.Ready)
+	}
+	if len(work.Blocked) != 2 {
+		t.Fatalf("expected blocked stories to be returned: %+v", work.Blocked)
+	}
+	assertBlockedReason(t, work.Blocked, "Ship exports", "blocked by implement-invoices [todo]")
+	assertBlockedReason(t, work.Blocked, "Manual blocker", "story status is blocked")
+
+	if _, err := manager.UpdateStory("implement-invoices", StoryChanges{Status: "done"}); err != nil {
+		t.Fatal(err)
+	}
+	work, err = manager.ReadyWork()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(work.Ready) != 1 || work.Ready[0].Title != "Ship exports" {
+		t.Fatalf("expected exports story to become ready once blocker is done: %+v", work.Ready)
+	}
+}
+
+func assertBlockedReason(t *testing.T, blocked []BlockedStory, title, reason string) {
+	t.Helper()
+	for _, item := range blocked {
+		if item.Story.Title != title {
+			continue
+		}
+		for _, current := range item.Reasons {
+			if current == reason {
+				return
+			}
+		}
+		t.Fatalf("expected blocker reason %q for %s: %+v", reason, title, item)
+	}
+	t.Fatalf("expected blocked story %s: %+v", title, blocked)
+}

--- a/internal/planning/manager_test.go
+++ b/internal/planning/manager_test.go
@@ -360,3 +360,60 @@ func TestStatusBuildsRoadmapVersionSummaries(t *testing.T) {
 		t.Fatalf("expected no unassigned epics: %+v", status.UnassignedEpics)
 	}
 }
+
+func TestUpdateStoryStoresNormalizedBlockerMetadata(t *testing.T) {
+	root := t.TempDir()
+	ws := workspace.New(root)
+	if _, err := ws.Init(); err != nil {
+		t.Fatal(err)
+	}
+	manager := New(ws)
+
+	if _, err := manager.CreateEpic("Billing", ""); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := manager.SetSpecStatus("billing", "approved"); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := manager.CreateStory(
+		"billing",
+		"Implement invoices",
+		"Create invoice generation flow",
+		[]string{"Generate invoices from line items"},
+		[]string{"Run focused billing tests"},
+		nil,
+	); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := manager.CreateStory(
+		"billing",
+		"Ship exports",
+		"Create export flow",
+		[]string{"Export invoices"},
+		[]string{"Run export tests"},
+		nil,
+	); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := manager.UpdateStory("ship-exports", StoryChanges{
+		SetBlockers: []string{"Implement invoices", "implement-invoices", " "},
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	stories, err := manager.ListStories("billing", "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, story := range stories {
+		if story.Title != "Ship exports" {
+			continue
+		}
+		if len(story.Blockers) != 1 || story.Blockers[0] != "implement-invoices" {
+			t.Fatalf("expected normalized blocker slugs: %+v", story)
+		}
+		return
+	}
+	t.Fatal("expected updated story in listing")
+}

--- a/internal/planning/manager_test.go
+++ b/internal/planning/manager_test.go
@@ -9,7 +9,7 @@ import (
 	"plan/internal/workspace"
 )
 
-func TestPromoteBrainstormSeedsSpec(t *testing.T) {
+func TestPromoteBrainstormSeedsEpicAndSpecWithProvenance(t *testing.T) {
 	root := t.TempDir()
 	ws := workspace.New(root)
 	if _, err := ws.Init(); err != nil {
@@ -20,9 +20,17 @@ func TestPromoteBrainstormSeedsSpec(t *testing.T) {
 	brainstorm, err := manager.CreateBrainstormWithInput(BrainstormCreateInput{
 		Topic:         "Auth System",
 		FocusQuestion: "How do we make sign-in simpler without lowering trust?",
-		Ideas:         []string{"Support passwordless sign-in"},
 	})
 	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := manager.AddBrainstormEntry("auth-system", "desired-outcome", "Deliver an auth flow that feels low-friction for small teams."); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := manager.AddBrainstormEntry("auth-system", "constraints", "Keep setup local-first and avoid hosted auth dependencies."); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := manager.AddBrainstormEntry("auth-system", "ideas", "Support passwordless sign-in"); err != nil {
 		t.Fatal(err)
 	}
 	if _, err := manager.AddBrainstormEntry("auth-system", "open-questions", "How should account recovery work?"); err != nil {
@@ -40,13 +48,42 @@ func TestPromoteBrainstormSeedsSpec(t *testing.T) {
 		t.Fatalf("unexpected spec path: %s", bundle.Spec.Path)
 	}
 	if got := bundle.Epic.Metadata["source_brainstorm"]; got != brainstorm.Path {
-		t.Fatalf("unexpected brainstorm link: %v", got)
+		t.Fatalf("unexpected epic brainstorm link: %v", got)
+	}
+	if got := bundle.Spec.Metadata["source_brainstorm"]; got != brainstorm.Path {
+		t.Fatalf("unexpected spec brainstorm link: %v", got)
+	}
+	if !strings.Contains(bundle.Epic.Content, "Deliver an auth flow that feels low-friction for small teams.") {
+		t.Fatalf("expected brainstorm outcome in epic:\n%s", bundle.Epic.Content)
+	}
+	if !strings.Contains(bundle.Epic.Content, "[Source Brainstorm](../brainstorms/auth-system.md)") {
+		t.Fatalf("expected brainstorm link in epic resources:\n%s", bundle.Epic.Content)
+	}
+	if !strings.Contains(bundle.Spec.Content, "How do we make sign-in simpler without lowering trust?") {
+		t.Fatalf("expected brainstorm focus question in spec problem:\n%s", bundle.Spec.Content)
 	}
 	if !strings.Contains(bundle.Spec.Content, "Support passwordless sign-in") {
 		t.Fatalf("expected brainstorm idea in spec:\n%s", bundle.Spec.Content)
 	}
+	if !strings.Contains(bundle.Spec.Content, "Keep setup local-first and avoid hosted auth dependencies.") {
+		t.Fatalf("expected brainstorm constraints in spec:\n%s", bundle.Spec.Content)
+	}
+	if !strings.Contains(bundle.Spec.Content, "How should account recovery work?") {
+		t.Fatalf("expected brainstorm questions in spec:\n%s", bundle.Spec.Content)
+	}
 	if strings.Contains(bundle.Spec.Content, "**") {
 		t.Fatalf("expected seeded spec content to avoid brainstorm timestamp noise:\n%s", bundle.Spec.Content)
+	}
+
+	promotedBrainstorm, err := notes.Read(filepath.Join(root, ".plan", "brainstorms", "auth-system.md"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if promotedBrainstorm.Metadata["status"] != "promoted" {
+		t.Fatalf("expected brainstorm to be marked promoted: %+v", promotedBrainstorm.Metadata)
+	}
+	if promotedBrainstorm.Metadata["epic"] != "auth-system" || promotedBrainstorm.Metadata["spec"] != "auth-system" {
+		t.Fatalf("expected brainstorm promotion links: %+v", promotedBrainstorm.Metadata)
 	}
 }
 

--- a/internal/planning/manager_test.go
+++ b/internal/planning/manager_test.go
@@ -309,3 +309,54 @@ func TestUpdateStorySyncsSpecLifecycleAndEpicProgress(t *testing.T) {
 		t.Fatalf("expected epic status to reflect completed story: %+v", status.Epics)
 	}
 }
+
+func TestStatusBuildsRoadmapVersionSummaries(t *testing.T) {
+	root := t.TempDir()
+	ws := workspace.New(root)
+	if _, err := ws.Init(); err != nil {
+		t.Fatal(err)
+	}
+	manager := New(ws)
+
+	if _, err := manager.CreateEpic("Roadmap Work", ""); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := manager.UpdateSpec("roadmap-work", notes.UpdateInput{
+		Metadata: map[string]any{"status": "approved", "target_version": "v2"},
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := manager.CreateStory(
+		"roadmap-work",
+		"Ship roadmap parser",
+		"Parse version sections from roadmap",
+		[]string{"Version sections are parsed"},
+		[]string{"go test ./internal/planning"},
+		nil,
+	); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := manager.UpdateStory("ship-roadmap-parser", StoryChanges{Status: "in_progress"}); err != nil {
+		t.Fatal(err)
+	}
+
+	status, err := manager.Status()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if status.RoadmapPath != ".plan/ROADMAP.md" {
+		t.Fatalf("expected roadmap path in status: %+v", status)
+	}
+	if len(status.Versions) < 2 {
+		t.Fatalf("expected roadmap versions in status: %+v", status.Versions)
+	}
+	if status.Versions[1].Key != "v2" || len(status.Versions[1].Epics) != 1 {
+		t.Fatalf("expected v2 version grouping: %+v", status.Versions)
+	}
+	if status.Versions[1].Epics[0].Title != "Roadmap Work" {
+		t.Fatalf("expected roadmap epic in v2 group: %+v", status.Versions[1].Epics)
+	}
+	if len(status.UnassignedEpics) != 0 {
+		t.Fatalf("expected no unassigned epics: %+v", status.UnassignedEpics)
+	}
+}

--- a/internal/planning/manager_test.go
+++ b/internal/planning/manager_test.go
@@ -174,6 +174,28 @@ func TestCreateStoryRequiresApprovedSpec(t *testing.T) {
 	}
 }
 
+func TestCreateStoryRequiresAcceptanceAndVerification(t *testing.T) {
+	root := t.TempDir()
+	ws := workspace.New(root)
+	if _, err := ws.Init(); err != nil {
+		t.Fatal(err)
+	}
+	manager := New(ws)
+
+	if _, err := manager.CreateEpic("Billing", ""); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := manager.SetSpecStatus("billing", "approved"); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := manager.CreateStory("billing", "Implement invoices", "", nil, []string{"Run focused billing tests"}, nil); err == nil {
+		t.Fatal("expected missing acceptance criteria to be rejected")
+	}
+	if _, err := manager.CreateStory("billing", "Implement invoices", "", []string{"Generate invoices from line items"}, nil, nil); err == nil {
+		t.Fatal("expected missing verification steps to be rejected")
+	}
+}
+
 func TestCreateStoryAddsSpecReferenceAndCriteria(t *testing.T) {
 	root := t.TempDir()
 	ws := workspace.New(root)
@@ -215,5 +237,75 @@ func TestCreateStoryAddsSpecReferenceAndCriteria(t *testing.T) {
 	}
 	if !strings.Contains(raw.Content, "[Canonical Spec](../specs/billing.md)") {
 		t.Fatalf("expected canonical spec link in story:\n%s", raw.Content)
+	}
+}
+
+func TestUpdateStorySyncsSpecLifecycleAndEpicProgress(t *testing.T) {
+	root := t.TempDir()
+	ws := workspace.New(root)
+	if _, err := ws.Init(); err != nil {
+		t.Fatal(err)
+	}
+	manager := New(ws)
+
+	if _, err := manager.CreateEpic("Billing", ""); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := manager.SetSpecStatus("billing", "approved"); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := manager.CreateStory(
+		"billing",
+		"Implement invoices",
+		"Create invoice generation flow",
+		[]string{"Generate invoices from line items"},
+		[]string{"Run focused billing tests"},
+		nil,
+	); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := manager.UpdateStory("implement-invoices", StoryChanges{Status: "in_progress"}); err != nil {
+		t.Fatal(err)
+	}
+	spec, err := manager.ReadSpec("billing")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if spec.Metadata["status"] != "implementing" {
+		t.Fatalf("expected spec to move into implementing: %+v", spec.Metadata)
+	}
+
+	status, err := manager.Status()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if status.InProgressStories != 1 {
+		t.Fatalf("expected project in-progress story count to update: %+v", status)
+	}
+	if len(status.Epics) != 1 || status.Epics[0].InProgressStories != 1 || status.Epics[0].DoneStories != 0 {
+		t.Fatalf("expected epic progress counts to update: %+v", status.Epics)
+	}
+
+	if _, err := manager.UpdateStory("implement-invoices", StoryChanges{Status: "done"}); err != nil {
+		t.Fatal(err)
+	}
+	spec, err = manager.ReadSpec("billing")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if spec.Metadata["status"] != "done" {
+		t.Fatalf("expected spec to move into done: %+v", spec.Metadata)
+	}
+
+	status, err = manager.Status()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if status.DoneStories != 1 || status.InProgressStories != 0 {
+		t.Fatalf("expected project status to reflect completed story: %+v", status)
+	}
+	if len(status.Epics) != 1 || status.Epics[0].DoneStories != 1 || status.Epics[0].InProgressStories != 0 {
+		t.Fatalf("expected epic status to reflect completed story: %+v", status.Epics)
 	}
 }

--- a/internal/planning/ready.go
+++ b/internal/planning/ready.go
@@ -1,0 +1,63 @@
+package planning
+
+import "fmt"
+
+type ReadyWork struct {
+	Ready   []StoryInfo
+	Blocked []BlockedStory
+}
+
+type BlockedStory struct {
+	Story   StoryInfo
+	Reasons []string
+}
+
+func (m *Manager) ReadyWork() (*ReadyWork, error) {
+	stories, err := m.ListStories("", "")
+	if err != nil {
+		return nil, err
+	}
+	index := make(map[string]StoryInfo, len(stories))
+	for _, story := range stories {
+		if slug := slugFromPath(story.Path); slug != "" {
+			index[slug] = story
+		}
+	}
+
+	work := &ReadyWork{}
+	for _, story := range stories {
+		switch story.Status {
+		case "done", "in_progress":
+			continue
+		}
+
+		reasons := readyBlockerReasons(story, index)
+		if len(reasons) == 0 {
+			work.Ready = append(work.Ready, story)
+			continue
+		}
+		work.Blocked = append(work.Blocked, BlockedStory{
+			Story:   story,
+			Reasons: reasons,
+		})
+	}
+	return work, nil
+}
+
+func readyBlockerReasons(story StoryInfo, index map[string]StoryInfo) []string {
+	var reasons []string
+	if story.Status == "blocked" {
+		reasons = append(reasons, "story status is blocked")
+	}
+	for _, blocker := range story.Blockers {
+		blockerStory, ok := index[slugify(blocker)]
+		if !ok {
+			reasons = append(reasons, fmt.Sprintf("missing blocker story %q", blocker))
+			continue
+		}
+		if blockerStory.Status != "done" {
+			reasons = append(reasons, fmt.Sprintf("blocked by %s [%s]", blocker, blockerStory.Status))
+		}
+	}
+	return reasons
+}

--- a/internal/planning/roadmap.go
+++ b/internal/planning/roadmap.go
@@ -1,0 +1,179 @@
+package planning
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+type Roadmap struct {
+	Path          string
+	Overview      string
+	Versions      []RoadmapVersion
+	OrderingNotes []string
+	ParkingLot    []string
+}
+
+type RoadmapVersion struct {
+	Key     string
+	Title   string
+	Goal    string
+	Summary []string
+	Epics   []RoadmapEpic
+}
+
+type RoadmapEpic struct {
+	Title string
+	Done  bool
+}
+
+func (m *Manager) ReadRoadmap() (*Roadmap, error) {
+	info, err := m.workspace.EnsureInitialized()
+	if err != nil {
+		return nil, err
+	}
+	raw, err := os.ReadFile(info.RoadmapFile)
+	if err != nil {
+		return nil, err
+	}
+	roadmap := ParseRoadmap(rel(info.ProjectDir, info.RoadmapFile), string(raw))
+	return roadmap, nil
+}
+
+func ParseRoadmap(path, body string) *Roadmap {
+	sections := splitRoadmapSections(body)
+	roadmap := &Roadmap{Path: filepath.ToSlash(path)}
+	for _, section := range sections {
+		switch {
+		case strings.EqualFold(section.heading, "Overview"):
+			roadmap.Overview = strings.TrimSpace(strings.Join(section.lines, "\n"))
+		case strings.EqualFold(section.heading, "Ordering Notes"):
+			roadmap.OrderingNotes = collectLooseList(section.lines)
+		case strings.EqualFold(section.heading, "Parking Lot"):
+			roadmap.ParkingLot = collectLooseList(section.lines)
+		case isRoadmapVersionHeading(section.heading):
+			roadmap.Versions = append(roadmap.Versions, parseRoadmapVersion(section.heading, section.lines))
+		}
+	}
+	return roadmap
+}
+
+type roadmapSection struct {
+	heading string
+	lines   []string
+}
+
+func splitRoadmapSections(body string) []roadmapSection {
+	lines := strings.Split(strings.ReplaceAll(body, "\r\n", "\n"), "\n")
+	var sections []roadmapSection
+	var current *roadmapSection
+	for _, line := range lines {
+		trimmed := strings.TrimSpace(line)
+		if strings.HasPrefix(trimmed, "## ") {
+			sections = appendCurrentRoadmapSection(sections, current)
+			current = &roadmapSection{heading: strings.TrimSpace(strings.TrimPrefix(trimmed, "## "))}
+			continue
+		}
+		if current == nil {
+			continue
+		}
+		current.lines = append(current.lines, line)
+	}
+	return appendCurrentRoadmapSection(sections, current)
+}
+
+func appendCurrentRoadmapSection(sections []roadmapSection, current *roadmapSection) []roadmapSection {
+	if current == nil {
+		return sections
+	}
+	copy := roadmapSection{
+		heading: current.heading,
+		lines:   append([]string(nil), current.lines...),
+	}
+	return append(sections, copy)
+}
+
+func isRoadmapVersionHeading(heading string) bool {
+	heading = strings.TrimSpace(strings.ToLower(heading))
+	return strings.HasPrefix(heading, "v") && strings.Contains(heading, ":")
+}
+
+func parseRoadmapVersion(heading string, lines []string) RoadmapVersion {
+	version := RoadmapVersion{}
+	parts := strings.SplitN(heading, ":", 2)
+	version.Key = strings.TrimSpace(parts[0])
+	if len(parts) == 2 {
+		version.Title = strings.TrimSpace(parts[1])
+	}
+
+	inSummary := false
+	for _, line := range lines {
+		trimmed := strings.TrimSpace(line)
+		if trimmed == "" {
+			continue
+		}
+		if strings.HasPrefix(trimmed, "Goal:") {
+			version.Goal = strings.TrimSpace(strings.TrimPrefix(trimmed, "Goal:"))
+			inSummary = false
+			continue
+		}
+		if trimmed == "Summary:" {
+			inSummary = true
+			continue
+		}
+		if epic, ok := parseRoadmapEpic(trimmed); ok {
+			version.Epics = append(version.Epics, epic)
+			inSummary = false
+			continue
+		}
+		if bullet, ok := parseLooseBullet(trimmed); ok {
+			if inSummary {
+				version.Summary = append(version.Summary, bullet)
+			}
+			continue
+		}
+		if inSummary {
+			version.Summary = append(version.Summary, trimmed)
+		}
+	}
+
+	return version
+}
+
+func parseRoadmapEpic(line string) (RoadmapEpic, bool) {
+	switch {
+	case strings.HasPrefix(line, "- [ ] "):
+		return RoadmapEpic{Title: strings.TrimSpace(strings.TrimPrefix(line, "- [ ] ")), Done: false}, true
+	case strings.HasPrefix(strings.ToLower(line), "- [x] "):
+		return RoadmapEpic{Title: strings.TrimSpace(line[6:]), Done: true}, true
+	default:
+		return RoadmapEpic{}, false
+	}
+}
+
+func collectLooseList(lines []string) []string {
+	var out []string
+	for _, line := range lines {
+		trimmed := strings.TrimSpace(line)
+		if trimmed == "" {
+			continue
+		}
+		if item, ok := parseLooseBullet(trimmed); ok {
+			out = append(out, item)
+			continue
+		}
+		out = append(out, trimmed)
+	}
+	return out
+}
+
+func parseLooseBullet(line string) (string, bool) {
+	switch {
+	case strings.HasPrefix(line, "- "):
+		return strings.TrimSpace(strings.TrimPrefix(line, "- ")), true
+	case strings.HasPrefix(line, "* "):
+		return strings.TrimSpace(strings.TrimPrefix(line, "* ")), true
+	default:
+		return "", false
+	}
+}

--- a/internal/planning/roadmap_test.go
+++ b/internal/planning/roadmap_test.go
@@ -1,0 +1,154 @@
+package planning
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"plan/internal/workspace"
+)
+
+func TestParseRoadmapReadsVersionStructureAndOrder(t *testing.T) {
+	roadmap := ParseRoadmap(".plan/ROADMAP.md", `
+# Roadmap: plan
+
+## Overview
+
+Alpha overview.
+
+## v1: Local-First Core
+
+Goal: Ship the trustworthy foundation.
+
+- [ ] Core Workspace and Artifact System
+- [ ] Spec-Driven Planning Workflow
+
+Summary:
+- establish .plan as the workspace
+- make the core loop work
+
+## v2: Planning Rigor
+
+Goal: Make plans sharper.
+
+- [x] Roadmap and Portfolio Planning
+
+Summary:
+- add roadmap helpers
+
+## Ordering Notes
+
+- v1 first
+- v2 second
+
+## Parking Lot
+
+- hosted dashboards
+`)
+
+	if roadmap.Path != ".plan/ROADMAP.md" {
+		t.Fatalf("unexpected roadmap path: %+v", roadmap)
+	}
+	if roadmap.Overview != "Alpha overview." {
+		t.Fatalf("unexpected overview: %q", roadmap.Overview)
+	}
+	if len(roadmap.Versions) != 2 {
+		t.Fatalf("expected 2 versions, got %d", len(roadmap.Versions))
+	}
+	if roadmap.Versions[0].Key != "v1" || roadmap.Versions[0].Title != "Local-First Core" {
+		t.Fatalf("unexpected first version: %+v", roadmap.Versions[0])
+	}
+	if roadmap.Versions[0].Goal != "Ship the trustworthy foundation." {
+		t.Fatalf("unexpected first goal: %+v", roadmap.Versions[0])
+	}
+	if len(roadmap.Versions[0].Epics) != 2 || roadmap.Versions[0].Epics[1].Title != "Spec-Driven Planning Workflow" {
+		t.Fatalf("unexpected first version epics: %+v", roadmap.Versions[0].Epics)
+	}
+	if len(roadmap.Versions[1].Epics) != 1 || !roadmap.Versions[1].Epics[0].Done {
+		t.Fatalf("expected checked roadmap epic to parse as done: %+v", roadmap.Versions[1].Epics)
+	}
+	if len(roadmap.OrderingNotes) != 2 || roadmap.OrderingNotes[0] != "v1 first" {
+		t.Fatalf("unexpected ordering notes: %+v", roadmap.OrderingNotes)
+	}
+	if len(roadmap.ParkingLot) != 1 || roadmap.ParkingLot[0] != "hosted dashboards" {
+		t.Fatalf("unexpected parking lot: %+v", roadmap.ParkingLot)
+	}
+}
+
+func TestParseRoadmapToleratesEmptySections(t *testing.T) {
+	roadmap := ParseRoadmap(".plan/ROADMAP.md", `
+# Roadmap
+
+## Overview
+
+## v1: Core
+
+Goal: Ship core.
+
+## v2: Later
+
+## Ordering Notes
+
+## Parking Lot
+`)
+
+	if len(roadmap.Versions) != 2 {
+		t.Fatalf("expected empty version sections to still parse, got %+v", roadmap.Versions)
+	}
+	if roadmap.Versions[0].Key != "v1" || roadmap.Versions[1].Key != "v2" {
+		t.Fatalf("expected version order to stay stable: %+v", roadmap.Versions)
+	}
+	if roadmap.Versions[0].Goal != "Ship core." {
+		t.Fatalf("unexpected goal from sparse roadmap: %+v", roadmap.Versions[0])
+	}
+	if len(roadmap.Versions[1].Epics) != 0 || len(roadmap.OrderingNotes) != 0 || len(roadmap.ParkingLot) != 0 {
+		t.Fatalf("expected empty sections to stay empty: %+v", roadmap)
+	}
+}
+
+func TestReadRoadmapParsesWorkspaceRoadmapFile(t *testing.T) {
+	root := t.TempDir()
+	ws := workspace.New(root)
+	if _, err := ws.Init(); err != nil {
+		t.Fatal(err)
+	}
+	manager := New(ws)
+
+	body := `# Roadmap: plan
+
+## Overview
+
+Overview text.
+
+## v1: Local-First Core
+
+Goal: Ship core.
+
+- [ ] Core Workspace and Artifact System
+
+Summary:
+- establish .plan
+
+## Ordering Notes
+
+- core first
+
+## Parking Lot
+
+- integrations later
+`
+	if err := os.WriteFile(filepath.Join(root, ".plan", "ROADMAP.md"), []byte(body), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	roadmap, err := manager.ReadRoadmap()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if roadmap.Path != ".plan/ROADMAP.md" {
+		t.Fatalf("unexpected roadmap path: %+v", roadmap)
+	}
+	if len(roadmap.Versions) != 1 || roadmap.Versions[0].Title != "Local-First Core" {
+		t.Fatalf("unexpected parsed roadmap versions: %+v", roadmap.Versions)
+	}
+}

--- a/internal/skills/install.go
+++ b/internal/skills/install.go
@@ -109,9 +109,12 @@ func (i *Installer) ResolveTargets(req InstallRequest) ([]Target, error) {
 		if projectDir == "" {
 			projectDir = "."
 		}
-		projectDir = filepath.Clean(expandHome(projectDir, i.Home))
+		resolvedProjectDir, err := resolveProjectDir(projectDir, i.Home)
+		if err != nil {
+			return nil, err
+		}
 		for _, agent := range agents {
-			root := knownLocalSkillRoot(projectDir, agent)
+			root := knownLocalSkillRoot(resolvedProjectDir, agent)
 			targets = append(targets, Target{
 				Agent: agent,
 				Scope: string(ScopeLocal),
@@ -309,4 +312,13 @@ func expandHome(path, home string) string {
 		return home
 	}
 	return filepath.Join(home, strings.TrimPrefix(path, "~/"))
+}
+
+func resolveProjectDir(path, home string) (string, error) {
+	path = filepath.Clean(expandHome(path, home))
+	abs, err := filepath.Abs(path)
+	if err != nil {
+		return "", fmt.Errorf("resolve project dir %s: %w", path, err)
+	}
+	return abs, nil
 }

--- a/internal/skills/install_test.go
+++ b/internal/skills/install_test.go
@@ -1,6 +1,7 @@
 package skills
 
 import (
+	"encoding/json"
 	"os"
 	"path/filepath"
 	"testing"
@@ -62,6 +63,134 @@ func TestInstallCopiesSkillBundleAndWritesManifest(t *testing.T) {
 	}
 	if manifest.BundleHash != bundleHash {
 		t.Fatalf("unexpected bundle hash: %+v", manifest)
+	}
+}
+
+func TestResolveTargetsLocalScopeUsesAbsoluteProjectDir(t *testing.T) {
+	installer := NewInstaller("/home/tester")
+	projectDir := t.TempDir()
+	prevWD, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chdir(projectDir); err != nil {
+		t.Fatal(err)
+	}
+	defer func() {
+		_ = os.Chdir(prevWD)
+	}()
+
+	targets, err := installer.ResolveTargets(InstallRequest{
+		Scope:      ScopeLocal,
+		Agents:     []string{"codex"},
+		ProjectDir: ".",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(targets) != 1 {
+		t.Fatalf("expected 1 target, got %d", len(targets))
+	}
+	if !filepath.IsAbs(targets[0].Root) || !filepath.IsAbs(targets[0].Path) {
+		t.Fatalf("expected absolute local target paths: %+v", targets[0])
+	}
+	if targets[0].Path != filepath.Join(projectDir, ".codex", "skills", "plan") {
+		t.Fatalf("unexpected resolved target path: %+v", targets[0])
+	}
+}
+
+func TestInspectFlagsLegacyAndStaleInstalls(t *testing.T) {
+	bundleHash := registerTestBundle(t)
+
+	home := t.TempDir()
+	installer := NewInstaller(home)
+
+	legacyDir := filepath.Join(home, ".claude", "skills", "plan")
+	if err := os.MkdirAll(legacyDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(legacyDir, "SKILL.md"), []byte("legacy"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	staleDir := filepath.Join(home, ".codex", "skills", "plan")
+	if err := os.MkdirAll(staleDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(staleDir, "SKILL.md"), []byte("skill"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	raw, err := json.MarshalIndent(Manifest{
+		SchemaVersion: manifestSchemaVersion,
+		PlanVersion:   "v0.0.1",
+		PlanCommit:    "deadbeef",
+		BundleHash:    "stale-hash",
+		InstalledAt:   "2026-01-01T00:00:00Z",
+		Agent:         "codex",
+		Scope:         string(ScopeGlobal),
+	}, "", "  ")
+	if err != nil {
+		t.Fatal(err)
+	}
+	raw = append(raw, '\n')
+	if err := os.WriteFile(manifestPath(staleDir), raw, 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	statuses, err := installer.Inspect(InstallRequest{
+		Scope:  ScopeGlobal,
+		Agents: []string{"codex", "claude"},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	reasons := map[string]string{}
+	for _, status := range statuses {
+		if status.Path == staleDir {
+			if status.Manifest == nil || status.Manifest.BundleHash == bundleHash {
+				t.Fatalf("expected stale manifest to be inspected: %+v", status)
+			}
+		}
+		reasons[status.Path] = status.Reason
+	}
+	if reasons[legacyDir] != "legacy_install" {
+		t.Fatalf("expected legacy install reason, got %q", reasons[legacyDir])
+	}
+	if reasons[staleDir] != "stale_bundle" {
+		t.Fatalf("expected stale bundle reason, got %q", reasons[staleDir])
+	}
+}
+
+func TestInstallRepairsLegacyInstallCleanly(t *testing.T) {
+	bundleHash := registerTestBundle(t)
+
+	home := t.TempDir()
+	installer := NewInstaller(home)
+	skillDir := filepath.Join(home, ".codex", "skills", "plan")
+	if err := os.MkdirAll(skillDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(skillDir, "old.txt"), []byte("stale"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := installer.Install(InstallRequest{
+		Scope:  ScopeGlobal,
+		Agents: []string{"codex"},
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := os.Stat(filepath.Join(skillDir, "old.txt")); !os.IsNotExist(err) {
+		t.Fatalf("expected stale file to be removed, got %v", err)
+	}
+	manifest, err := readManifest(skillDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if manifest.BundleHash != bundleHash {
+		t.Fatalf("unexpected repaired manifest: %+v", manifest)
 	}
 }
 

--- a/internal/skills/install_test.go
+++ b/internal/skills/install_test.go
@@ -8,24 +8,26 @@ import (
 )
 
 func TestResolveTargetsGlobalAndLocal(t *testing.T) {
-	installer := NewInstaller("/home/tester")
+	home := t.TempDir()
+	projectDir := t.TempDir()
+	installer := NewInstaller(home)
 	targets, err := installer.ResolveTargets(InstallRequest{
 		Scope:      ScopeBoth,
 		Agents:     []string{"codex", "copilot", "pi", "zed"},
-		ProjectDir: "/tmp/project",
+		ProjectDir: projectDir,
 	})
 	if err != nil {
 		t.Fatal(err)
 	}
 	want := map[string]bool{
-		filepath.Join("/home/tester", ".codex", "skills", "plan"):       true,
-		filepath.Join("/home/tester", ".copilot", "skills", "plan"):     true,
-		filepath.Join("/home/tester", ".pi", "agent", "skills", "plan"): true,
-		filepath.Join("/home/tester", ".zed", "skills", "plan"):         true,
-		filepath.Join("/tmp/project", ".codex", "skills", "plan"):       true,
-		filepath.Join("/tmp/project", ".github", "skills", "plan"):      true,
-		filepath.Join("/tmp/project", ".pi", "skills", "plan"):          true,
-		filepath.Join("/tmp/project", ".zed", "skills", "plan"):         true,
+		filepath.Join(home, ".codex", "skills", "plan"):        true,
+		filepath.Join(home, ".copilot", "skills", "plan"):      true,
+		filepath.Join(home, ".pi", "agent", "skills", "plan"):  true,
+		filepath.Join(home, ".zed", "skills", "plan"):          true,
+		filepath.Join(projectDir, ".codex", "skills", "plan"):  true,
+		filepath.Join(projectDir, ".github", "skills", "plan"): true,
+		filepath.Join(projectDir, ".pi", "skills", "plan"):     true,
+		filepath.Join(projectDir, ".zed", "skills", "plan"):    true,
 	}
 	if len(targets) != len(want) {
 		t.Fatalf("expected %d targets, got %d", len(want), len(targets))

--- a/internal/templates/ROADMAP.md
+++ b/internal/templates/ROADMAP.md
@@ -4,9 +4,23 @@ Created: {{ .Now }}
 
 ## Overview
 
-## Epics
+## v1: Core
 
-- [ ] Example epic
+Goal:
+
+Summary:
+
+## v2: Rigor
+
+Goal:
+
+Summary:
+
+## v3: Power
+
+Goal:
+
+Summary:
 
 ## Ordering Notes
 

--- a/internal/templates/brainstorm.md
+++ b/internal/templates/brainstorm.md
@@ -4,10 +4,12 @@ Started: {{ .Now }}
 
 ## Focus Question
 
-What are we exploring?
+## Desired Outcome
+
+## Constraints
+
+## Open Questions
 
 ## Ideas
-
-## Related
 
 ## Raw Notes

--- a/internal/workspace/workspace.go
+++ b/internal/workspace/workspace.go
@@ -23,10 +23,22 @@ type WorkspaceMeta struct {
 }
 
 type MigrationState struct {
-	SchemaVersion int      `json:"schema_version"`
-	Known         []string `json:"known"`
-	LastRunAt     string   `json:"last_run_at,omitempty"`
-	Status        string   `json:"status,omitempty"`
+	SchemaVersion int            `json:"schema_version"`
+	Known         []string       `json:"known"`
+	LastRunAt     string         `json:"last_run_at,omitempty"`
+	Status        string         `json:"status,omitempty"`
+	LastOperation string         `json:"last_operation,omitempty"`
+	LastCreated   []string       `json:"last_created,omitempty"`
+	LastUpdated   []string       `json:"last_updated,omitempty"`
+	History       []MigrationRun `json:"history,omitempty"`
+}
+
+type MigrationRun struct {
+	Operation string   `json:"operation"`
+	At        string   `json:"at"`
+	Status    string   `json:"status"`
+	Created   []string `json:"created,omitempty"`
+	Updated   []string `json:"updated,omitempty"`
 }
 
 type Surface struct {
@@ -205,6 +217,9 @@ func (m *Manager) Init() (*InitResult, error) {
 	} else if created {
 		result.Created = append(result.Created, rel(info.ProjectDir, info.MigrationsFile))
 	}
+	if err := recordMigrationRun(info, "init", result.Created, nil, now); err != nil {
+		return nil, err
+	}
 
 	return result, nil
 }
@@ -368,7 +383,7 @@ func (m *Manager) Update() (*UpdateResult, error) {
 		}
 		return nil, err
 	}
-	return m.repairWorkspace(info)
+	return m.repairWorkspace(info, "update")
 }
 
 func (m *Manager) Adopt() (*UpdateResult, error) {
@@ -376,10 +391,10 @@ func (m *Manager) Adopt() (*UpdateResult, error) {
 	if err != nil {
 		return nil, err
 	}
-	return m.repairWorkspace(info)
+	return m.repairWorkspace(info, "adopt")
 }
 
-func (m *Manager) repairWorkspace(info *Info) (*UpdateResult, error) {
+func (m *Manager) repairWorkspace(info *Info, operation string) (*UpdateResult, error) {
 	result := &UpdateResult{Info: info}
 	for _, dir := range append([]string{info.PlanDir}, info.directoryPaths()...) {
 		created, err := ensureDir(dir)
@@ -433,6 +448,9 @@ func (m *Manager) repairWorkspace(info *Info) (*UpdateResult, error) {
 		if updated {
 			result.Updated = append(result.Updated, rel(info.ProjectDir, info.MigrationsFile))
 		}
+	}
+	if err := recordMigrationRun(info, operation, result.Created, result.Updated, now); err != nil {
+		return nil, err
 	}
 
 	return result, nil
@@ -635,6 +653,36 @@ func validateMigrationState(state *MigrationState) error {
 	default:
 		return nil
 	}
+}
+
+func recordMigrationRun(info *Info, operation string, created, updated []string, now string) error {
+	if len(created) == 0 && len(updated) == 0 {
+		return nil
+	}
+	state, err := readMigrationStateFile(info.MigrationsFile)
+	if err != nil {
+		defaultState := defaultMigrationState(now)
+		state = &defaultState
+	}
+	created = append([]string(nil), created...)
+	updated = append([]string(nil), updated...)
+	run := MigrationRun{
+		Operation: operation,
+		At:        now,
+		Status:    "current",
+		Created:   created,
+		Updated:   updated,
+	}
+	state.LastRunAt = now
+	state.Status = "current"
+	state.LastOperation = operation
+	state.LastCreated = created
+	state.LastUpdated = updated
+	state.History = append(state.History, run)
+	if len(state.History) > 10 {
+		state.History = append([]MigrationRun(nil), state.History[len(state.History)-10:]...)
+	}
+	return writeJSON(info.MigrationsFile, state)
 }
 
 func writeJSON(path string, v any) error {

--- a/internal/workspace/workspace.go
+++ b/internal/workspace/workspace.go
@@ -79,6 +79,7 @@ type DoctorReport struct {
 	MigrationStatus string   `json:"migration_status"`
 	Missing         []string `json:"missing,omitempty"`
 	Broken          []string `json:"broken,omitempty"`
+	Guidance        []string `json:"guidance,omitempty"`
 }
 
 type Manager struct {
@@ -287,11 +288,12 @@ func (m *Manager) Doctor() (*DoctorReport, error) {
 	report := &DoctorReport{
 		ProjectDir:      info.ProjectDir,
 		PlanDir:         info.PlanDir,
-		WorkspaceStatus: "not_initialized",
+		WorkspaceStatus: "adoptable",
 		MigrationStatus: "not_initialized",
 	}
 	if _, err := os.Stat(info.PlanDir); err != nil {
 		if os.IsNotExist(err) {
+			report.Guidance = guidanceForWorkspaceStatus(report.WorkspaceStatus)
 			return report, nil
 		}
 		return nil, err
@@ -335,17 +337,23 @@ func (m *Manager) Doctor() (*DoctorReport, error) {
 		}
 	}
 
-	report.WorkspaceStatus = classifyHealth(report.Missing, report.Broken)
+	report.WorkspaceStatus = classifyDoctorWorkspace(report.Missing, report.Broken)
+	if report.WorkspaceStatus == "partial" && report.MigrationStatus == "current" {
+		report.MigrationStatus = "partial"
+	}
 	if report.MigrationStatus == "" {
 		switch {
 		case contains(report.Broken, "migrations.json"):
 			report.MigrationStatus = "broken"
+		case isPartialWorkspace(report.Missing):
+			report.MigrationStatus = "partial"
 		case contains(report.Missing, "migrations.json"):
 			report.MigrationStatus = "missing"
 		default:
 			report.MigrationStatus = "current"
 		}
 	}
+	report.Guidance = guidanceForWorkspaceStatus(report.WorkspaceStatus)
 	return report, nil
 }
 
@@ -635,14 +643,52 @@ func rel(root, path string) string {
 	return filepath.ToSlash(r)
 }
 
-func classifyHealth(missing, broken []string) string {
+func classifyDoctorWorkspace(missing, broken []string) string {
 	switch {
+	case isBrokenWorkspace(broken):
+		return "broken"
+	case isPartialWorkspace(missing):
+		return "partial"
 	case len(broken) > 0:
 		return "broken"
 	case len(missing) > 0:
 		return "missing"
 	default:
 		return "current"
+	}
+}
+
+func isPartialWorkspace(missing []string) bool {
+	return contains(missing, ".meta/") || contains(missing, "workspace.json") || contains(missing, "migrations.json")
+}
+
+func isBrokenWorkspace(broken []string) bool {
+	return contains(broken, "workspace.json") || contains(broken, "migrations.json")
+}
+
+func guidanceForWorkspaceStatus(status string) []string {
+	switch status {
+	case "adoptable":
+		return []string{
+			"Run `plan adopt --project .` to create and register the local .plan workspace for this repo.",
+		}
+	case "partial":
+		return []string{
+			"Run `plan adopt --project .` to finish adopting the partial .plan workspace.",
+			"Use `plan update --project .` after adoption to normalize any remaining plan-managed files.",
+		}
+	case "missing":
+		return []string{
+			"Run `plan update --project .` to recreate missing plan-managed surfaces without overwriting user-authored notes.",
+		}
+	case "broken":
+		return []string{
+			"Run `plan update --project .` to repair broken plan-managed metadata and restore a current workspace.",
+		}
+	default:
+		return []string{
+			"Workspace is current. Use `plan update --project .` only after upgrades or when doctor reports drift.",
+		}
 	}
 }
 

--- a/internal/workspace/workspace.go
+++ b/internal/workspace/workspace.go
@@ -24,7 +24,7 @@ type WorkspaceMeta struct {
 
 type MigrationState struct {
 	SchemaVersion int      `json:"schema_version"`
-	Known         []string `json:"known,omitempty"`
+	Known         []string `json:"known"`
 	LastRunAt     string   `json:"last_run_at,omitempty"`
 	Status        string   `json:"status,omitempty"`
 }
@@ -75,8 +75,10 @@ type DoctorReport struct {
 	Initialized     bool     `json:"initialized"`
 	PlanningModel   string   `json:"planning_model,omitempty"`
 	SchemaVersion   int      `json:"schema_version,omitempty"`
+	WorkspaceStatus string   `json:"workspace_status"`
 	MigrationStatus string   `json:"migration_status"`
 	Missing         []string `json:"missing,omitempty"`
+	Broken          []string `json:"broken,omitempty"`
 }
 
 type Manager struct {
@@ -227,8 +229,12 @@ func (m *Manager) EnsureInitialized() (*Info, error) {
 		}
 		return nil, err
 	}
-	if _, err := m.ReadWorkspaceMeta(); err != nil {
+	meta, err := m.ReadWorkspaceMeta()
+	if err != nil {
 		return nil, err
+	}
+	if err := validateWorkspaceMeta(meta); err != nil {
+		return nil, fmt.Errorf("validate workspace metadata: %w", err)
 	}
 	return info, nil
 }
@@ -238,7 +244,11 @@ func (m *Manager) ReadWorkspaceMeta() (*WorkspaceMeta, error) {
 	if err != nil {
 		return nil, err
 	}
-	raw, err := os.ReadFile(info.WorkspaceFile)
+	return readWorkspaceMetaFile(info.WorkspaceFile)
+}
+
+func readWorkspaceMetaFile(path string) (*WorkspaceMeta, error) {
+	raw, err := os.ReadFile(path)
 	if err != nil {
 		return nil, fmt.Errorf("read workspace metadata: %w", err)
 	}
@@ -249,6 +259,26 @@ func (m *Manager) ReadWorkspaceMeta() (*WorkspaceMeta, error) {
 	return &meta, nil
 }
 
+func (m *Manager) ReadMigrationState() (*MigrationState, error) {
+	info, err := m.Resolve()
+	if err != nil {
+		return nil, err
+	}
+	return readMigrationStateFile(info.MigrationsFile)
+}
+
+func readMigrationStateFile(path string) (*MigrationState, error) {
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("read migration state: %w", err)
+	}
+	var state MigrationState
+	if err := json.Unmarshal(raw, &state); err != nil {
+		return nil, fmt.Errorf("parse migration state: %w", err)
+	}
+	return &state, nil
+}
+
 func (m *Manager) Doctor() (*DoctorReport, error) {
 	info, err := m.Resolve()
 	if err != nil {
@@ -257,6 +287,7 @@ func (m *Manager) Doctor() (*DoctorReport, error) {
 	report := &DoctorReport{
 		ProjectDir:      info.ProjectDir,
 		PlanDir:         info.PlanDir,
+		WorkspaceStatus: "not_initialized",
 		MigrationStatus: "not_initialized",
 	}
 	if _, err := os.Stat(info.PlanDir); err != nil {
@@ -267,41 +298,53 @@ func (m *Manager) Doctor() (*DoctorReport, error) {
 	}
 	report.Initialized = true
 
-	for _, path := range []struct {
-		label string
-		path  string
-	}{
-		{"PROJECT.md", info.ProjectFile},
-		{"ROADMAP.md", info.RoadmapFile},
-		{"brainstorms/", info.BrainstormsDir},
-		{"epics/", info.EpicsDir},
-		{"specs/", info.SpecsDir},
-		{"stories/", info.StoriesDir},
-		{"workspace.json", info.WorkspaceFile},
-		{"migrations.json", info.MigrationsFile},
-	} {
-		if _, err := os.Stat(path.path); err != nil {
+	for _, surface := range info.RequiredSurfaces() {
+		if _, err := os.Stat(surface.absPath); err != nil {
 			if os.IsNotExist(err) {
-				report.Missing = append(report.Missing, path.label)
+				report.Missing = append(report.Missing, surface.Label)
 				continue
 			}
 			return nil, err
 		}
 	}
 
-	meta, err := m.ReadWorkspaceMeta()
+	meta, err := readWorkspaceMetaFile(info.WorkspaceFile)
 	if err != nil {
-		report.MigrationStatus = "broken"
-		return report, nil
+		if !contains(report.Missing, "workspace.json") {
+			report.Broken = append(report.Broken, "workspace.json")
+		}
+	} else {
+		report.PlanningModel = meta.PlanningModel
+		report.SchemaVersion = meta.SchemaVersion
+		if err := validateWorkspaceMeta(meta); err != nil {
+			report.Broken = append(report.Broken, "workspace.json")
+		}
 	}
-	report.PlanningModel = meta.PlanningModel
-	report.SchemaVersion = meta.SchemaVersion
 
-	switch {
-	case len(report.Missing) > 0:
-		report.MigrationStatus = "missing"
-	default:
-		report.MigrationStatus = "current"
+	state, err := readMigrationStateFile(info.MigrationsFile)
+	if err != nil {
+		if !contains(report.Missing, "migrations.json") {
+			report.Broken = append(report.Broken, "migrations.json")
+		}
+	} else {
+		report.MigrationStatus = state.Status
+		if err := validateMigrationState(state); err != nil {
+			if !contains(report.Broken, "migrations.json") {
+				report.Broken = append(report.Broken, "migrations.json")
+			}
+		}
+	}
+
+	report.WorkspaceStatus = classifyHealth(report.Missing, report.Broken)
+	if report.MigrationStatus == "" {
+		switch {
+		case contains(report.Broken, "migrations.json"):
+			report.MigrationStatus = "broken"
+		case contains(report.Missing, "migrations.json"):
+			report.MigrationStatus = "missing"
+		default:
+			report.MigrationStatus = "current"
+		}
 	}
 	return report, nil
 }
@@ -319,13 +362,7 @@ func (m *Manager) Update() (*UpdateResult, error) {
 	}
 
 	result := &UpdateResult{Info: info}
-	for _, dir := range []string{
-		info.BrainstormsDir,
-		info.EpicsDir,
-		info.SpecsDir,
-		info.StoriesDir,
-		info.MetaDir,
-	} {
+	for _, dir := range info.directoryPaths() {
 		created, err := ensureDir(dir)
 		if err != nil {
 			return nil, err
@@ -357,20 +394,26 @@ func (m *Manager) Update() (*UpdateResult, error) {
 	} else if created {
 		result.Created = append(result.Created, rel(info.ProjectDir, info.WorkspaceFile))
 	} else {
-		if err := touchWorkspaceMeta(info.WorkspaceFile, now); err != nil {
+		updated, err := reconcileWorkspaceMeta(info.WorkspaceFile, now)
+		if err != nil {
 			return nil, err
 		}
-		result.Updated = append(result.Updated, rel(info.ProjectDir, info.WorkspaceFile))
+		if updated {
+			result.Updated = append(result.Updated, rel(info.ProjectDir, info.WorkspaceFile))
+		}
 	}
 	if created, err := ensureMigrationState(info.MigrationsFile, now); err != nil {
 		return nil, err
 	} else if created {
 		result.Created = append(result.Created, rel(info.ProjectDir, info.MigrationsFile))
 	} else {
-		if err := touchMigrationState(info.MigrationsFile, now); err != nil {
+		updated, err := reconcileMigrationState(info.MigrationsFile, now)
+		if err != nil {
 			return nil, err
 		}
-		result.Updated = append(result.Updated, rel(info.ProjectDir, info.MigrationsFile))
+		if updated {
+			result.Updated = append(result.Updated, rel(info.ProjectDir, info.MigrationsFile))
+		}
 	}
 
 	return result, nil
@@ -410,35 +453,27 @@ func ensureWorkspaceMeta(path, now string) (bool, error) {
 	} else if !os.IsNotExist(err) {
 		return false, err
 	}
-	meta := WorkspaceMeta{
-		SchemaVersion: CurrentSchemaVersion,
-		PlanningModel: PlanningModel,
-		CreatedAt:     now,
-		UpdatedAt:     now,
-	}
+	meta := defaultWorkspaceMeta(now)
 	return true, writeJSON(path, meta)
 }
 
-func touchWorkspaceMeta(path, now string) error {
+func reconcileWorkspaceMeta(path, now string) (bool, error) {
 	raw, err := os.ReadFile(path)
 	if err != nil {
-		return err
+		return false, err
 	}
 	var meta WorkspaceMeta
 	if err := json.Unmarshal(raw, &meta); err != nil {
-		return err
+		return true, writeJSON(path, defaultWorkspaceMeta(now))
 	}
-	if meta.SchemaVersion == 0 {
-		meta.SchemaVersion = CurrentSchemaVersion
+	normalized, changed, err := normalizeWorkspaceMeta(meta, now)
+	if err != nil {
+		return false, err
 	}
-	if meta.PlanningModel == "" {
-		meta.PlanningModel = PlanningModel
+	if !changed {
+		return false, nil
 	}
-	if meta.CreatedAt == "" {
-		meta.CreatedAt = now
-	}
-	meta.UpdatedAt = now
-	return writeJSON(path, meta)
+	return true, writeJSON(path, normalized)
 }
 
 func ensureMigrationState(path, now string) (bool, error) {
@@ -447,33 +482,140 @@ func ensureMigrationState(path, now string) (bool, error) {
 	} else if !os.IsNotExist(err) {
 		return false, err
 	}
-	state := MigrationState{
+	state := defaultMigrationState(now)
+	return true, writeJSON(path, state)
+}
+
+func reconcileMigrationState(path, now string) (bool, error) {
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		return false, err
+	}
+	var state MigrationState
+	if err := json.Unmarshal(raw, &state); err != nil {
+		return true, writeJSON(path, defaultMigrationState(now))
+	}
+	normalized, changed, err := normalizeMigrationState(state, now)
+	if err != nil {
+		return false, err
+	}
+	if !changed {
+		return false, nil
+	}
+	return true, writeJSON(path, normalized)
+}
+
+func defaultWorkspaceMeta(now string) WorkspaceMeta {
+	return WorkspaceMeta{
+		SchemaVersion: CurrentSchemaVersion,
+		PlanningModel: PlanningModel,
+		CreatedAt:     now,
+		UpdatedAt:     now,
+	}
+}
+
+func defaultMigrationState(now string) MigrationState {
+	return MigrationState{
 		SchemaVersion: CurrentSchemaVersion,
 		Known:         []string{},
 		LastRunAt:     now,
 		Status:        "current",
 	}
-	return true, writeJSON(path, state)
 }
 
-func touchMigrationState(path, now string) error {
-	raw, err := os.ReadFile(path)
-	if err != nil {
-		return err
+func normalizeWorkspaceMeta(meta WorkspaceMeta, now string) (WorkspaceMeta, bool, error) {
+	if meta.SchemaVersion > CurrentSchemaVersion {
+		return WorkspaceMeta{}, false, fmt.Errorf("workspace schema version %d is newer than supported version %d", meta.SchemaVersion, CurrentSchemaVersion)
 	}
-	var state MigrationState
-	if err := json.Unmarshal(raw, &state); err != nil {
-		return err
+	if meta.PlanningModel != "" && meta.PlanningModel != PlanningModel {
+		return WorkspaceMeta{}, false, fmt.Errorf("workspace planning model %q is not supported by this build", meta.PlanningModel)
 	}
-	if state.SchemaVersion == 0 {
-		state.SchemaVersion = CurrentSchemaVersion
+
+	normalized := meta
+	changed := false
+	if normalized.SchemaVersion == 0 {
+		normalized.SchemaVersion = CurrentSchemaVersion
+		changed = true
 	}
-	if state.Known == nil {
-		state.Known = []string{}
+	if normalized.PlanningModel == "" {
+		normalized.PlanningModel = PlanningModel
+		changed = true
 	}
-	state.LastRunAt = now
-	state.Status = "current"
-	return writeJSON(path, state)
+	if normalized.CreatedAt == "" {
+		normalized.CreatedAt = now
+		changed = true
+	}
+	if normalized.UpdatedAt == "" {
+		normalized.UpdatedAt = now
+		changed = true
+	}
+	if changed {
+		normalized.UpdatedAt = now
+	}
+	return normalized, changed, nil
+}
+
+func normalizeMigrationState(state MigrationState, now string) (MigrationState, bool, error) {
+	if state.SchemaVersion > CurrentSchemaVersion {
+		return MigrationState{}, false, fmt.Errorf("migration schema version %d is newer than supported version %d", state.SchemaVersion, CurrentSchemaVersion)
+	}
+
+	normalized := state
+	changed := false
+	if normalized.SchemaVersion == 0 {
+		normalized.SchemaVersion = CurrentSchemaVersion
+		changed = true
+	}
+	if normalized.Known == nil {
+		normalized.Known = []string{}
+		changed = true
+	}
+	if normalized.LastRunAt == "" {
+		normalized.LastRunAt = now
+		changed = true
+	}
+	if normalized.Status == "" {
+		normalized.Status = "current"
+		changed = true
+	}
+	if changed {
+		normalized.LastRunAt = now
+	}
+	return normalized, changed, nil
+}
+
+func validateWorkspaceMeta(meta *WorkspaceMeta) error {
+	switch {
+	case meta.SchemaVersion == 0:
+		return fmt.Errorf("schema_version is required")
+	case meta.SchemaVersion > CurrentSchemaVersion:
+		return fmt.Errorf("schema_version %d is newer than supported %d", meta.SchemaVersion, CurrentSchemaVersion)
+	case meta.PlanningModel == "":
+		return fmt.Errorf("planning_model is required")
+	case meta.PlanningModel != PlanningModel:
+		return fmt.Errorf("planning_model %q is not supported", meta.PlanningModel)
+	case meta.CreatedAt == "":
+		return fmt.Errorf("created_at is required")
+	case meta.UpdatedAt == "":
+		return fmt.Errorf("updated_at is required")
+	default:
+		return nil
+	}
+}
+
+func validateMigrationState(state *MigrationState) error {
+	switch {
+	case state.SchemaVersion == 0:
+		return fmt.Errorf("schema_version is required")
+	case state.SchemaVersion > CurrentSchemaVersion:
+		return fmt.Errorf("schema_version %d is newer than supported %d", state.SchemaVersion, CurrentSchemaVersion)
+	case state.LastRunAt == "":
+		return fmt.Errorf("last_run_at is required")
+	case state.Status == "":
+		return fmt.Errorf("status is required")
+	default:
+		return nil
+	}
 }
 
 func writeJSON(path string, v any) error {
@@ -491,4 +633,24 @@ func rel(root, path string) string {
 		return path
 	}
 	return filepath.ToSlash(r)
+}
+
+func classifyHealth(missing, broken []string) string {
+	switch {
+	case len(broken) > 0:
+		return "broken"
+	case len(missing) > 0:
+		return "missing"
+	default:
+		return "current"
+	}
+}
+
+func contains(items []string, target string) bool {
+	for _, item := range items {
+		if item == target {
+			return true
+		}
+	}
+	return false
 }

--- a/internal/workspace/workspace.go
+++ b/internal/workspace/workspace.go
@@ -368,9 +368,20 @@ func (m *Manager) Update() (*UpdateResult, error) {
 		}
 		return nil, err
 	}
+	return m.repairWorkspace(info)
+}
 
+func (m *Manager) Adopt() (*UpdateResult, error) {
+	info, err := m.Resolve()
+	if err != nil {
+		return nil, err
+	}
+	return m.repairWorkspace(info)
+}
+
+func (m *Manager) repairWorkspace(info *Info) (*UpdateResult, error) {
 	result := &UpdateResult{Info: info}
-	for _, dir := range info.directoryPaths() {
+	for _, dir := range append([]string{info.PlanDir}, info.directoryPaths()...) {
 		created, err := ensureDir(dir)
 		if err != nil {
 			return nil, err

--- a/internal/workspace/workspace.go
+++ b/internal/workspace/workspace.go
@@ -29,6 +29,20 @@ type MigrationState struct {
 	Status        string   `json:"status,omitempty"`
 }
 
+type Surface struct {
+	Label string `json:"label"`
+	Path  string `json:"path"`
+	Kind  string `json:"kind"`
+	Type  string `json:"type"`
+
+	absPath string
+}
+
+type Contract struct {
+	UserAuthored []Surface `json:"user_authored"`
+	ToolManaged  []Surface `json:"tool_managed"`
+}
+
 type Info struct {
 	ProjectDir     string
 	ProjectName    string
@@ -101,6 +115,49 @@ func (m *Manager) Resolve() (*Info, error) {
 	}, nil
 }
 
+func (i *Info) Contract() Contract {
+	return Contract{
+		UserAuthored: i.UserAuthoredSurfaces(),
+		ToolManaged:  i.ToolManagedSurfaces(),
+	}
+}
+
+func (i *Info) UserAuthoredSurfaces() []Surface {
+	return []Surface{
+		i.newSurface("PROJECT.md", i.ProjectFile, "user_authored", "file"),
+		i.newSurface("ROADMAP.md", i.RoadmapFile, "user_authored", "file"),
+		i.newSurface("brainstorms/", i.BrainstormsDir, "user_authored", "dir"),
+		i.newSurface("epics/", i.EpicsDir, "user_authored", "dir"),
+		i.newSurface("specs/", i.SpecsDir, "user_authored", "dir"),
+		i.newSurface("stories/", i.StoriesDir, "user_authored", "dir"),
+	}
+}
+
+func (i *Info) ToolManagedSurfaces() []Surface {
+	return []Surface{
+		i.newSurface(".meta/", i.MetaDir, "tool_managed", "dir"),
+		i.newSurface("workspace.json", i.WorkspaceFile, "tool_managed", "file"),
+		i.newSurface("migrations.json", i.MigrationsFile, "tool_managed", "file"),
+	}
+}
+
+func (i *Info) RequiredSurfaces() []Surface {
+	surfaces := make([]Surface, 0, len(i.UserAuthoredSurfaces())+len(i.ToolManagedSurfaces()))
+	surfaces = append(surfaces, i.UserAuthoredSurfaces()...)
+	surfaces = append(surfaces, i.ToolManagedSurfaces()...)
+	return surfaces
+}
+
+func (i *Info) newSurface(label, path, kind, surfaceType string) Surface {
+	return Surface{
+		Label:   label,
+		Path:    rel(i.ProjectDir, path),
+		Kind:    kind,
+		Type:    surfaceType,
+		absPath: path,
+	}
+}
+
 func (m *Manager) Init() (*InitResult, error) {
 	info, err := m.Resolve()
 	if err != nil {
@@ -108,14 +165,7 @@ func (m *Manager) Init() (*InitResult, error) {
 	}
 
 	result := &InitResult{Info: info}
-	for _, dir := range []string{
-		info.PlanDir,
-		info.BrainstormsDir,
-		info.EpicsDir,
-		info.SpecsDir,
-		info.StoriesDir,
-		info.MetaDir,
-	} {
+	for _, dir := range append([]string{info.PlanDir}, info.directoryPaths()...) {
 		created, err := ensureDir(dir)
 		if err != nil {
 			return nil, err
@@ -154,6 +204,16 @@ func (m *Manager) Init() (*InitResult, error) {
 	}
 
 	return result, nil
+}
+
+func (i *Info) directoryPaths() []string {
+	var dirs []string
+	for _, surface := range i.RequiredSurfaces() {
+		if surface.Type == "dir" {
+			dirs = append(dirs, surface.absPath)
+		}
+	}
+	return dirs
 }
 
 func (m *Manager) EnsureInitialized() (*Info, error) {

--- a/internal/workspace/workspace_test.go
+++ b/internal/workspace/workspace_test.go
@@ -72,6 +72,22 @@ func TestWorkspaceContractSeparatesUserAuthoredAndToolManagedSurfaces(t *testing
 	}
 }
 
+func TestDoctorReportsNotInitializedBeforeInit(t *testing.T) {
+	root := t.TempDir()
+	manager := New(root)
+
+	report, err := manager.Doctor()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if report.Initialized {
+		t.Fatalf("expected uninitialized workspace report: %+v", report)
+	}
+	if report.WorkspaceStatus != "not_initialized" || report.MigrationStatus != "not_initialized" {
+		t.Fatalf("unexpected uninitialized report state: %+v", report)
+	}
+}
+
 func TestDoctorReportsCurrentAfterInit(t *testing.T) {
 	root := t.TempDir()
 	manager := New(root)
@@ -188,6 +204,45 @@ func TestUpdateRepairsToolManagedStateWithoutTouchingUserNotes(t *testing.T) {
 	}
 }
 
+func TestUpdateRecreatesMissingScaffoldingWithoutOverwritingExistingNotes(t *testing.T) {
+	root := t.TempDir()
+	manager := New(root)
+	if _, err := manager.Init(); err != nil {
+		t.Fatal(err)
+	}
+
+	projectPath := filepath.Join(root, ".plan", "PROJECT.md")
+	const customProject = "# kept project note\n"
+	if err := os.WriteFile(projectPath, []byte(customProject), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Remove(filepath.Join(root, ".plan", "ROADMAP.md")); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.RemoveAll(filepath.Join(root, ".plan", "stories")); err != nil {
+		t.Fatal(err)
+	}
+
+	result, err := manager.Update()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !contains(result.Created, ".plan/ROADMAP.md") {
+		t.Fatalf("expected roadmap recreation: %+v", result)
+	}
+	if !contains(result.Created, ".plan/stories") {
+		t.Fatalf("expected stories directory recreation: %+v", result)
+	}
+
+	raw, err := os.ReadFile(projectPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(raw) != customProject {
+		t.Fatalf("project note was overwritten:\n%s", raw)
+	}
+}
+
 func TestUpdateIsIdempotentWhenWorkspaceIsCurrent(t *testing.T) {
 	root := t.TempDir()
 	manager := New(root)
@@ -209,5 +264,20 @@ func TestUpdateIsIdempotentWhenWorkspaceIsCurrent(t *testing.T) {
 	}
 	if len(second.Created) != 0 || len(second.Updated) != 0 {
 		t.Fatalf("expected second update to stay idempotent: %+v", second)
+	}
+}
+
+func TestEnsureInitializedRejectsInvalidWorkspaceMetadata(t *testing.T) {
+	root := t.TempDir()
+	manager := New(root)
+	if _, err := manager.Init(); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(root, ".plan", ".meta", "workspace.json"), []byte(`{"schema_version":1}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := manager.EnsureInitialized(); err == nil {
+		t.Fatal("expected invalid workspace metadata to fail initialization check")
 	}
 }

--- a/internal/workspace/workspace_test.go
+++ b/internal/workspace/workspace_test.go
@@ -244,6 +244,77 @@ func TestUpdateRepairsToolManagedStateWithoutTouchingUserNotes(t *testing.T) {
 	}
 }
 
+func TestAdoptCreatesWorkspaceWithoutTouchingRepoFiles(t *testing.T) {
+	root := t.TempDir()
+	manager := New(root)
+
+	readmePath := filepath.Join(root, "README.md")
+	const readme = "# existing repo\n"
+	if err := os.WriteFile(readmePath, []byte(readme), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	result, err := manager.Adopt()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !contains(result.Created, ".plan") || !contains(result.Created, ".plan/PROJECT.md") || !contains(result.Created, ".plan/.meta/workspace.json") {
+		t.Fatalf("expected adopt to create plan workspace surfaces: %+v", result)
+	}
+
+	raw, err := os.ReadFile(readmePath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(raw) != readme {
+		t.Fatalf("expected non-plan repo files to stay untouched:\n%s", raw)
+	}
+
+	report, err := manager.Doctor()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if report.WorkspaceStatus != "current" {
+		t.Fatalf("expected adopted workspace to be current: %+v", report)
+	}
+}
+
+func TestAdoptRepairsPartialWorkspace(t *testing.T) {
+	root := t.TempDir()
+	manager := New(root)
+	if err := os.MkdirAll(filepath.Join(root, ".plan"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	projectPath := filepath.Join(root, ".plan", "PROJECT.md")
+	const customProject = "# preserved project\n"
+	if err := os.WriteFile(projectPath, []byte(customProject), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	result, err := manager.Adopt()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !contains(result.Created, ".plan/.meta/workspace.json") {
+		t.Fatalf("expected adopt to fill missing managed surfaces: %+v", result)
+	}
+	raw, err := os.ReadFile(projectPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(raw) != customProject {
+		t.Fatalf("expected adopt to preserve existing plan notes:\n%s", raw)
+	}
+
+	report, err := manager.Doctor()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if report.WorkspaceStatus != "current" || report.MigrationStatus != "current" {
+		t.Fatalf("expected adopted partial workspace to become current: %+v", report)
+	}
+}
+
 func TestUpdateRecreatesMissingScaffoldingWithoutOverwritingExistingNotes(t *testing.T) {
 	root := t.TempDir()
 	manager := New(root)

--- a/internal/workspace/workspace_test.go
+++ b/internal/workspace/workspace_test.go
@@ -72,8 +72,11 @@ func TestWorkspaceContractSeparatesUserAuthoredAndToolManagedSurfaces(t *testing
 	}
 }
 
-func TestDoctorReportsNotInitializedBeforeInit(t *testing.T) {
+func TestDoctorReportsAdoptableBeforeInit(t *testing.T) {
 	root := t.TempDir()
+	if err := os.WriteFile(filepath.Join(root, "README.md"), []byte("# repo\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
 	manager := New(root)
 
 	report, err := manager.Doctor()
@@ -83,8 +86,11 @@ func TestDoctorReportsNotInitializedBeforeInit(t *testing.T) {
 	if report.Initialized {
 		t.Fatalf("expected uninitialized workspace report: %+v", report)
 	}
-	if report.WorkspaceStatus != "not_initialized" || report.MigrationStatus != "not_initialized" {
-		t.Fatalf("unexpected uninitialized report state: %+v", report)
+	if report.WorkspaceStatus != "adoptable" || report.MigrationStatus != "not_initialized" {
+		t.Fatalf("unexpected adoptable report state: %+v", report)
+	}
+	if !contains(report.Guidance, "Run `plan adopt --project .` to create and register the local .plan workspace for this repo.") {
+		t.Fatalf("expected adopt guidance: %+v", report)
 	}
 }
 
@@ -133,6 +139,37 @@ func TestDoctorReportsMissingWorkspaceSurfaces(t *testing.T) {
 	if report.MigrationStatus != "current" {
 		t.Fatalf("unexpected migration status: %+v", report)
 	}
+	if !contains(report.Guidance, "Run `plan update --project .` to recreate missing plan-managed surfaces without overwriting user-authored notes.") {
+		t.Fatalf("expected missing-workspace guidance: %+v", report)
+	}
+}
+
+func TestDoctorReportsPartialWhenToolManagedSurfacesAreMissing(t *testing.T) {
+	root := t.TempDir()
+	manager := New(root)
+	if _, err := manager.Init(); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Remove(filepath.Join(root, ".plan", ".meta", "workspace.json")); err != nil {
+		t.Fatal(err)
+	}
+
+	report, err := manager.Doctor()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if report.WorkspaceStatus != "partial" {
+		t.Fatalf("unexpected workspace status: %+v", report)
+	}
+	if report.MigrationStatus != "partial" {
+		t.Fatalf("unexpected migration status for partial workspace: %+v", report)
+	}
+	if !contains(report.Missing, "workspace.json") {
+		t.Fatalf("expected missing workspace metadata in report: %+v", report)
+	}
+	if !contains(report.Guidance, "Run `plan adopt --project .` to finish adopting the partial .plan workspace.") {
+		t.Fatalf("expected partial-workspace guidance: %+v", report)
+	}
 }
 
 func TestDoctorReportsBrokenToolManagedState(t *testing.T) {
@@ -154,6 +191,9 @@ func TestDoctorReportsBrokenToolManagedState(t *testing.T) {
 	}
 	if !contains(report.Broken, "workspace.json") {
 		t.Fatalf("expected broken workspace metadata in report: %+v", report)
+	}
+	if !contains(report.Guidance, "Run `plan update --project .` to repair broken plan-managed metadata and restore a current workspace.") {
+		t.Fatalf("expected broken-workspace guidance: %+v", report)
 	}
 }
 

--- a/internal/workspace/workspace_test.go
+++ b/internal/workspace/workspace_test.go
@@ -315,6 +315,85 @@ func TestAdoptRepairsPartialWorkspace(t *testing.T) {
 	}
 }
 
+func TestMigrationStateRecordsMeaningfulRepairDetails(t *testing.T) {
+	root := t.TempDir()
+	manager := New(root)
+
+	if _, err := manager.Adopt(); err != nil {
+		t.Fatal(err)
+	}
+	state, err := manager.ReadMigrationState()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if state.LastOperation != "adopt" || len(state.History) != 1 {
+		t.Fatalf("expected adopt run to be recorded: %+v", state)
+	}
+	if !contains(state.LastCreated, ".plan/PROJECT.md") {
+		t.Fatalf("expected adopt details to include created workspace files: %+v", state)
+	}
+
+	if err := os.Remove(filepath.Join(root, ".plan", "ROADMAP.md")); err != nil {
+		t.Fatal(err)
+	}
+	result, err := manager.Update()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !contains(result.Created, ".plan/ROADMAP.md") {
+		t.Fatalf("expected update to repair roadmap: %+v", result)
+	}
+
+	state, err = manager.ReadMigrationState()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if state.LastOperation != "update" || len(state.History) != 2 {
+		t.Fatalf("expected update repair to append migration history: %+v", state)
+	}
+	last := state.History[len(state.History)-1]
+	if last.Operation != "update" || !contains(last.Created, ".plan/ROADMAP.md") {
+		t.Fatalf("expected update run details in migration history: %+v", last)
+	}
+}
+
+func TestRepeatedAdoptAndUpdateRemainIdempotent(t *testing.T) {
+	root := t.TempDir()
+	manager := New(root)
+
+	if _, err := manager.Adopt(); err != nil {
+		t.Fatal(err)
+	}
+	state, err := manager.ReadMigrationState()
+	if err != nil {
+		t.Fatal(err)
+	}
+	initialHistory := len(state.History)
+
+	adoptAgain, err := manager.Adopt()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(adoptAgain.Created) != 0 || len(adoptAgain.Updated) != 0 {
+		t.Fatalf("expected repeated adopt to stay idempotent: %+v", adoptAgain)
+	}
+	updateAgain, err := manager.Update()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(updateAgain.Created) != 0 || len(updateAgain.Updated) != 0 {
+		t.Fatalf("expected repeated update to stay idempotent: %+v", updateAgain)
+	}
+
+	state, err = manager.ReadMigrationState()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(state.History) != initialHistory {
+		t.Fatalf("expected no-op adopt/update to avoid mutation churn: %+v", state)
+	}
+}
+
 func TestUpdateRecreatesMissingScaffoldingWithoutOverwritingExistingNotes(t *testing.T) {
 	root := t.TempDir()
 	manager := New(root)

--- a/internal/workspace/workspace_test.go
+++ b/internal/workspace/workspace_test.go
@@ -3,6 +3,7 @@ package workspace
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 )
 
@@ -19,6 +20,11 @@ func TestInitCreatesPlanWorkspace(t *testing.T) {
 	}
 
 	for _, path := range []string{
+		filepath.Join(root, ".plan", "brainstorms"),
+		filepath.Join(root, ".plan", "epics"),
+		filepath.Join(root, ".plan", "specs"),
+		filepath.Join(root, ".plan", "stories"),
+		filepath.Join(root, ".plan", ".meta"),
 		filepath.Join(root, ".plan", "PROJECT.md"),
 		filepath.Join(root, ".plan", "ROADMAP.md"),
 		filepath.Join(root, ".plan", ".meta", "workspace.json"),
@@ -26,6 +32,42 @@ func TestInitCreatesPlanWorkspace(t *testing.T) {
 	} {
 		if _, err := os.Stat(path); err != nil {
 			t.Fatalf("expected %s: %v", path, err)
+		}
+	}
+}
+
+func TestWorkspaceContractSeparatesUserAuthoredAndToolManagedSurfaces(t *testing.T) {
+	root := t.TempDir()
+	manager := New(root)
+
+	info, err := manager.Resolve()
+	if err != nil {
+		t.Fatal(err)
+	}
+	contract := info.Contract()
+
+	if len(contract.UserAuthored) != 6 {
+		t.Fatalf("unexpected user-authored surface count: %d", len(contract.UserAuthored))
+	}
+	if len(contract.ToolManaged) != 3 {
+		t.Fatalf("unexpected tool-managed surface count: %d", len(contract.ToolManaged))
+	}
+
+	for _, surface := range contract.UserAuthored {
+		if surface.Kind != "user_authored" {
+			t.Fatalf("unexpected user-authored surface kind: %+v", surface)
+		}
+		if !strings.HasPrefix(surface.Path, ".plan/") {
+			t.Fatalf("unexpected user-authored surface path: %+v", surface)
+		}
+	}
+
+	for _, surface := range contract.ToolManaged {
+		if surface.Kind != "tool_managed" {
+			t.Fatalf("unexpected tool-managed surface kind: %+v", surface)
+		}
+		if !strings.HasPrefix(surface.Path, ".plan/") {
+			t.Fatalf("unexpected tool-managed surface path: %+v", surface)
 		}
 	}
 }

--- a/internal/workspace/workspace_test.go
+++ b/internal/workspace/workspace_test.go
@@ -93,3 +93,121 @@ func TestDoctorReportsCurrentAfterInit(t *testing.T) {
 		t.Fatalf("unexpected planning model: %+v", report)
 	}
 }
+
+func TestDoctorReportsMissingWorkspaceSurfaces(t *testing.T) {
+	root := t.TempDir()
+	manager := New(root)
+	if _, err := manager.Init(); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Remove(filepath.Join(root, ".plan", "ROADMAP.md")); err != nil {
+		t.Fatal(err)
+	}
+
+	report, err := manager.Doctor()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if report.WorkspaceStatus != "missing" {
+		t.Fatalf("unexpected workspace status: %+v", report)
+	}
+	if !contains(report.Missing, "ROADMAP.md") {
+		t.Fatalf("expected missing roadmap in report: %+v", report)
+	}
+	if report.MigrationStatus != "current" {
+		t.Fatalf("unexpected migration status: %+v", report)
+	}
+}
+
+func TestDoctorReportsBrokenToolManagedState(t *testing.T) {
+	root := t.TempDir()
+	manager := New(root)
+	if _, err := manager.Init(); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(root, ".plan", ".meta", "workspace.json"), []byte("{broken"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	report, err := manager.Doctor()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if report.WorkspaceStatus != "broken" {
+		t.Fatalf("unexpected workspace status: %+v", report)
+	}
+	if !contains(report.Broken, "workspace.json") {
+		t.Fatalf("expected broken workspace metadata in report: %+v", report)
+	}
+}
+
+func TestUpdateRepairsToolManagedStateWithoutTouchingUserNotes(t *testing.T) {
+	root := t.TempDir()
+	manager := New(root)
+	if _, err := manager.Init(); err != nil {
+		t.Fatal(err)
+	}
+
+	projectPath := filepath.Join(root, ".plan", "PROJECT.md")
+	const customProject = "# custom project\n"
+	if err := os.WriteFile(projectPath, []byte(customProject), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(root, ".plan", ".meta", "workspace.json"), []byte("{broken"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Remove(filepath.Join(root, ".plan", ".meta", "migrations.json")); err != nil {
+		t.Fatal(err)
+	}
+
+	result, err := manager.Update()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !contains(result.Updated, ".plan/.meta/workspace.json") {
+		t.Fatalf("expected workspace metadata repair: %+v", result)
+	}
+	if !contains(result.Created, ".plan/.meta/migrations.json") {
+		t.Fatalf("expected migration state recreation: %+v", result)
+	}
+
+	raw, err := os.ReadFile(projectPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(raw) != customProject {
+		t.Fatalf("project note was modified:\n%s", raw)
+	}
+
+	report, err := manager.Doctor()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if report.WorkspaceStatus != "current" || report.MigrationStatus != "current" {
+		t.Fatalf("expected repaired workspace to be current: %+v", report)
+	}
+}
+
+func TestUpdateIsIdempotentWhenWorkspaceIsCurrent(t *testing.T) {
+	root := t.TempDir()
+	manager := New(root)
+	if _, err := manager.Init(); err != nil {
+		t.Fatal(err)
+	}
+
+	first, err := manager.Update()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(first.Created) != 0 || len(first.Updated) != 0 {
+		t.Fatalf("expected no changes for current workspace: %+v", first)
+	}
+
+	second, err := manager.Update()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(second.Created) != 0 || len(second.Updated) != 0 {
+		t.Fatalf("expected second update to stay idempotent: %+v", second)
+	}
+}

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -15,6 +15,10 @@ die() {
   exit 1
 }
 
+log() {
+  printf 'plan install: %s\n' "$1"
+}
+
 need_cmd() {
   command -v "$1" >/dev/null 2>&1
 }
@@ -66,6 +70,12 @@ fetch() {
 }
 
 latest_version() {
+  version="$(latest_version_from_redirect)"
+  if [ -n "${version}" ]; then
+    printf '%s\n' "${version}"
+    return
+  fi
+
   if need_cmd curl; then
     RESPONSE="$(curl -fsSL "${API_BASE}/repos/${OWNER}/${REPO}/releases/latest" 2>/dev/null || true)"
   elif need_cmd wget; then
@@ -76,6 +86,27 @@ latest_version() {
   printf '%s\n' "${RESPONSE}" |
     sed -n 's/.*"tag_name"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p' |
     head -n 1
+}
+
+latest_version_from_redirect() {
+  RELEASES_LATEST="https://github.com/${OWNER}/${REPO}/releases/latest"
+  if need_cmd curl; then
+    EFFECTIVE_URL="$(curl -fsSL -o /dev/null -w '%{url_effective}' "${RELEASES_LATEST}" 2>/dev/null || true)"
+    printf '%s\n' "${EFFECTIVE_URL}" |
+      sed -n 's#.*/tag/\(v[0-9][^/]*\)/\{0,1\}$#\1#p' |
+      head -n 1
+    return
+  fi
+  if need_cmd wget; then
+    RESPONSE="$(wget -S --spider "${RELEASES_LATEST}" 2>&1 || true)"
+    printf '%s\n' "${RESPONSE}" |
+      awk '/^  Location: / { print $2 }' |
+      tr -d '\r' |
+      sed -n 's#.*/tag/\(v[0-9][^/]*\)/\{0,1\}$#\1#p' |
+      tail -n 1
+    return
+  fi
+  die "need curl or wget"
 }
 
 detect_os() {
@@ -134,7 +165,7 @@ install_from_source_main() {
     chmod 0755 "${INSTALL_DIR}/plan"
   fi
 
-  printf 'Installed to %s/plan by building the current main branch source\n' "${INSTALL_DIR}"
+  log "installed to ${INSTALL_DIR}/plan by building the current main branch source"
   refresh_global_skills
 }
 
@@ -143,6 +174,7 @@ TMPDIR="$(mktemp -d)"
 trap 'rm -rf "${TMPDIR}"' EXIT INT TERM
 
 if [ -z "${VERSION}" ]; then
+  log "no published release found; falling back to a source build from main"
   install_from_source_main
   exit 0
 fi
@@ -157,7 +189,7 @@ ARCHIVE_PATH="${TMPDIR}/${ARCHIVE}"
 CHECKSUMS_PATH="${TMPDIR}/${CHECKSUMS}"
 BIN_PATH="${TMPDIR}/plan"
 
-printf 'Installing plan %s for %s/%s\n' "${VERSION}" "${OS}" "${ARCH}"
+log "installing ${VERSION} for ${OS}/${ARCH}"
 fetch "${ARCHIVE_URL}" "${ARCHIVE_PATH}"
 fetch "${CHECKSUMS_URL}" "${CHECKSUMS_PATH}"
 
@@ -177,5 +209,5 @@ else
   chmod 0755 "${INSTALL_DIR}/plan"
 fi
 
-printf 'Installed to %s/plan\n' "${INSTALL_DIR}"
+log "installed to ${INSTALL_DIR}/plan"
 refresh_global_skills

--- a/skills/plan/SKILL.md
+++ b/skills/plan/SKILL.md
@@ -1,0 +1,63 @@
+---
+name: plan
+description: Use this skill when working with a project-local `plan` workspace that keeps planning material under `.plan/`. Focus on brainstorms, epics, specs, stories, and roadmap updates.
+user-invocable: true
+args:
+  - name: task
+    description: The planning task to perform.
+    required: false
+---
+
+# Plan
+
+Use `plan` as the primary interface for repo-local planning.
+
+## Goals
+
+- keep planning local to the repo
+- treat specs as the canonical execution contract
+- create stories only after spec approval
+- keep stories execution-ready and verification-aware
+- avoid creating sidecar planning systems outside `.plan/`
+
+## Startup
+
+When a repo uses `plan`:
+
+1. Read `.plan/PROJECT.md`.
+2. Read `.plan/ROADMAP.md`.
+3. Read the epic, spec, and story notes relevant to the task.
+4. Use the `plan` CLI for durable planning changes.
+
+## Commands
+
+- `plan init --project .`
+- `plan adopt --project .`
+- `plan doctor --project .`
+- `plan update --project .`
+- `plan check --project .`
+- `plan brainstorm start --project . "<topic>"`
+- `plan brainstorm idea --project . <brainstorm-slug> --body "<idea>"`
+- `plan epic create --project . "<title>"`
+- `plan epic promote --project . <brainstorm-slug>`
+- `plan spec show --project . <epic-slug>`
+- `plan spec status --project . <epic-slug> --set approved`
+- `plan story create --project . <epic-slug> "<title>"`
+- `plan story update --project . <story-slug> --status in_progress`
+- `plan roadmap show --project .`
+- `plan roadmap versions --project . --version v2`
+- `plan ready --project .`
+- `plan status --project .`
+- `plan status --project . --version v3 --story-status todo`
+- `plan story list --project . --version v3`
+- `plan import brain inspect --workspace ../brain`
+- `plan import brain apply --project . --workspace ../brain --epic planning-and-brainstorming-ux`
+
+## Rules
+
+- Brainstorms are discovery material, not the canonical hierarchy.
+- Canonical hierarchy is `Epic -> Spec -> Story`.
+- Keep roadmap lightweight.
+- Keep the simple default path first. Reach for filters, ready-work views, and Brain imports only when the repo size justifies them.
+- Do not add tasks beneath stories as first-class objects unless the project explicitly asks for that system.
+- Keep planning separate from memory, retrieval, or context management systems.

--- a/skills/plan/agents/openai.yaml
+++ b/skills/plan/agents/openai.yaml
@@ -1,0 +1,2 @@
+name: plan
+description: Local-first planning guidance for repos using the `plan` CLI.

--- a/testdata/brain-workspace/.brain/brainstorms/mempalace-inspired-brain-improvements.md
+++ b/testdata/brain-workspace/.brain/brainstorms/mempalace-inspired-brain-improvements.md
@@ -1,0 +1,17 @@
+---
+brainstorm_status: active
+created_at: "2026-04-01T00:00:00Z"
+project: brain
+title: Mempalace Inspired Brain Improvements
+type: brainstorm
+updated_at: "2026-04-01T00:00:00Z"
+---
+
+## Goal
+
+Capture planning improvements worth porting into `plan`.
+
+## Ideas
+
+- Make brainstorming promotion cleaner.
+- Tighten the epic to spec to story loop.

--- a/testdata/brain-workspace/.brain/planning/epics/planning-and-brainstorming-ux.md
+++ b/testdata/brain-workspace/.brain/planning/epics/planning-and-brainstorming-ux.md
@@ -1,0 +1,12 @@
+---
+created_at: "2026-04-01T00:00:00Z"
+project: brain
+spec: planning-and-brainstorming-ux
+title: Planning And Brainstorming UX
+type: epic
+updated_at: "2026-04-01T00:00:00Z"
+---
+
+## Outcome
+
+Planning workflows should be simple to start and easy to deepen.

--- a/testdata/brain-workspace/.brain/planning/specs/planning-and-brainstorming-ux.md
+++ b/testdata/brain-workspace/.brain/planning/specs/planning-and-brainstorming-ux.md
@@ -1,0 +1,18 @@
+---
+created_at: "2026-04-01T00:00:00Z"
+epic: planning-and-brainstorming-ux
+project: brain
+status: approved
+title: Planning And Brainstorming UX
+type: spec
+updated_at: "2026-04-01T00:00:00Z"
+---
+
+## Summary
+
+Define the planning workflow artifacts and the transitions between them.
+
+## Acceptance
+
+- Brainstorms can seed epics.
+- Specs are the approval gate before story work.

--- a/testdata/brain-workspace/.brain/planning/stories/add-session-aware-memory-distillation.md
+++ b/testdata/brain-workspace/.brain/planning/stories/add-session-aware-memory-distillation.md
@@ -1,0 +1,19 @@
+---
+created_at: "2026-04-01T00:00:00Z"
+epic: planning-and-brainstorming-ux
+project: brain
+spec: planning-and-brainstorming-ux
+status: todo
+title: Add Session Aware Memory Distillation
+type: story
+updated_at: "2026-04-01T00:00:00Z"
+---
+
+## Outcome
+
+Imported stories should carry enough context to review and normalize them locally.
+
+## Verification
+
+- Import succeeds.
+- Provenance stays visible in the destination story.


### PR DESCRIPTION
This replaces #1 with a normal review branch so the PR only shows pull-request CI checks. The previous PR used main as the head branch, which caused push release checks from main to appear in the PR check rollup.

## Summary

- review the complete v1-v3 implementation from a stable branch snapshot
- keep PR checks limited to the CI pull-request workflow
- preserve the full implementation diff against review/v1-v3-baseline

## Verification

- go test ./...
- go build ./...
- env GOOS=windows GOARCH=amd64 go build ./...
