### PR TITLE
feat: complete v5 shaping and eval loop

### DIFF
--- a/.plan/ROADMAP.md
+++ b/.plan/ROADMAP.md
@@ -14,10 +14,10 @@ considered.
 Goal: Reset the product story, simplify the CLI, and ship the first two
 high-leverage shaping passes.
 
-- [ ] Product Reset and Docs Convergence
-- [ ] CLI Surface Simplification
-- [ ] Guided Brainstorm Refinement
-- [ ] Spec Analysis Foundation
+- [x] Product Reset and Docs Convergence
+- [x] CLI Surface Simplification
+- [x] Guided Brainstorm Refinement
+- [x] Spec Analysis Foundation
 
 Summary:
 - converge README, product docs, roadmap, project notes, templates, and skill text
@@ -30,16 +30,20 @@ Summary:
 Goal: Make prompt quality, shaping passes, and benchmarked improvements
 first-class product work.
 
-- [ ] Model-Aware Planning Skills
-- [ ] Benchmark Fixtures and Rubric Evals
-- [ ] Brainstorm Challenge
-- [ ] Epic Shaping
-- [ ] Spec Checklist Profiles
+- [x] Model-Aware Planning Skills
+- [x] Benchmark Fixtures and Rubric Evals
+- [x] Brainstorm Challenge
+- [x] Epic Shaping
+- [x] Spec Checklist Profiles
 
 Summary:
 - ship model-aware planning skill guidance
 - benchmark prompt and workflow improvements before expanding the surface
 - add the next shaping passes around brainstorms, epics, and specs
+
+Current focus:
+- move into `v6` story slicing and execution-readiness work
+- keep the default path simple while the optional shaping passes deepen
 
 ## v6: Story Slicing and Execution Readiness
 

--- a/.plan/epics/benchmark-fixtures-and-rubric-evals.md
+++ b/.plan/epics/benchmark-fixtures-and-rubric-evals.md
@@ -1,0 +1,57 @@
+---
+created_at: "2026-04-17T20:19:38Z"
+project: plan
+slug: benchmark-fixtures-and-rubric-evals
+spec: benchmark-fixtures-and-rubric-evals
+title: Benchmark Fixtures and Rubric Evals
+type: epic
+updated_at: "2026-04-17T20:19:38Z"
+---
+
+# Benchmark Fixtures and Rubric Evals
+
+Created: 2026-04-17T20:19:38Z
+
+## Outcome
+
+Add a maintainable benchmark and rubric workflow that lets `plan` evaluate
+whether new shaping passes actually improve plan quality before more surface is
+added.
+
+## Why Now
+
+The product reset explicitly says prompt and workflow changes should be proven,
+not assumed. Without fixtures and rubrics, `v5` risks growing based on taste
+instead of measured planning quality.
+
+## Scope Boundary
+
+- benchmark fixtures for realistic planning scenarios
+- rubric categories aligned with the product thesis
+- a deterministic local evaluation harness for maintainers
+- docs and tests that keep the eval loop usable
+
+Not in scope:
+
+- remote eval services
+- leaderboard or hosted dashboards
+- user-facing scoring UIs
+
+## Spec
+
+- [Draft Spec](../specs/benchmark-fixtures-and-rubric-evals.md)
+
+## Resources
+
+- [Product Direction](../PRODUCT.md)
+- [Roadmap](../ROADMAP.md)
+
+## Progress
+
+- Target version: `v5`
+- Status: planned
+
+## Notes
+
+This epic protects the product from drifting back toward power-first feature
+work without evidence that the shaping loop is improving.

--- a/.plan/epics/brainstorm-challenge.md
+++ b/.plan/epics/brainstorm-challenge.md
@@ -1,0 +1,56 @@
+---
+created_at: "2026-04-17T20:19:38Z"
+project: plan
+slug: brainstorm-challenge
+spec: brainstorm-challenge
+title: Brainstorm Challenge
+type: epic
+updated_at: "2026-04-17T20:19:38Z"
+---
+
+# Brainstorm Challenge
+
+Created: 2026-04-17T20:19:38Z
+
+## Outcome
+
+Add a durable brainstorm challenge pass that pressure-tests ideas before they
+harden into epics and specs.
+
+## Why Now
+
+`plan brainstorm refine` reduces ambiguity, but it does not yet push on risks,
+overengineering, rabbit holes, or explicit no-gos. That leaves too much weak
+shaping work to happen informally.
+
+## Scope Boundary
+
+- challenge sections in brainstorm notes
+- an interactive `plan brainstorm challenge` pass
+- resumable updates and idempotent note writes
+- tests for the new challenge loop
+
+Not in scope:
+
+- automatic promotion to epics
+- AI-provider-specific network calls
+- new artifact types outside brainstorm notes
+
+## Spec
+
+- [Draft Spec](../specs/brainstorm-challenge.md)
+
+## Resources
+
+- [Product Direction](../PRODUCT.md)
+- [Roadmap](../ROADMAP.md)
+
+## Progress
+
+- Target version: `v5`
+- Status: planned
+
+## Notes
+
+The goal is to make shaping more adversarial in a useful way before teams invest
+in specs and execution.

--- a/.plan/epics/epic-shaping.md
+++ b/.plan/epics/epic-shaping.md
@@ -1,0 +1,54 @@
+---
+created_at: "2026-04-17T20:19:39Z"
+project: plan
+slug: epic-shaping
+spec: epic-shaping
+title: Epic Shaping
+type: epic
+updated_at: "2026-04-17T20:19:39Z"
+---
+
+# Epic Shaping
+
+Created: 2026-04-17T20:19:39Z
+
+## Outcome
+
+Make epics behave like real shaped bets with appetite, outcome, scope boundary,
+explicit out-of-scope decisions, and a success signal.
+
+## Why Now
+
+The current epic note captures a title and broad scope, but it does not yet
+support the stronger shaping language that the new product direction requires.
+
+## Scope Boundary
+
+- `## Shape` support in epic notes
+- an `epic shape` command that updates those sections safely
+- tests and checks that keep shaped epic output stable
+
+Not in scope:
+
+- execution orchestration
+- roadmap portfolio math
+- replacing specs as the canonical contract
+
+## Spec
+
+- [Draft Spec](../specs/epic-shaping.md)
+
+## Resources
+
+- [Product Direction](../PRODUCT.md)
+- [Roadmap](../ROADMAP.md)
+
+## Progress
+
+- Target version: `v5`
+- Status: planned
+
+## Notes
+
+Epic shaping should strengthen the boundary between brainstorm discovery and
+spec execution without introducing new hierarchy levels.

--- a/.plan/epics/model-aware-planning-skills.md
+++ b/.plan/epics/model-aware-planning-skills.md
@@ -1,0 +1,57 @@
+---
+created_at: "2026-04-17T20:19:38Z"
+project: plan
+slug: model-aware-planning-skills
+spec: model-aware-planning-skills
+title: Model-Aware Planning Skills
+type: epic
+updated_at: "2026-04-17T20:19:38Z"
+---
+
+# Model-Aware Planning Skills
+
+Created: 2026-04-17T20:19:38Z
+
+## Outcome
+
+Ship a stronger installed `plan` skill bundle that steers GPT-style and
+reasoning-heavy models differently while preserving the same local-first
+planning contract.
+
+## Why Now
+
+The repo now has the first refinement and analysis passes, but the installed
+skill still behaves like a thin generic wrapper. `v5` should make planning
+guidance itself a product surface instead of relying on note templates alone.
+
+## Scope Boundary
+
+- model-family guidance in the bundled skill
+- explicit planning passes and completion rules
+- examples and rubrics that match `plan`'s artifact model
+- verification that the shipped skill text matches the new product story
+
+Not in scope:
+
+- hosted prompt orchestration
+- model routing outside the skill bundle
+- cloud memory or context systems
+
+## Spec
+
+- [Draft Spec](../specs/model-aware-planning-skills.md)
+
+## Resources
+
+- [Product Direction](../PRODUCT.md)
+- [Roadmap](../ROADMAP.md)
+
+## Progress
+
+- Target version: `v5`
+- Status: planned
+
+## Notes
+
+This epic turns prompt quality into a first-class part of the product rather
+than an afterthought bolted onto markdown templates.

--- a/.plan/epics/spec-checklist-profiles.md
+++ b/.plan/epics/spec-checklist-profiles.md
@@ -1,0 +1,56 @@
+---
+created_at: "2026-04-17T20:19:39Z"
+project: plan
+slug: spec-checklist-profiles
+spec: spec-checklist-profiles
+title: Spec Checklist Profiles
+type: epic
+updated_at: "2026-04-17T20:19:39Z"
+---
+
+# Spec Checklist Profiles
+
+Created: 2026-04-17T20:19:39Z
+
+## Outcome
+
+Add reusable spec checklist profiles that catch domain-specific planning gaps
+without rewriting the canonical spec sections.
+
+## Why Now
+
+`plan spec analyze` gives one general diagnostic pass. `v5` needs a second,
+profile-driven pass that helps users review UI flows, integrations, and
+migrations with more tailored questions.
+
+## Scope Boundary
+
+- `## Checklist` support in spec notes
+- a `plan spec checklist` command with named profiles
+- blocking versus advisory findings where appropriate
+- docs and tests for stable checklist behavior
+
+Not in scope:
+
+- code generation
+- organization-specific checklist registries
+- auto-approval of specs
+
+## Spec
+
+- [Draft Spec](../specs/spec-checklist-profiles.md)
+
+## Resources
+
+- [Product Direction](../PRODUCT.md)
+- [Roadmap](../ROADMAP.md)
+
+## Progress
+
+- Target version: `v5`
+- Status: planned
+
+## Notes
+
+Checklist profiles should deepen planning rigor only when users ask for the
+extra pass.

--- a/.plan/specs/benchmark-fixtures-and-rubric-evals.md
+++ b/.plan/specs/benchmark-fixtures-and-rubric-evals.md
@@ -1,0 +1,110 @@
+---
+created_at: "2026-04-17T20:19:38Z"
+epic: benchmark-fixtures-and-rubric-evals
+project: plan
+slug: benchmark-fixtures-and-rubric-evals
+status: done
+target_version: v5
+title: Benchmark Fixtures and Rubric Evals Spec
+type: spec
+updated_at: "2026-04-17T20:34:02Z"
+---
+
+# Benchmark Fixtures and Rubric Evals Spec
+
+Created: 2026-04-17T20:19:38Z
+
+## Why
+
+The roadmap reset says new shaping and prompt work should prove quality gains
+before more complexity is added.
+
+## Problem
+
+Without benchmark fixtures and a rubric harness, `plan` has no durable way to
+measure whether new guidance or workflows improve clarity and executability.
+
+## Goals
+
+- add realistic planning benchmark fixtures to the repo
+- define rubric categories that match the product thesis
+- provide a deterministic local maintainer evaluation harness
+- document how to run and interpret the evaluation loop
+
+## Non-Goals
+
+- hosted eval infrastructure
+- auto-tuning prompts via remote services
+- scoring features visible to end users
+
+## Constraints
+
+- fixtures should be easy to inspect and update in git
+- rubric categories should stay stable across minor iterations
+- evaluation output should be deterministic and scriptable
+- the harness must not require network access
+
+## Solution Shape
+
+- add benchmark fixtures under repo-owned testdata
+- implement a small rubric/eval package that scores fixtures and responses
+- expose the workflow through tests and maintainer docs first
+- keep the harness simple enough to extend in later versions
+
+## Flows
+
+1. Maintainer runs the eval workflow locally or in CI.
+2. The harness loads fixtures and rubric expectations.
+3. Results show pass/fail or score deltas for the planned quality categories.
+4. Maintainer uses the results to judge whether a new pass should stick.
+
+## Data / Interfaces
+
+- benchmark fixture files in `testdata/`
+- rubric/eval code under `internal/`
+- maintainer docs for running the benchmark loop
+
+## Risks / Open Questions
+
+- how much of the future scoring loop should be implemented now versus staged
+  behind helpers
+- how to keep fixtures realistic without creating heavy maintenance cost
+
+## Rollout
+
+- land the fixture format and baseline rubric harness in `v5`
+- use tests as the first maintainer entry point
+- only widen the interface after the local workflow proves useful
+
+## Verification
+
+- fixtures load deterministically in tests
+- rubric scores are reproducible for the same input
+- maintainer docs describe the evaluation loop accurately
+
+## Story Breakdown
+
+- [x] [Add planning benchmark fixtures](../stories/add-planning-benchmark-fixtures.md)
+- [x] [Implement rubric evaluation harness](../stories/implement-rubric-evaluation-harness.md)
+- [x] [Document and verify the maintainer eval workflow](../stories/document-and-verify-the-maintainer-eval-workflow.md)
+
+## Analysis
+
+### Missing Constraints
+
+### Success Criteria Gaps
+
+### Hidden Dependencies
+
+### Risk Gaps
+
+### What/Why vs How Leakage
+
+### Recommended Revisions
+
+## Resources
+
+- [Epic](../epics/benchmark-fixtures-and-rubric-evals.md)
+- [Product Direction](../PRODUCT.md)
+
+## Notes

--- a/.plan/specs/brainstorm-challenge.md
+++ b/.plan/specs/brainstorm-challenge.md
@@ -1,0 +1,110 @@
+---
+created_at: "2026-04-17T20:19:38Z"
+epic: brainstorm-challenge
+project: plan
+slug: brainstorm-challenge
+status: done
+target_version: v5
+title: Brainstorm Challenge Spec
+type: spec
+updated_at: "2026-04-17T20:34:02Z"
+---
+
+# Brainstorm Challenge Spec
+
+Created: 2026-04-17T20:19:38Z
+
+## Why
+
+Refinement makes brainstorms clearer, but it does not yet challenge them.
+
+## Problem
+
+Users can still promote brainstorms into epics without a durable pass that
+captures rabbit holes, no-gos, assumptions, or simpler alternatives.
+
+## Goals
+
+- add a durable `## Challenge` section to brainstorm notes
+- ship `plan brainstorm challenge`
+- keep challenge passes resumable and idempotent
+- make the output useful before epic promotion
+
+## Non-Goals
+
+- automatic rejection of brainstorms
+- remote AI-provider integrations
+- replacing the lighter-weight brainstorm idea capture flow
+
+## Constraints
+
+- brainstorm notes remain the only durable artifact for this pass
+- challenge updates should not rewrite canonical brainstorm content
+- the command should work well in an interactive TTY loop
+- reruns should resume from what is still missing
+
+## Solution Shape
+
+- extend the brainstorm template with a fixed `## Challenge` section
+- add a command that collects challenge data in clustered prompts
+- persist after each cluster using the existing note update primitives
+- keep the output simple markdown with no extra workflow state
+
+## Flows
+
+1. User starts or refines a brainstorm.
+2. User runs `plan brainstorm challenge <brainstorm-slug>`.
+3. `plan` prompts for rabbit holes, no-gos, assumptions, overengineering, and a
+   simpler alternative.
+4. The brainstorm note is updated after each cluster and can be resumed later.
+
+## Data / Interfaces
+
+- brainstorm template additions
+- a `ChallengeInput` shape in planning code
+- the `plan brainstorm challenge` command
+
+## Risks / Open Questions
+
+- how to keep the prompt loop useful without becoming too ceremonial
+- whether some sections should allow empty answers without blocking completion
+
+## Rollout
+
+- land the note schema and command together
+- verify reruns and partial updates in tests
+- keep the pass optional but easy to discover next to `refine`
+
+## Verification
+
+- new brainstorms include the `## Challenge` headings
+- `plan brainstorm challenge` updates only the challenge section
+- reruns preserve earlier answers and prompt only for missing fields where
+  possible
+
+## Story Breakdown
+
+- [x] [Add brainstorm challenge note schema](../stories/add-brainstorm-challenge-note-schema.md)
+- [x] [Implement brainstorm challenge command flow](../stories/implement-brainstorm-challenge-command-flow.md)
+- [x] [Add brainstorm challenge tests and resume coverage](../stories/add-brainstorm-challenge-tests-and-resume-coverage.md)
+
+## Analysis
+
+### Missing Constraints
+
+### Success Criteria Gaps
+
+### Hidden Dependencies
+
+### Risk Gaps
+
+### What/Why vs How Leakage
+
+### Recommended Revisions
+
+## Resources
+
+- [Epic](../epics/brainstorm-challenge.md)
+- [Product Direction](../PRODUCT.md)
+
+## Notes

--- a/.plan/specs/epic-shaping.md
+++ b/.plan/specs/epic-shaping.md
@@ -1,0 +1,111 @@
+---
+created_at: "2026-04-17T20:19:39Z"
+epic: epic-shaping
+project: plan
+slug: epic-shaping
+status: done
+target_version: v5
+title: Epic Shaping Spec
+type: spec
+updated_at: "2026-04-17T20:34:02Z"
+---
+
+# Epic Shaping Spec
+
+Created: 2026-04-17T20:19:39Z
+
+## Why
+
+Epics should be more than named containers. They should capture the shaped bet
+that makes the later spec stronger.
+
+## Problem
+
+The current epic model lacks appetite, explicit out-of-scope decisions, and a
+clear success signal, which leaves a gap between brainstorm work and spec work.
+
+## Goals
+
+- add a durable `## Shape` section to epic notes
+- ship `plan epic shape`
+- make shaped epic output stable and easy to inspect
+- keep specs as the canonical execution contract
+
+## Non-Goals
+
+- replacing specs with epics as the main source of truth
+- adding new hierarchy layers
+- tying shaping to external trackers
+
+## Constraints
+
+- epic shaping must stay additive to the current note structure
+- the command should update notes safely and idempotently
+- shape output should be understandable to both humans and agents
+- the simple `epic create` path should remain valid without immediate shaping
+
+## Solution Shape
+
+- extend the epic template with a fixed `## Shape` section
+- add a structured `epic shape` command for appetite, outcome, scope boundary,
+  out of scope, and success signal
+- use note update helpers that preserve the rest of the epic content
+
+## Flows
+
+1. User creates or promotes an epic.
+2. User runs `plan epic shape <epic-slug>`.
+3. `plan` records appetite, outcome, scope boundary, out-of-scope decisions, and
+   a success signal.
+4. The shaped epic informs the later spec and roadmap conversations.
+
+## Data / Interfaces
+
+- epic template additions
+- an `EpicShapeInput` in planning code
+- the `plan epic shape` command
+
+## Risks / Open Questions
+
+- whether shaped fields should also update the older top-level epic sections
+- how much shape data should later seed specs automatically
+
+## Rollout
+
+- land the note schema and command in `v5`
+- verify note writes and output stability in tests
+- consider deeper spec seeding only after the basic flow proves useful
+
+## Verification
+
+- new epics include the `## Shape` headings
+- `plan epic shape` updates the correct sections without damaging the rest of the
+  note
+- tests cover first-run and rerun behavior
+
+## Story Breakdown
+
+- [x] [Add epic shape note schema](../stories/add-epic-shape-note-schema.md)
+- [x] [Implement epic shape command flow](../stories/implement-epic-shape-command-flow.md)
+- [x] [Add epic shape tests and check coverage](../stories/add-epic-shape-tests-and-check-coverage.md)
+
+## Analysis
+
+### Missing Constraints
+
+### Success Criteria Gaps
+
+### Hidden Dependencies
+
+### Risk Gaps
+
+### What/Why vs How Leakage
+
+### Recommended Revisions
+
+## Resources
+
+- [Epic](../epics/epic-shaping.md)
+- [Product Direction](../PRODUCT.md)
+
+## Notes

--- a/.plan/specs/model-aware-planning-skills.md
+++ b/.plan/specs/model-aware-planning-skills.md
@@ -1,0 +1,112 @@
+---
+created_at: "2026-04-17T20:19:38Z"
+epic: model-aware-planning-skills
+project: plan
+slug: model-aware-planning-skills
+status: done
+target_version: v5
+title: Model-Aware Planning Skills Spec
+type: spec
+updated_at: "2026-04-17T20:34:01Z"
+---
+
+# Model-Aware Planning Skills Spec
+
+Created: 2026-04-17T20:19:38Z
+
+## Why
+
+The skill bundle is the product's main steering surface for agent behavior. It
+should encode the new planning thesis explicitly instead of assuming every model
+needs the same prompt shape.
+
+## Problem
+
+`plan` now ships refinement and analysis passes, but the installed skill does
+not help models apply them consistently or differently based on model style.
+
+## Goals
+
+- add model-aware planning guidance to the bundled skill
+- make GPT-style guidance more explicit, step-ordered, and example-driven
+- make reasoning-model guidance higher-level but still rubric-aware
+- align the skill text with the v4-v7 product reset
+
+## Non-Goals
+
+- dynamic prompt generation services
+- cloud profile management
+- replacing local markdown artifacts with prompt-only workflows
+
+## Constraints
+
+- the skill must stay local-first and repo-friendly
+- guidance must preserve `Brainstorm -> Epic -> Spec -> Story`
+- the simple default path must remain discoverable
+- installed skill files should be easy to inspect and diff
+
+## Solution Shape
+
+- expand `skills/plan/SKILL.md` with explicit planning modes and model guidance
+- add richer agent guidance files for the installed bundle
+- include completion rules, verification expectations, and ambiguity behavior
+- keep the bundle static and versioned with the repo
+
+## Flows
+
+1. Maintainer updates the skill text and agent guidance files.
+2. User installs the skill with `plan skills install`.
+3. The installed bundle gives models sharper planning instructions that match
+   the current roadmap and passes.
+4. Maintainers verify the shipped bundle matches repo expectations.
+
+## Data / Interfaces
+
+- `skills/plan/SKILL.md`
+- `skills/plan/agents/*.yaml`
+- install targets under Codex and OpenClaw skill roots
+
+## Risks / Open Questions
+
+- how much variation between model families is helpful before the bundle becomes
+  too complex
+- whether the current agent manifest format needs more structure than YAML text
+
+## Rollout
+
+- ship updated skill text and agent guidance in `v5`
+- verify installation behavior against existing targets
+- expand to more providers only if the local bundle remains easy to reason about
+
+## Verification
+
+- the repo skill text documents GPT-style and reasoning-model guidance
+- installed bundle files include the new guidance
+- tests or golden checks fail if the shipped bundle loses the new structure
+
+## Story Breakdown
+
+- [x] [Expand plan skill with model-aware guidance](../stories/expand-plan-skill-with-model-aware-guidance.md)
+- [x] [Add model-family agent guidance files](../stories/add-model-family-agent-guidance-files.md)
+- [x] [Validate installed skill bundle behavior](../stories/validate-installed-skill-bundle-behavior.md)
+
+## Analysis
+
+### Missing Constraints
+
+### Success Criteria Gaps
+
+### Hidden Dependencies
+
+### Risk Gaps
+
+### What/Why vs How Leakage
+
+### Recommended Revisions
+
+## Resources
+
+- [Epic](../epics/model-aware-planning-skills.md)
+- [Product Direction](../PRODUCT.md)
+
+## Notes

--- a/.plan/specs/spec-checklist-profiles.md
+++ b/.plan/specs/spec-checklist-profiles.md
@@ -1,0 +1,112 @@
+---
+created_at: "2026-04-17T20:19:39Z"
+epic: spec-checklist-profiles
+project: plan
+slug: spec-checklist-profiles
+status: done
+target_version: v5
+title: Spec Checklist Profiles Spec
+type: spec
+updated_at: "2026-04-17T20:34:02Z"
+---
+
+# Spec Checklist Profiles Spec
+
+Created: 2026-04-17T20:19:39Z
+
+## Why
+
+`plan spec analyze` provides a general diagnostic pass, but some planning work
+needs more targeted questions.
+
+## Problem
+
+UI-heavy flows, integrations, and migrations each fail in different ways.
+Without checklist profiles, the tool cannot offer deeper rigor where it matters
+most.
+
+## Goals
+
+- add a durable `## Checklist` section to spec notes
+- ship `plan spec checklist`
+- support named profiles for general, UI flow, API integration, and data
+  migration review
+- keep the checklist pass additive and non-destructive
+
+## Non-Goals
+
+- domain registries loaded from the network
+- automatic spec approval
+- checklist modes for every possible specialty on day one
+
+## Constraints
+
+- checklist output should live in the spec note
+- profiles must be deterministic and versionable in repo code
+- reruns should replace or refresh only checklist output
+- findings should distinguish blocking from advisory issues cleanly
+
+## Solution Shape
+
+- extend the spec template with a fixed `## Checklist` section
+- add profile definitions in code
+- implement a command that writes checklist results and returns a meaningful exit
+  status
+- keep profile output readable for both humans and agents
+
+## Flows
+
+1. User drafts or updates a spec.
+2. User runs `plan spec checklist <epic-slug> --profile <profile>`.
+3. `plan` evaluates the spec against the chosen profile.
+4. Results are written under `## Checklist` and summarized in the CLI output.
+
+## Data / Interfaces
+
+- spec template additions
+- checklist profile definitions in planning code
+- `plan spec checklist` command flags and exit behavior
+
+## Risks / Open Questions
+
+- how aggressively the profile pass should block compared with `spec analyze`
+- whether one spec should support multiple stored profile reports cleanly
+
+## Rollout
+
+- land the note schema and a small initial profile set in `v5`
+- validate the results through tests and docs
+- expand profiles only after the first set proves useful
+
+## Verification
+
+- specs include the `## Checklist` headings
+- profile runs are deterministic and idempotent
+- exit codes reflect blocking issues where the profile says they should
+
+## Story Breakdown
+
+- [x] [Add spec checklist note schema and profiles](../stories/add-spec-checklist-note-schema-and-profiles.md)
+- [x] [Implement spec checklist command and findings](../stories/implement-spec-checklist-command-and-findings.md)
+- [x] [Add spec checklist tests and docs](../stories/add-spec-checklist-tests-and-docs.md)
+
+## Analysis
+
+### Missing Constraints
+
+### Success Criteria Gaps
+
+### Hidden Dependencies
+
+### Risk Gaps
+
+### What/Why vs How Leakage
+
+### Recommended Revisions
+
+## Resources
+
+- [Epic](../epics/spec-checklist-profiles.md)
+- [Product Direction](../PRODUCT.md)
+
+## Notes

--- a/.plan/stories/add-brainstorm-challenge-note-schema.md
+++ b/.plan/stories/add-brainstorm-challenge-note-schema.md
@@ -1,0 +1,31 @@
+---
+created_at: "2026-04-17T20:22:10Z"
+epic: brainstorm-challenge
+project: plan
+slug: add-brainstorm-challenge-note-schema
+spec: brainstorm-challenge
+status: done
+title: Add brainstorm challenge note schema
+type: story
+updated_at: "2026-04-17T20:34:02Z"
+---
+
+# Add brainstorm challenge note schema
+
+Created: 2026-04-17T20:22:10Z
+
+## Description
+
+Extend brainstorm notes and templates with a stable Challenge section for rabbit holes, no-gos, assumptions, overengineering, and simpler alternatives.
+## Acceptance Criteria
+
+- [ ] New brainstorm notes include the full Challenge section scaffold.
+
+- [ ] The added section is additive and does not disturb existing brainstorm content.
+## Verification
+
+- Run brainstorm note/template tests.
+## Resources
+
+- [Canonical Spec](../specs/brainstorm-challenge.md)
+## Notes

--- a/.plan/stories/add-brainstorm-challenge-tests-and-resume-coverage.md
+++ b/.plan/stories/add-brainstorm-challenge-tests-and-resume-coverage.md
@@ -1,0 +1,31 @@
+---
+created_at: "2026-04-17T20:22:10Z"
+epic: brainstorm-challenge
+project: plan
+slug: add-brainstorm-challenge-tests-and-resume-coverage
+spec: brainstorm-challenge
+status: done
+title: Add brainstorm challenge tests and resume coverage
+type: story
+updated_at: "2026-04-17T20:34:02Z"
+---
+
+# Add brainstorm challenge tests and resume coverage
+
+Created: 2026-04-17T20:22:10Z
+
+## Description
+
+Expand test coverage around reruns, partial completion, and safe note updates for the challenge pass.
+## Acceptance Criteria
+
+- [ ] Tests cover reruns and partially completed challenge notes.
+
+- [ ] The challenge section updates remain idempotent.
+## Verification
+
+- Run the brainstorm challenge test suite.
+## Resources
+
+- [Canonical Spec](../specs/brainstorm-challenge.md)
+## Notes

--- a/.plan/stories/add-epic-shape-note-schema.md
+++ b/.plan/stories/add-epic-shape-note-schema.md
@@ -1,0 +1,31 @@
+---
+created_at: "2026-04-17T20:22:10Z"
+epic: epic-shaping
+project: plan
+slug: add-epic-shape-note-schema
+spec: epic-shaping
+status: done
+title: Add epic shape note schema
+type: story
+updated_at: "2026-04-17T20:34:02Z"
+---
+
+# Add epic shape note schema
+
+Created: 2026-04-17T20:22:10Z
+
+## Description
+
+Extend epic notes and templates with a stable Shape section for appetite, outcome, scope boundary, out of scope, and success signal.
+## Acceptance Criteria
+
+- [ ] New epic notes include the full Shape section scaffold.
+
+- [ ] The shape section is additive and readable for humans and agents.
+## Verification
+
+- Run epic note/template tests.
+## Resources
+
+- [Canonical Spec](../specs/epic-shaping.md)
+## Notes

--- a/.plan/stories/add-epic-shape-tests-and-check-coverage.md
+++ b/.plan/stories/add-epic-shape-tests-and-check-coverage.md
@@ -1,0 +1,31 @@
+---
+created_at: "2026-04-17T20:22:11Z"
+epic: epic-shaping
+project: plan
+slug: add-epic-shape-tests-and-check-coverage
+spec: epic-shaping
+status: done
+title: Add epic shape tests and check coverage
+type: story
+updated_at: "2026-04-17T20:34:02Z"
+---
+
+# Add epic shape tests and check coverage
+
+Created: 2026-04-17T20:22:11Z
+
+## Description
+
+Expand test and quality-check coverage for epic shape behavior, including reruns and compatibility with the broader planning checks.
+## Acceptance Criteria
+
+- [ ] Tests cover first-run and rerun epic shaping behavior.
+
+- [ ] Quality checks continue to pass with shaped epic notes present.
+## Verification
+
+- Run the epic shaping and check-related tests.
+## Resources
+
+- [Canonical Spec](../specs/epic-shaping.md)
+## Notes

--- a/.plan/stories/add-model-family-agent-guidance-files.md
+++ b/.plan/stories/add-model-family-agent-guidance-files.md
@@ -1,0 +1,31 @@
+---
+created_at: "2026-04-17T20:22:10Z"
+epic: model-aware-planning-skills
+project: plan
+slug: add-model-family-agent-guidance-files
+spec: model-aware-planning-skills
+status: done
+title: Add model-family agent guidance files
+type: story
+updated_at: "2026-04-17T20:34:01Z"
+---
+
+# Add model-family agent guidance files
+
+Created: 2026-04-17T20:22:10Z
+
+## Description
+
+Add richer agent guidance files that differentiate between GPT-style and reasoning-heavy planning behaviors while keeping the same local-first contract.
+## Acceptance Criteria
+
+- [ ] The skill bundle contains model-family guidance that is specific enough to change how agents are steered.
+
+- [ ] The guidance remains static, local, and inspectable in git.
+## Verification
+
+- Inspect the checked-in agent guidance files and confirm both model-family paths are covered.
+## Resources
+
+- [Canonical Spec](../specs/model-aware-planning-skills.md)
+## Notes

--- a/.plan/stories/add-planning-benchmark-fixtures.md
+++ b/.plan/stories/add-planning-benchmark-fixtures.md
@@ -1,0 +1,31 @@
+---
+created_at: "2026-04-17T20:22:10Z"
+epic: benchmark-fixtures-and-rubric-evals
+project: plan
+slug: add-planning-benchmark-fixtures
+spec: benchmark-fixtures-and-rubric-evals
+status: done
+title: Add planning benchmark fixtures
+type: story
+updated_at: "2026-04-17T20:34:01Z"
+---
+
+# Add planning benchmark fixtures
+
+Created: 2026-04-17T20:22:10Z
+
+## Description
+
+Create a realistic benchmark fixture set that covers multiple planning scenarios and captures the expected rubric dimensions for v5 evaluation.
+## Acceptance Criteria
+
+- [ ] Benchmark fixtures cover multiple realistic planning scenarios.
+
+- [ ] Fixtures live in repo-owned testdata and are easy to inspect.
+## Verification
+
+- Run the fixture-loading tests.
+## Resources
+
+- [Canonical Spec](../specs/benchmark-fixtures-and-rubric-evals.md)
+## Notes

--- a/.plan/stories/add-spec-checklist-note-schema-and-profiles.md
+++ b/.plan/stories/add-spec-checklist-note-schema-and-profiles.md
@@ -1,0 +1,31 @@
+---
+created_at: "2026-04-17T20:22:11Z"
+epic: spec-checklist-profiles
+project: plan
+slug: add-spec-checklist-note-schema-and-profiles
+spec: spec-checklist-profiles
+status: done
+title: Add spec checklist note schema and profiles
+type: story
+updated_at: "2026-04-17T20:34:02Z"
+---
+
+# Add spec checklist note schema and profiles
+
+Created: 2026-04-17T20:22:11Z
+
+## Description
+
+Extend spec notes with a Checklist section and add the initial set of general, UI flow, API integration, and data migration profiles.
+## Acceptance Criteria
+
+- [ ] Specs include a durable Checklist section scaffold.
+
+- [ ] The initial checklist profile set is defined in code and covers the planned v5 domains.
+## Verification
+
+- Run spec note/template and profile definition tests.
+## Resources
+
+- [Canonical Spec](../specs/spec-checklist-profiles.md)
+## Notes

--- a/.plan/stories/add-spec-checklist-tests-and-docs.md
+++ b/.plan/stories/add-spec-checklist-tests-and-docs.md
@@ -1,0 +1,31 @@
+---
+created_at: "2026-04-17T20:22:11Z"
+epic: spec-checklist-profiles
+project: plan
+slug: add-spec-checklist-tests-and-docs
+spec: spec-checklist-profiles
+status: done
+title: Add spec checklist tests and docs
+type: story
+updated_at: "2026-04-17T20:34:02Z"
+---
+
+# Add spec checklist tests and docs
+
+Created: 2026-04-17T20:22:11Z
+
+## Description
+
+Add coverage and docs for reruns, profile selection, and maintainer guidance around checklist behavior.
+## Acceptance Criteria
+
+- [ ] Tests cover reruns, multiple profiles, and stable note updates.
+
+- [ ] Docs explain when to use checklist profiles and what their output means.
+## Verification
+
+- Run the spec checklist test suite.
+## Resources
+
+- [Canonical Spec](../specs/spec-checklist-profiles.md)
+## Notes

--- a/.plan/stories/document-and-verify-the-maintainer-eval-workflow.md
+++ b/.plan/stories/document-and-verify-the-maintainer-eval-workflow.md
@@ -1,0 +1,31 @@
+---
+created_at: "2026-04-17T20:22:10Z"
+epic: benchmark-fixtures-and-rubric-evals
+project: plan
+slug: document-and-verify-the-maintainer-eval-workflow
+spec: benchmark-fixtures-and-rubric-evals
+status: done
+title: Document and verify the maintainer eval workflow
+type: story
+updated_at: "2026-04-17T20:34:02Z"
+---
+
+# Document and verify the maintainer eval workflow
+
+Created: 2026-04-17T20:22:10Z
+
+## Description
+
+Document how maintainers run the benchmark loop and add verification that the documented workflow remains accurate.
+## Acceptance Criteria
+
+- [ ] Maintainer docs explain how to run and interpret the local eval workflow.
+
+- [ ] Verification covers the documented benchmark entry points.
+## Verification
+
+- Run the maintainer eval workflow tests.
+## Resources
+
+- [Canonical Spec](../specs/benchmark-fixtures-and-rubric-evals.md)
+## Notes

--- a/.plan/stories/expand-plan-skill-with-model-aware-guidance.md
+++ b/.plan/stories/expand-plan-skill-with-model-aware-guidance.md
@@ -1,0 +1,31 @@
+---
+created_at: "2026-04-17T20:22:10Z"
+epic: model-aware-planning-skills
+project: plan
+slug: expand-plan-skill-with-model-aware-guidance
+spec: model-aware-planning-skills
+status: done
+title: Expand plan skill with model-aware guidance
+type: story
+updated_at: "2026-04-17T20:34:01Z"
+---
+
+# Expand plan skill with model-aware guidance
+
+Created: 2026-04-17T20:22:10Z
+
+## Description
+
+Rewrite the bundled plan skill so it explains the new v5 shaping loop, ambiguity handling, verification expectations, and how optional passes should be used.
+## Acceptance Criteria
+
+- [ ] The bundled skill text documents the v5 shaping workflow and optional passes clearly.
+
+- [ ] The skill guidance keeps plan focused on planning rather than memory or context management.
+## Verification
+
+- Review the checked-in skill markdown for the new sections and wording.
+## Resources
+
+- [Canonical Spec](../specs/model-aware-planning-skills.md)
+## Notes

--- a/.plan/stories/implement-brainstorm-challenge-command-flow.md
+++ b/.plan/stories/implement-brainstorm-challenge-command-flow.md
@@ -1,0 +1,31 @@
+---
+created_at: "2026-04-17T20:22:10Z"
+epic: brainstorm-challenge
+project: plan
+slug: implement-brainstorm-challenge-command-flow
+spec: brainstorm-challenge
+status: done
+title: Implement brainstorm challenge command flow
+type: story
+updated_at: "2026-04-17T20:34:02Z"
+---
+
+# Implement brainstorm challenge command flow
+
+Created: 2026-04-17T20:22:10Z
+
+## Description
+
+Add the interactive brainstorm challenge command and its note update logic so challenge data is persisted safely across runs.
+## Acceptance Criteria
+
+- [ ] The command collects the challenge fields and writes them into the brainstorm note.
+
+- [ ] Reruns preserve earlier answers and only refresh the challenge section.
+## Verification
+
+- Run the brainstorm command tests for challenge flow.
+## Resources
+
+- [Canonical Spec](../specs/brainstorm-challenge.md)
+## Notes

--- a/.plan/stories/implement-epic-shape-command-flow.md
+++ b/.plan/stories/implement-epic-shape-command-flow.md
@@ -1,0 +1,31 @@
+---
+created_at: "2026-04-17T20:22:11Z"
+epic: epic-shaping
+project: plan
+slug: implement-epic-shape-command-flow
+spec: epic-shaping
+status: done
+title: Implement epic shape command flow
+type: story
+updated_at: "2026-04-17T20:34:02Z"
+---
+
+# Implement epic shape command flow
+
+Created: 2026-04-17T20:22:11Z
+
+## Description
+
+Add the interactive epic shape command and its note update logic so shaped epic boundaries can be recorded safely and rerun cleanly.
+## Acceptance Criteria
+
+- [ ] The command collects appetite, outcome, scope boundary, out-of-scope decisions, and success signal.
+
+- [ ] The command updates the correct note sections without damaging other epic content.
+## Verification
+
+- Run the epic command tests for shape flow.
+## Resources
+
+- [Canonical Spec](../specs/epic-shaping.md)
+## Notes

--- a/.plan/stories/implement-rubric-evaluation-harness.md
+++ b/.plan/stories/implement-rubric-evaluation-harness.md
@@ -1,0 +1,31 @@
+---
+created_at: "2026-04-17T20:22:10Z"
+epic: benchmark-fixtures-and-rubric-evals
+project: plan
+slug: implement-rubric-evaluation-harness
+spec: benchmark-fixtures-and-rubric-evals
+status: done
+title: Implement rubric evaluation harness
+type: story
+updated_at: "2026-04-17T20:34:02Z"
+---
+
+# Implement rubric evaluation harness
+
+Created: 2026-04-17T20:22:10Z
+
+## Description
+
+Add a deterministic rubric evaluation harness that scores planning artifacts against the benchmark dimensions described in the roadmap reset.
+## Acceptance Criteria
+
+- [ ] The harness computes stable rubric output for the same fixture input.
+
+- [ ] The rubric categories align with the v5 product thesis.
+## Verification
+
+- Run the rubric evaluation tests.
+## Resources
+
+- [Canonical Spec](../specs/benchmark-fixtures-and-rubric-evals.md)
+## Notes

--- a/.plan/stories/implement-spec-checklist-command-and-findings.md
+++ b/.plan/stories/implement-spec-checklist-command-and-findings.md
@@ -1,0 +1,31 @@
+---
+created_at: "2026-04-17T20:22:11Z"
+epic: spec-checklist-profiles
+project: plan
+slug: implement-spec-checklist-command-and-findings
+spec: spec-checklist-profiles
+status: done
+title: Implement spec checklist command and findings
+type: story
+updated_at: "2026-04-17T20:34:02Z"
+---
+
+# Implement spec checklist command and findings
+
+Created: 2026-04-17T20:22:11Z
+
+## Description
+
+Add the spec checklist command so a chosen profile writes deterministic checklist findings into the spec note and returns meaningful exit codes.
+## Acceptance Criteria
+
+- [ ] The command writes checklist findings into the spec note for the chosen profile.
+
+- [ ] Exit codes distinguish blocking checklist issues from advisory output.
+## Verification
+
+- Run the spec checklist command tests.
+## Resources
+
+- [Canonical Spec](../specs/spec-checklist-profiles.md)
+## Notes

--- a/.plan/stories/validate-installed-skill-bundle-behavior.md
+++ b/.plan/stories/validate-installed-skill-bundle-behavior.md
@@ -1,0 +1,31 @@
+---
+created_at: "2026-04-17T20:22:10Z"
+epic: model-aware-planning-skills
+project: plan
+slug: validate-installed-skill-bundle-behavior
+spec: model-aware-planning-skills
+status: done
+title: Validate installed skill bundle behavior
+type: story
+updated_at: "2026-04-17T20:34:01Z"
+---
+
+# Validate installed skill bundle behavior
+
+Created: 2026-04-17T20:22:10Z
+
+## Description
+
+Add tests and maintainer checks that prove the installed skill bundle includes the new files and guidance when copied to target roots.
+## Acceptance Criteria
+
+- [ ] The install path covers the new model-aware guidance files.
+
+- [ ] Verification fails if expected skill bundle files are missing after install.
+## Verification
+
+- Run the relevant skill installation tests.
+## Resources
+
+- [Canonical Spec](../specs/model-aware-planning-skills.md)
+## Notes

--- a/README.md
+++ b/README.md
@@ -29,10 +29,12 @@ Workflow entry:
 
 1. Brainstorm
 2. Refine
-3. Promote to epic
-4. Write and approve spec
-5. Analyze the spec
-6. Split into stories
+3. Challenge
+4. Promote to epic
+5. Shape the epic
+6. Write and approve spec
+7. Analyze or checklist the spec
+8. Split into stories
 
 The default path stays small. New shaping passes should improve the same
 artifacts rather than add new top-level planning objects.
@@ -76,9 +78,12 @@ user-authored planning notes just to migrate product direction.
 plan init --project .
 plan brainstorm start --project . "Newsletter system"
 plan brainstorm refine --project . newsletter-system
+plan brainstorm challenge --project . newsletter-system
 plan epic promote --project . newsletter-system
+plan epic shape --project . newsletter-system
 plan spec show --project . newsletter-system
 plan spec analyze --project . newsletter-system
+plan spec checklist --project . newsletter-system --profile general
 plan spec status --project . newsletter-system --set approved
 plan story create --project . newsletter-system "Build template editor" \
   --criteria "Templates can be created and edited" \
@@ -93,8 +98,9 @@ plan status --project .
 - `plan doctor`
 - `plan update`
 - `plan brainstorm start|idea|show|refine`
-- `plan epic create|promote|list|show`
-- `plan spec show|edit|status|analyze`
+- `plan brainstorm challenge`
+- `plan epic create|promote|list|show|shape`
+- `plan spec show|edit|status|analyze|checklist`
 - `plan story create|update|list|show`
 - `plan roadmap show|edit`
 - `plan check`
@@ -148,6 +154,19 @@ Preview install targets:
 ```bash
 plan skills targets --scope both --agent codex --project .
 ```
+
+## Evaluating Prompt And Workflow Changes
+
+`v5` adds a local benchmark and rubric harness for maintainers. The initial
+workflow is test-driven:
+
+```bash
+go test ./internal/planning -run TestBenchmarkFixturesSatisfyMinimumScores
+go test ./internal/planning -run TestRubricEvaluationIsDeterministic
+```
+
+The fixtures live under `testdata/evals/fixtures/` and the rubric code lives in
+`internal/planning/evals.go`.
 
 ## Release Flow
 

--- a/cmd/brainstorm.go
+++ b/cmd/brainstorm.go
@@ -97,7 +97,6 @@ func newBrainstormCommand() *cobra.Command {
 			if err := runRefinementCluster(
 				reader,
 				out,
-				args[0],
 				"cluster 1/4: problem and user/value",
 				state.Problem == "",
 				"Problem",
@@ -120,7 +119,6 @@ func newBrainstormCommand() *cobra.Command {
 			if err := runRefinementCluster(
 				reader,
 				out,
-				args[0],
 				"cluster 2/4: constraints and appetite",
 				state.Constraints == "",
 				"Constraints",
@@ -143,7 +141,6 @@ func newBrainstormCommand() *cobra.Command {
 			if err := runRefinementCluster(
 				reader,
 				out,
-				args[0],
 				"cluster 3/4: open questions and candidate approaches",
 				state.RemainingOpenQuestions == "",
 				"Remaining Open Questions",
@@ -164,7 +161,7 @@ func newBrainstormCommand() *cobra.Command {
 			}
 
 			if state.DecisionSnapshot == "" {
-				value, err := promptRefinementValue(reader, out, "Decision Snapshot", "Summarize the current best direction or next decision in one short block.")
+				value, err := promptSectionValue(reader, out, "Decision Snapshot", "Summarize the current best direction or next decision in one short block.")
 				if err != nil {
 					return err
 				}
@@ -187,18 +184,99 @@ func newBrainstormCommand() *cobra.Command {
 		},
 	}
 
-	cmd.AddCommand(start, idea, show, refine)
+	challenge := &cobra.Command{
+		Use:   "challenge <brainstorm-slug>",
+		Short: "Interactively challenge a brainstorm before it hardens into an epic",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			reader := bufio.NewReader(cmd.InOrStdin())
+			out := cmd.OutOrStdout()
+
+			state, err := planningManager().ReadBrainstormChallenge(args[0])
+			if err != nil {
+				return err
+			}
+
+			if err := runRefinementCluster(
+				reader,
+				out,
+				"cluster 1/3: rabbit holes and no-gos",
+				state.RabbitHoles == "",
+				"Rabbit Holes",
+				"List the traps or rabbit holes that could make this idea sprawl. Enter one per line.",
+				&state.RabbitHoles,
+				state.NoGos == "",
+				"No-Gos",
+				"List the explicit no-gos or exclusions for this idea. Enter one per line.",
+				&state.NoGos,
+			); err != nil {
+				return err
+			}
+			if _, err := planningManager().UpdateBrainstormChallenge(args[0], planning.BrainstormChallengeInput{
+				RabbitHoles: state.RabbitHoles,
+				NoGos:       state.NoGos,
+			}); err != nil {
+				return err
+			}
+
+			if err := runRefinementCluster(
+				reader,
+				out,
+				"cluster 2/3: assumptions and likely overengineering",
+				state.Assumptions == "",
+				"Assumptions",
+				"Capture the assumptions this idea depends on. Enter one per line.",
+				&state.Assumptions,
+				state.LikelyOverengineering == "",
+				"Likely Overengineering",
+				"Describe where this idea is most likely to become more complex than it should.",
+				&state.LikelyOverengineering,
+			); err != nil {
+				return err
+			}
+			if _, err := planningManager().UpdateBrainstormChallenge(args[0], planning.BrainstormChallengeInput{
+				Assumptions:           state.Assumptions,
+				LikelyOverengineering: state.LikelyOverengineering,
+			}); err != nil {
+				return err
+			}
+
+			if state.SimplerAlternative == "" {
+				value, err := promptSectionValue(reader, out, "Simpler Alternative", "Describe the simplest credible version of this idea.")
+				if err != nil {
+					return err
+				}
+				state.SimplerAlternative = value
+			} else {
+				fmt.Fprintf(out, "Skipping Simpler Alternative; already captured.\n")
+			}
+			if _, err := planningManager().UpdateBrainstormChallenge(args[0], planning.BrainstormChallengeInput{
+				SimplerAlternative: state.SimplerAlternative,
+			}); err != nil {
+				return err
+			}
+
+			if state.HasGaps() {
+				fmt.Fprintf(out, "Challenge saved for %s with remaining gaps.\n", state.Path)
+				return nil
+			}
+			fmt.Fprintf(out, "Challenge saved for %s\n", state.Path)
+			return nil
+		},
+	}
+
+	cmd.AddCommand(start, idea, show, refine, challenge)
 	return cmd
 }
 
-func runRefinementCluster(reader *bufio.Reader, out io.Writer, slug, label string, askA bool, titleA, helpA string, valueA *string, askB bool, titleB, helpB string, valueB *string) error {
+func runRefinementCluster(reader *bufio.Reader, out io.Writer, label string, askA bool, titleA, helpA string, valueA *string, askB bool, titleB, helpB string, valueB *string) error {
 	if !askA && !askB {
 		fmt.Fprintf(out, "Skipping %s; already complete.\n", label)
 		return nil
 	}
 	fmt.Fprintf(out, "%s\n", label)
 	if askA {
-		value, err := promptRefinementValue(reader, out, titleA, helpA)
+		value, err := promptSectionValue(reader, out, titleA, helpA)
 		if err != nil {
 			return err
 		}
@@ -207,7 +285,7 @@ func runRefinementCluster(reader *bufio.Reader, out io.Writer, slug, label strin
 		}
 	}
 	if askB {
-		value, err := promptRefinementValue(reader, out, titleB, helpB)
+		value, err := promptSectionValue(reader, out, titleB, helpB)
 		if err != nil {
 			return err
 		}
@@ -219,7 +297,7 @@ func runRefinementCluster(reader *bufio.Reader, out io.Writer, slug, label strin
 	return nil
 }
 
-func promptRefinementValue(reader *bufio.Reader, out io.Writer, heading, help string) (string, error) {
+func promptSectionValue(reader *bufio.Reader, out io.Writer, heading, help string) (string, error) {
 	fmt.Fprintf(out, "%s\n%s\nFinish with a blank line. Leave empty to skip.\n", heading, help)
 	var lines []string
 	for {

--- a/cmd/brainstorm_test.go
+++ b/cmd/brainstorm_test.go
@@ -76,3 +76,67 @@ func TestBrainstormRefineCommandPersistsClustersAndResumes(t *testing.T) {
 		t.Fatalf("expected candidate approaches after resume:\n%s", note.Content)
 	}
 }
+
+func TestBrainstormChallengeCommandPersistsClustersAndResumes(t *testing.T) {
+	root := t.TempDir()
+	ws := workspace.New(root)
+	if _, err := ws.Init(); err != nil {
+		t.Fatal(err)
+	}
+	manager := planning.New(ws)
+	if _, err := manager.CreateBrainstorm("Billing Flow"); err != nil {
+		t.Fatal(err)
+	}
+
+	firstInput := strings.Join([]string{
+		"Schema changes without rollout planning.",
+		"Too many sidecar workflow objects.",
+		"",
+		"Do not add hosted services.",
+		"Do not turn plan into a tracker clone.",
+		"",
+		"Users will accept one more planning pass.",
+		"Prompt guidance can stay inspectable in git.",
+		"",
+		"",
+	}, "\n")
+	var first bytes.Buffer
+	command := newRootCmd()
+	command.SetOut(&first)
+	command.SetErr(&first)
+	command.SetIn(strings.NewReader(firstInput))
+	command.SetArgs([]string{"--project", root, "brainstorm", "challenge", "billing-flow"})
+	if err := command.Execute(); err != nil {
+		t.Fatalf("expected first challenge pass to succeed: %v\n%s", err, first.String())
+	}
+
+	secondInput := strings.Join([]string{
+		"If we add too many profiles too early, the product gets ceremonial.",
+		"",
+		"Start with one shaped prompt loop and one checklist pass.",
+		"",
+	}, "\n")
+	var second bytes.Buffer
+	command = newRootCmd()
+	command.SetOut(&second)
+	command.SetErr(&second)
+	command.SetIn(strings.NewReader(secondInput))
+	command.SetArgs([]string{"--project", root, "brainstorm", "challenge", "billing-flow"})
+	if err := command.Execute(); err != nil {
+		t.Fatalf("expected resumed challenge pass to succeed: %v\n%s", err, second.String())
+	}
+
+	note, err := notes.Read(filepath.Join(root, ".plan", "brainstorms", "billing-flow.md"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(note.Content, "## Challenge") || !strings.Contains(note.Content, "### Simpler Alternative") {
+		t.Fatalf("expected challenge section in note:\n%s", note.Content)
+	}
+	if !strings.Contains(note.Content, "### Rabbit Holes\n\n- Schema changes without rollout planning.") {
+		t.Fatalf("expected rabbit holes in challenge section:\n%s", note.Content)
+	}
+	if !strings.Contains(note.Content, "### Simpler Alternative\n\nStart with one shaped prompt loop and one checklist pass.") {
+		t.Fatalf("expected simpler alternative after resume:\n%s", note.Content)
+	}
+}

--- a/cmd/epic.go
+++ b/cmd/epic.go
@@ -1,7 +1,10 @@
 package cmd
 
 import (
+	"bufio"
 	"fmt"
+
+	"plan/internal/planning"
 
 	"github.com/spf13/cobra"
 )
@@ -80,6 +83,87 @@ func newEpicCommand() *cobra.Command {
 		},
 	}
 
-	cmd.AddCommand(create, promote, list, show)
+	shape := &cobra.Command{
+		Use:   "shape <epic-slug>",
+		Short: "Interactively shape an epic with appetite and scope boundaries",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			reader := bufio.NewReader(cmd.InOrStdin())
+			out := cmd.OutOrStdout()
+
+			state, err := planningManager().ReadEpicShape(args[0])
+			if err != nil {
+				return err
+			}
+
+			if err := runRefinementCluster(
+				reader,
+				out,
+				"cluster 1/3: appetite and outcome",
+				state.Appetite == "",
+				"Appetite",
+				"Describe how big this epic should be. Keep it as a boundary, not a schedule.",
+				&state.Appetite,
+				state.Outcome == "",
+				"Outcome",
+				"Describe the concrete outcome this epic should achieve if it succeeds.",
+				&state.Outcome,
+			); err != nil {
+				return err
+			}
+			if _, err := planningManager().UpdateEpicShape(args[0], planning.EpicShapeInput{
+				Appetite: state.Appetite,
+				Outcome:  state.Outcome,
+			}); err != nil {
+				return err
+			}
+
+			if err := runRefinementCluster(
+				reader,
+				out,
+				"cluster 2/3: scope boundary and out of scope",
+				state.ScopeBoundary == "",
+				"Scope Boundary",
+				"Describe the boundary of the work this epic should cover.",
+				&state.ScopeBoundary,
+				state.OutOfScope == "",
+				"Out of Scope",
+				"List the work this epic will explicitly not do. Enter one per line.",
+				&state.OutOfScope,
+			); err != nil {
+				return err
+			}
+			if _, err := planningManager().UpdateEpicShape(args[0], planning.EpicShapeInput{
+				ScopeBoundary: state.ScopeBoundary,
+				OutOfScope:    state.OutOfScope,
+			}); err != nil {
+				return err
+			}
+
+			if state.SuccessSignal == "" {
+				value, err := promptSectionValue(reader, out, "Success Signal", "Describe how you will know this epic is successful.")
+				if err != nil {
+					return err
+				}
+				state.SuccessSignal = value
+			} else {
+				fmt.Fprintf(out, "Skipping Success Signal; already captured.\n")
+			}
+			if _, err := planningManager().UpdateEpicShape(args[0], planning.EpicShapeInput{
+				SuccessSignal: state.SuccessSignal,
+			}); err != nil {
+				return err
+			}
+
+			if state.HasGaps() {
+				fmt.Fprintf(out, "Shape saved for %s with remaining gaps.\n", state.Path)
+				return nil
+			}
+			fmt.Fprintf(out, "Shape saved for %s\n", state.Path)
+			return nil
+		},
+	}
+
+	cmd.AddCommand(create, promote, list, show, shape)
 	return cmd
 }

--- a/cmd/epic_test.go
+++ b/cmd/epic_test.go
@@ -1,0 +1,73 @@
+package cmd
+
+import (
+	"bytes"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"plan/internal/notes"
+	"plan/internal/planning"
+	"plan/internal/workspace"
+)
+
+func TestEpicShapeCommandPersistsClustersAndResumes(t *testing.T) {
+	root := t.TempDir()
+	ws := workspace.New(root)
+	if _, err := ws.Init(); err != nil {
+		t.Fatal(err)
+	}
+	manager := planning.New(ws)
+	if _, err := manager.CreateEpic("Billing", ""); err != nil {
+		t.Fatal(err)
+	}
+
+	firstInput := strings.Join([]string{
+		"One extra shaping pass before spec approval.",
+		"",
+		"Make epics feel like bounded bets instead of loose containers.",
+		"",
+		"Capture appetite, scope, and success without inventing new hierarchy.",
+		"",
+		"Do not rebuild roadmap math.",
+		"Do not add coordination dashboards.",
+		"",
+	}, "\n")
+	var first bytes.Buffer
+	command := newRootCmd()
+	command.SetOut(&first)
+	command.SetErr(&first)
+	command.SetIn(strings.NewReader(firstInput))
+	command.SetArgs([]string{"--project", root, "epic", "shape", "billing"})
+	if err := command.Execute(); err != nil {
+		t.Fatalf("expected first shape pass to succeed: %v\n%s", err, first.String())
+	}
+
+	secondInput := strings.Join([]string{
+		"Specs inherit a clear appetite and scope boundary for later decomposition.",
+		"",
+	}, "\n")
+	var second bytes.Buffer
+	command = newRootCmd()
+	command.SetOut(&second)
+	command.SetErr(&second)
+	command.SetIn(strings.NewReader(secondInput))
+	command.SetArgs([]string{"--project", root, "epic", "shape", "billing"})
+	if err := command.Execute(); err != nil {
+		t.Fatalf("expected resumed shape pass to succeed: %v\n%s", err, second.String())
+	}
+
+	note, err := notes.Read(filepath.Join(root, ".plan", "epics", "billing.md"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(note.Content, "## Shape") || !strings.Contains(note.Content, "### Success Signal") {
+		t.Fatalf("expected shape section in epic note:\n%s", note.Content)
+	}
+	if !strings.Contains(note.Content, "## Outcome\n\nMake epics feel like bounded bets instead of loose containers.") {
+		t.Fatalf("expected top-level outcome to mirror epic shape:\n%s", note.Content)
+	}
+	if !strings.Contains(note.Content, "### Out of Scope\n\n- Do not rebuild roadmap math.") {
+		t.Fatalf("expected out-of-scope bullets in shape section:\n%s", note.Content)
+	}
+}

--- a/cmd/spec.go
+++ b/cmd/spec.go
@@ -100,7 +100,26 @@ func newSpecCommand() *cobra.Command {
 		},
 	}
 
-	cmd.AddCommand(show, edit, statusCmd, analyze)
+	var profile string
+	checklist := &cobra.Command{
+		Use:   "checklist <epic-slug>",
+		Short: "Run a profile-driven checklist pass against a spec",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			report, err := planningManager().RunSpecChecklist(args[0], profile)
+			if err != nil {
+				return err
+			}
+			printSpecChecklist(cmd.OutOrStdout(), report)
+			if report.HasBlockingFindings() {
+				return fmt.Errorf("spec checklist found %d blocking issue(s)", report.BlockingCount())
+			}
+			return nil
+		},
+	}
+	checklist.Flags().StringVar(&profile, "profile", "general", "checklist profile: general, ui-flow, api-integration, data-migration")
+
+	cmd.AddCommand(show, edit, statusCmd, analyze, checklist)
 	return cmd
 }
 
@@ -126,6 +145,26 @@ func printSpecAnalysis(out io.Writer, report *planning.SpecAnalysisReport) {
 			if item.Recommendation != "" {
 				fmt.Fprintf(out, "  fix: %s\n", item.Recommendation)
 			}
+		}
+	}
+}
+
+func printSpecChecklist(out io.Writer, report *planning.SpecChecklistReport) {
+	fmt.Fprintf(out, "spec_checklist: %s\n", report.SpecPath)
+	fmt.Fprintf(out, "profile: %s\n", report.Profile)
+	fmt.Fprintf(out, "findings: %d total, %d blocking, %d guidance\n",
+		len(report.Findings),
+		report.BlockingCount(),
+		report.WarningCount(),
+	)
+	if len(report.Findings) == 0 {
+		fmt.Fprintln(out, "status: ok")
+		return
+	}
+	for _, item := range report.Findings {
+		fmt.Fprintf(out, "- [%s] %s: %s\n", item.Severity, item.Area, item.Message)
+		if item.Recommendation != "" {
+			fmt.Fprintf(out, "  fix: %s\n", item.Recommendation)
 		}
 	}
 }

--- a/cmd/spec_test.go
+++ b/cmd/spec_test.go
@@ -101,3 +101,95 @@ func TestSpecAnalyzeCommandWritesAnalysisAndFailsOnBlockingFindings(t *testing.T
 		t.Fatalf("expected analysis section in spec note:\n%s", note.Content)
 	}
 }
+
+func TestSpecChecklistCommandWritesChecklistAndFailsOnBlockingFindings(t *testing.T) {
+	root := t.TempDir()
+	ws := workspace.New(root)
+	if _, err := ws.Init(); err != nil {
+		t.Fatal(err)
+	}
+	manager := planning.New(ws)
+
+	if _, err := manager.CreateEpic("Billing", ""); err != nil {
+		t.Fatal(err)
+	}
+	body := strings.Join([]string{
+		"# Billing Spec",
+		"",
+		"Created: now",
+		"",
+		"## Why",
+		"",
+		"The billing export should integrate with a third-party API.",
+		"",
+		"## Problem",
+		"",
+		"Billing exports are inconsistent.",
+		"",
+		"## Goals",
+		"",
+		"- ship export support",
+		"",
+		"## Non-Goals",
+		"",
+		"- redesign every billing screen",
+		"",
+		"## Constraints",
+		"",
+		"- keep the rollout low-risk",
+		"",
+		"## Solution Shape",
+		"",
+		"Add export support for billing.",
+		"",
+		"## Flows",
+		"",
+		"1. Trigger export.",
+		"",
+		"## Data / Interfaces",
+		"",
+		"- internal billing types",
+		"",
+		"## Risks / Open Questions",
+		"",
+		"- what should the export format be",
+		"",
+		"## Rollout",
+		"",
+		"- ship it carefully",
+		"",
+		"## Verification",
+		"",
+		"- run billing tests",
+		"",
+	}, "\n")
+	if _, err := manager.UpdateSpec("billing", notes.UpdateInput{Body: &body}); err != nil {
+		t.Fatal(err)
+	}
+
+	var buf bytes.Buffer
+	command := newRootCmd()
+	command.SetOut(&buf)
+	command.SetErr(&buf)
+	command.SetArgs([]string{"--project", root, "spec", "checklist", "billing", "--profile", "api-integration"})
+	err := command.Execute()
+	if err == nil {
+		t.Fatalf("expected blocking checklist findings:\n%s", buf.String())
+	}
+
+	output := buf.String()
+	if !strings.Contains(output, "spec_checklist: .plan/specs/billing.md") || !strings.Contains(output, "profile: api-integration") {
+		t.Fatalf("expected checklist header in output:\n%s", output)
+	}
+	if !strings.Contains(output, "[error] Data / Interfaces:") {
+		t.Fatalf("expected blocking checklist item in output:\n%s", output)
+	}
+
+	note, err := notes.Read(filepath.Join(root, ".plan", "specs", "billing.md"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(note.Content, "## Checklist") || !strings.Contains(note.Content, "### api-integration") {
+		t.Fatalf("expected checklist section in spec note:\n%s", note.Content)
+	}
+}

--- a/internal/notes/notes.go
+++ b/internal/notes/notes.go
@@ -299,3 +299,7 @@ func ExtractSection(content, heading string) string {
 	}
 	return strings.TrimSpace(strings.Join(out, "\n"))
 }
+
+func ExtractNestedSection(content, parentHeading, childHeading string) string {
+	return ExtractSection(ExtractSection(content, parentHeading), childHeading)
+}

--- a/internal/planning/challenge.go
+++ b/internal/planning/challenge.go
@@ -1,0 +1,110 @@
+package planning
+
+import (
+	"fmt"
+	"path/filepath"
+	"strings"
+
+	"plan/internal/notes"
+)
+
+type BrainstormChallenge struct {
+	Path                   string
+	RabbitHoles            string
+	NoGos                  string
+	Assumptions            string
+	LikelyOverengineering  string
+	SimplerAlternative     string
+}
+
+type BrainstormChallengeInput struct {
+	RabbitHoles           string
+	NoGos                 string
+	Assumptions           string
+	LikelyOverengineering string
+	SimplerAlternative    string
+}
+
+func (c BrainstormChallenge) HasGaps() bool {
+	return strings.TrimSpace(c.RabbitHoles) == "" ||
+		strings.TrimSpace(c.NoGos) == "" ||
+		strings.TrimSpace(c.Assumptions) == "" ||
+		strings.TrimSpace(c.LikelyOverengineering) == "" ||
+		strings.TrimSpace(c.SimplerAlternative) == ""
+}
+
+func (m *Manager) ReadBrainstormChallenge(brainstormSlug string) (*BrainstormChallenge, error) {
+	info, err := m.workspace.EnsureInitialized()
+	if err != nil {
+		return nil, err
+	}
+	note, err := notes.Read(filepath.Join(info.BrainstormsDir, slugify(brainstormSlug)+".md"))
+	if err != nil {
+		return nil, err
+	}
+	if note.Type != "brainstorm" {
+		return nil, fmt.Errorf("%s is not a brainstorm note", note.Path)
+	}
+	state := extractBrainstormChallenge(note)
+	state.Path = rel(info.ProjectDir, note.Path)
+	return &state, nil
+}
+
+func (m *Manager) UpdateBrainstormChallenge(brainstormSlug string, input BrainstormChallengeInput) (*notes.Note, error) {
+	info, err := m.workspace.EnsureInitialized()
+	if err != nil {
+		return nil, err
+	}
+	path := filepath.Join(info.BrainstormsDir, slugify(brainstormSlug)+".md")
+	note, err := notes.Read(path)
+	if err != nil {
+		return nil, err
+	}
+	if note.Type != "brainstorm" {
+		return nil, fmt.Errorf("%s is not a brainstorm note", note.Path)
+	}
+
+	current := extractBrainstormChallenge(note)
+	if strings.TrimSpace(input.RabbitHoles) != "" {
+		current.RabbitHoles = normalizeBulletList(input.RabbitHoles)
+	}
+	if strings.TrimSpace(input.NoGos) != "" {
+		current.NoGos = normalizeBulletList(input.NoGos)
+	}
+	if strings.TrimSpace(input.Assumptions) != "" {
+		current.Assumptions = normalizeBulletList(input.Assumptions)
+	}
+	if strings.TrimSpace(input.LikelyOverengineering) != "" {
+		current.LikelyOverengineering = strings.TrimSpace(input.LikelyOverengineering)
+	}
+	if strings.TrimSpace(input.SimplerAlternative) != "" {
+		current.SimplerAlternative = strings.TrimSpace(input.SimplerAlternative)
+	}
+
+	body := notes.SetSection(note.Content, "Challenge", renderBrainstormChallenge(current))
+	updated, err := notes.Update(path, notes.UpdateInput{Body: &body})
+	if err != nil {
+		return nil, err
+	}
+	return m.relNote(updated, info.ProjectDir), nil
+}
+
+func extractBrainstormChallenge(note *notes.Note) BrainstormChallenge {
+	return BrainstormChallenge{
+		RabbitHoles:           extractSubsection(note.Content, "Challenge", "Rabbit Holes"),
+		NoGos:                 extractSubsection(note.Content, "Challenge", "No-Gos"),
+		Assumptions:           extractSubsection(note.Content, "Challenge", "Assumptions"),
+		LikelyOverengineering: extractSubsection(note.Content, "Challenge", "Likely Overengineering"),
+		SimplerAlternative:    extractSubsection(note.Content, "Challenge", "Simpler Alternative"),
+	}
+}
+
+func renderBrainstormChallenge(challenge BrainstormChallenge) string {
+	var lines []string
+	appendSubsection(&lines, "Rabbit Holes", challenge.RabbitHoles)
+	appendSubsection(&lines, "No-Gos", challenge.NoGos)
+	appendSubsection(&lines, "Assumptions", challenge.Assumptions)
+	appendSubsection(&lines, "Likely Overengineering", challenge.LikelyOverengineering)
+	appendSubsection(&lines, "Simpler Alternative", challenge.SimplerAlternative)
+	return strings.Join(lines, "\n")
+}

--- a/internal/planning/challenge_test.go
+++ b/internal/planning/challenge_test.go
@@ -1,0 +1,48 @@
+package planning
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"plan/internal/notes"
+	"plan/internal/workspace"
+)
+
+func TestUpdateBrainstormChallengeWritesIdempotentChallengeSection(t *testing.T) {
+	root := t.TempDir()
+	ws := workspace.New(root)
+	if _, err := ws.Init(); err != nil {
+		t.Fatal(err)
+	}
+	manager := New(ws)
+
+	if _, err := manager.CreateBrainstorm("Billing"); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := manager.UpdateBrainstormChallenge("billing", BrainstormChallengeInput{
+		RabbitHoles:           "Overbuilding the prompt loop",
+		NoGos:                 "Do not add cloud sync",
+		Assumptions:           "Users will tolerate one extra pass",
+		LikelyOverengineering: "Packing too many challenge fields into one command",
+		SimplerAlternative:    "Start with one adversarial pass",
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := manager.UpdateBrainstormChallenge("billing", BrainstormChallengeInput{
+		SimplerAlternative: "Start with one adversarial pass",
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	note, err := notes.Read(filepath.Join(root, ".plan", "brainstorms", "billing.md"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := strings.Count(note.Content, "## Challenge"); got != 1 {
+		t.Fatalf("expected one challenge section, got %d:\n%s", got, note.Content)
+	}
+	if !strings.Contains(note.Content, "### No-Gos\n\n- Do not add cloud sync") {
+		t.Fatalf("expected challenge content to persist:\n%s", note.Content)
+	}
+}

--- a/internal/planning/checklist.go
+++ b/internal/planning/checklist.go
@@ -1,0 +1,304 @@
+package planning
+
+import (
+	"fmt"
+	"path/filepath"
+	"slices"
+	"strings"
+
+	"plan/internal/notes"
+)
+
+const (
+	checklistProfileGeneral        = "general"
+	checklistProfileUIFlow         = "ui-flow"
+	checklistProfileAPIIntegration = "api-integration"
+	checklistProfileDataMigration  = "data-migration"
+)
+
+var specChecklistProfileOrder = []string{
+	checklistProfileGeneral,
+	checklistProfileUIFlow,
+	checklistProfileAPIIntegration,
+	checklistProfileDataMigration,
+}
+
+type SpecChecklistFinding struct {
+	Severity       string
+	Area           string
+	Message        string
+	Recommendation string
+}
+
+type SpecChecklistReport struct {
+	Project  string
+	SpecPath string
+	Title    string
+	Profile  string
+	Findings []SpecChecklistFinding
+}
+
+func (r *SpecChecklistReport) BlockingCount() int {
+	count := 0
+	for _, finding := range r.Findings {
+		if finding.Severity == "error" {
+			count++
+		}
+	}
+	return count
+}
+
+func (r *SpecChecklistReport) WarningCount() int {
+	count := 0
+	for _, finding := range r.Findings {
+		if finding.Severity == "warn" {
+			count++
+		}
+	}
+	return count
+}
+
+func (r *SpecChecklistReport) HasBlockingFindings() bool {
+	return r.BlockingCount() > 0
+}
+
+func SpecChecklistProfiles() []string {
+	return append([]string(nil), specChecklistProfileOrder...)
+}
+
+func (m *Manager) RunSpecChecklist(epicSlug, profile string) (*SpecChecklistReport, error) {
+	profile = strings.TrimSpace(profile)
+	if !slices.Contains(specChecklistProfileOrder, profile) {
+		return nil, fmt.Errorf("invalid checklist profile %q", profile)
+	}
+	info, err := m.workspace.EnsureInitialized()
+	if err != nil {
+		return nil, err
+	}
+	path := filepath.Join(info.SpecsDir, m.specSlugForEpic(epicSlug)+".md")
+	spec, err := notes.Read(path)
+	if err != nil {
+		return nil, err
+	}
+
+	report := &SpecChecklistReport{
+		Project:  info.ProjectName,
+		SpecPath: rel(info.ProjectDir, path),
+		Title:    spec.Title,
+		Profile:  profile,
+	}
+	report.Findings = buildSpecChecklistFindings(profile, spec)
+
+	existing := notes.ExtractSection(spec.Content, "Checklist")
+	sections := map[string]string{}
+	for _, name := range specChecklistProfileOrder {
+		if body := notes.ExtractSection(existing, name); strings.TrimSpace(body) != "" {
+			sections[name] = body
+		}
+	}
+	sections[profile] = renderSpecChecklistReport(report)
+	body := notes.SetSection(spec.Content, "Checklist", renderNamedSubsections(specChecklistProfileOrder, sections))
+	updated, err := notes.Update(path, notes.UpdateInput{Body: &body})
+	if err != nil {
+		return nil, err
+	}
+	report.SpecPath = rel(info.ProjectDir, updated.Path)
+	return report, nil
+}
+
+func buildSpecChecklistFindings(profile string, spec *notes.Note) []SpecChecklistFinding {
+	switch profile {
+	case checklistProfileGeneral:
+		return dedupeChecklistFindings(generalChecklistFindings(spec))
+	case checklistProfileUIFlow:
+		return dedupeChecklistFindings(uiFlowChecklistFindings(spec))
+	case checklistProfileAPIIntegration:
+		return dedupeChecklistFindings(apiIntegrationChecklistFindings(spec))
+	case checklistProfileDataMigration:
+		return dedupeChecklistFindings(dataMigrationChecklistFindings(spec))
+	default:
+		return nil
+	}
+}
+
+func generalChecklistFindings(spec *notes.Note) []SpecChecklistFinding {
+	var findings []SpecChecklistFinding
+	if sectionLooksThin(notes.ExtractSection(spec.Content, "Goals")) {
+		findings = append(findings, SpecChecklistFinding{
+			Severity:       "warn",
+			Area:           "Goals",
+			Message:        "The general checklist expects more concrete outcome framing under ## Goals.",
+			Recommendation: "Expand ## Goals with the clearest user-facing or execution-facing outcomes for this spec.",
+		})
+	}
+	if sectionLooksThin(notes.ExtractSection(spec.Content, "Non-Goals")) {
+		findings = append(findings, SpecChecklistFinding{
+			Severity:       "warn",
+			Area:           "Non-Goals",
+			Message:        "The general checklist expects explicit non-goals so scope stays bounded.",
+			Recommendation: "Add concrete exclusions under ## Non-Goals.",
+		})
+	}
+	if sectionLooksThin(notes.ExtractSection(spec.Content, "Solution Shape")) {
+		findings = append(findings, SpecChecklistFinding{
+			Severity:       "warn",
+			Area:           "Solution Shape",
+			Message:        "The general checklist expects enough solution-shape detail to guide later story slicing.",
+			Recommendation: "Expand ## Solution Shape with the intended approach and major boundary decisions.",
+		})
+	}
+	verification := notes.ExtractSection(spec.Content, "Verification")
+	if strings.TrimSpace(verification) == "" || sectionLooksThin(verification) {
+		findings = append(findings, SpecChecklistFinding{
+			Severity:       "error",
+			Area:           "Verification",
+			Message:        "The general checklist requires concrete verification so the spec can be executed safely.",
+			Recommendation: "Add explicit checks, tests, or validation flows under ## Verification.",
+		})
+	}
+	return findings
+}
+
+func uiFlowChecklistFindings(spec *notes.Note) []SpecChecklistFinding {
+	var findings []SpecChecklistFinding
+	flows := notes.ExtractSection(spec.Content, "Flows")
+	if strings.TrimSpace(flows) == "" || sectionLooksThin(flows) {
+		findings = append(findings, SpecChecklistFinding{
+			Severity:       "error",
+			Area:           "Flows",
+			Message:        "The UI flow checklist requires a concrete user journey under ## Flows.",
+			Recommendation: "Describe the primary UI journey step by step under ## Flows.",
+		})
+	}
+	if !containsAny(strings.ToLower(flows), []string{"screen", "page", "modal", "form", "click", "select", "submit", "view"}) {
+		findings = append(findings, SpecChecklistFinding{
+			Severity:       "warn",
+			Area:           "Flows",
+			Message:        "The UI flow checklist expects user-facing interaction detail in ## Flows.",
+			Recommendation: "Call out the user-visible screens, inputs, or transitions the flow depends on.",
+		})
+	}
+	verification := strings.ToLower(notes.ExtractSection(spec.Content, "Verification"))
+	if !containsAny(verification, []string{"manual", "screen", "ui", "click", "form", "visual", "journey"}) {
+		findings = append(findings, SpecChecklistFinding{
+			Severity:       "warn",
+			Area:           "Verification",
+			Message:        "The UI flow checklist expects at least one user-visible verification step.",
+			Recommendation: "Add manual or UI-facing verification language under ## Verification.",
+		})
+	}
+	if sectionLooksThin(notes.ExtractSection(spec.Content, "Non-Goals")) {
+		findings = append(findings, SpecChecklistFinding{
+			Severity:       "warn",
+			Area:           "Non-Goals",
+			Message:        "UI-heavy work benefits from explicit exclusions so the flow does not balloon.",
+			Recommendation: "State which adjacent UI work is intentionally out of scope under ## Non-Goals.",
+		})
+	}
+	return findings
+}
+
+func apiIntegrationChecklistFindings(spec *notes.Note) []SpecChecklistFinding {
+	var findings []SpecChecklistFinding
+	interfaces := strings.ToLower(notes.ExtractSection(spec.Content, "Data / Interfaces"))
+	if !containsAny(interfaces, []string{"api", "endpoint", "http", "webhook", "oauth", "external", "integration", "contract"}) {
+		findings = append(findings, SpecChecklistFinding{
+			Severity:       "error",
+			Area:           "Data / Interfaces",
+			Message:        "The API integration checklist requires the external contract to be described under ## Data / Interfaces.",
+			Recommendation: "Document the relevant endpoint, payload, auth, or contract details under ## Data / Interfaces.",
+		})
+	}
+	risks := strings.ToLower(notes.ExtractSection(spec.Content, "Risks / Open Questions"))
+	if !containsAny(risks, []string{"timeout", "retry", "failure", "auth", "ownership", "contract", "rate", "limit", "webhook"}) {
+		findings = append(findings, SpecChecklistFinding{
+			Severity:       "warn",
+			Area:           "Risks / Open Questions",
+			Message:        "The API integration checklist expects dependency and failure-handling risks to be called out.",
+			Recommendation: "Add external-contract, auth, timeout, retry, or ownership risks under ## Risks / Open Questions.",
+		})
+	}
+	rollout := strings.ToLower(notes.ExtractSection(spec.Content, "Rollout"))
+	if !containsAny(rollout, []string{"flag", "fallback", "monitor", "observe", "rollback", "backward"}) {
+		findings = append(findings, SpecChecklistFinding{
+			Severity:       "warn",
+			Area:           "Rollout",
+			Message:        "The API integration checklist expects rollout safety for external dependency changes.",
+			Recommendation: "Describe flags, fallback paths, monitoring, or backward-compatibility concerns under ## Rollout.",
+		})
+	}
+	return findings
+}
+
+func dataMigrationChecklistFindings(spec *notes.Note) []SpecChecklistFinding {
+	var findings []SpecChecklistFinding
+	interfaces := strings.ToLower(notes.ExtractSection(spec.Content, "Data / Interfaces"))
+	if !containsAny(interfaces, []string{"migration", "schema", "table", "column", "backfill", "data", "database"}) {
+		findings = append(findings, SpecChecklistFinding{
+			Severity:       "error",
+			Area:           "Data / Interfaces",
+			Message:        "The data migration checklist requires the schema or data-shape change to be described under ## Data / Interfaces.",
+			Recommendation: "Document the migration, backfill, or data-shape changes under ## Data / Interfaces.",
+		})
+	}
+	rollout := strings.ToLower(notes.ExtractSection(spec.Content, "Rollout"))
+	if !containsAny(rollout, []string{"rollback", "backfill", "batch", "monitor", "flag", "rehearse"}) {
+		findings = append(findings, SpecChecklistFinding{
+			Severity:       "warn",
+			Area:           "Rollout",
+			Message:        "The data migration checklist expects rollback, backfill, or rollout-safety detail.",
+			Recommendation: "Add rollout safety details such as rollback, batching, or backfill sequencing under ## Rollout.",
+		})
+	}
+	verification := strings.ToLower(notes.ExtractSection(spec.Content, "Verification"))
+	if !containsAny(verification, []string{"data", "migration", "backfill", "integrity", "row", "record", "schema"}) {
+		findings = append(findings, SpecChecklistFinding{
+			Severity:       "warn",
+			Area:           "Verification",
+			Message:        "The data migration checklist expects data validation beyond generic testing language.",
+			Recommendation: "Describe how migrated data, backfills, or schema changes will be validated under ## Verification.",
+		})
+	}
+	return findings
+}
+
+func renderSpecChecklistReport(report *SpecChecklistReport) string {
+	var lines []string
+	status := "ok"
+	if report.HasBlockingFindings() {
+		status = "action_needed"
+	} else if len(report.Findings) > 0 {
+		status = "guidance"
+	}
+	lines = append(lines,
+		"status: "+status,
+		fmt.Sprintf("blocking_findings: %d", report.BlockingCount()),
+		fmt.Sprintf("guidance_findings: %d", report.WarningCount()),
+	)
+	if len(report.Findings) == 0 {
+		lines = append(lines, "", "- [ok] No findings.")
+		return strings.Join(lines, "\n")
+	}
+	lines = append(lines, "")
+	for _, finding := range report.Findings {
+		lines = append(lines, fmt.Sprintf("- [%s] %s: %s", finding.Severity, finding.Area, finding.Message))
+		if strings.TrimSpace(finding.Recommendation) != "" {
+			lines = append(lines, "  fix: "+finding.Recommendation)
+		}
+	}
+	return strings.Join(lines, "\n")
+}
+
+func dedupeChecklistFindings(findings []SpecChecklistFinding) []SpecChecklistFinding {
+	seen := map[string]struct{}{}
+	var out []SpecChecklistFinding
+	for _, finding := range findings {
+		key := finding.Severity + "|" + finding.Area + "|" + finding.Message + "|" + finding.Recommendation
+		if _, ok := seen[key]; ok {
+			continue
+		}
+		seen[key] = struct{}{}
+		out = append(out, finding)
+	}
+	return out
+}

--- a/internal/planning/checklist_test.go
+++ b/internal/planning/checklist_test.go
@@ -1,0 +1,96 @@
+package planning
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"plan/internal/notes"
+	"plan/internal/workspace"
+)
+
+func TestRunSpecChecklistPreservesMultipleProfiles(t *testing.T) {
+	root := t.TempDir()
+	ws := workspace.New(root)
+	if _, err := ws.Init(); err != nil {
+		t.Fatal(err)
+	}
+	manager := New(ws)
+
+	if _, err := manager.CreateEpic("Billing", ""); err != nil {
+		t.Fatal(err)
+	}
+	body := strings.Join([]string{
+		"# Billing Spec",
+		"",
+		"Created: now",
+		"",
+		"## Why",
+		"",
+		"Billing needs a safer integration path.",
+		"",
+		"## Problem",
+		"",
+		"Billing integration work is underspecified.",
+		"",
+		"## Goals",
+		"",
+		"- ship the safer path",
+		"",
+		"## Non-Goals",
+		"",
+		"- redesign all billing UX",
+		"",
+		"## Constraints",
+		"",
+		"- stay local-first",
+		"",
+		"## Solution Shape",
+		"",
+		"Add an API export and a schema migration.",
+		"",
+		"## Flows",
+		"",
+		"1. Open the billing export screen.",
+		"2. Submit the export form.",
+		"",
+		"## Data / Interfaces",
+		"",
+		"- external API contract",
+		"- schema migration for export state",
+		"",
+		"## Risks / Open Questions",
+		"",
+		"- auth timeout handling",
+		"- migration rollout",
+		"",
+		"## Rollout",
+		"",
+		"- ship behind a flag with rollback and monitoring",
+		"",
+		"## Verification",
+		"",
+		"- manual UI verification",
+		"- validate migration data integrity",
+		"",
+	}, "\n")
+	if _, err := manager.UpdateSpec("billing", notes.UpdateInput{Body: &body}); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := manager.RunSpecChecklist("billing", checklistProfileUIFlow); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := manager.RunSpecChecklist("billing", checklistProfileAPIIntegration); err != nil {
+		t.Fatal(err)
+	}
+
+	note, err := notes.Read(filepath.Join(root, ".plan", "specs", "billing.md"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	checklist := notes.ExtractSection(note.Content, "Checklist")
+	if !strings.Contains(checklist, "### ui-flow") || !strings.Contains(checklist, "### api-integration") {
+		t.Fatalf("expected multiple checklist profiles to persist:\n%s", checklist)
+	}
+}

--- a/internal/planning/evals.go
+++ b/internal/planning/evals.go
@@ -1,0 +1,287 @@
+package planning
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"runtime"
+	"sort"
+	"strings"
+
+	"plan/internal/notes"
+)
+
+type RubricScores struct {
+	Clarity             int `json:"clarity"`
+	Boundedness         int `json:"boundedness"`
+	RiskCoverage        int `json:"risk_coverage"`
+	NonGoalQuality      int `json:"non_goal_quality"`
+	VerificationQuality int `json:"verification_quality"`
+	StorySliceQuality   int `json:"story_slice_quality"`
+	AgentExecutability  int `json:"agent_executability"`
+	ArtifactSimplicity  int `json:"artifact_simplicity"`
+	UserEffortCost      int `json:"user_effort_cost"`
+}
+
+type BenchmarkFixture struct {
+	Slug          string       `json:"slug"`
+	Title         string       `json:"title"`
+	ArtifactType  string       `json:"artifact_type"`
+	Scenario      string       `json:"scenario"`
+	Candidate     string       `json:"candidate"`
+	MinimumScores RubricScores `json:"minimum_scores"`
+}
+
+type BenchmarkEvaluation struct {
+	Fixture BenchmarkFixture `json:"fixture"`
+	Scores  RubricScores     `json:"scores"`
+}
+
+func (s RubricScores) MeetsMinimum(min RubricScores) bool {
+	return s.Clarity >= min.Clarity &&
+		s.Boundedness >= min.Boundedness &&
+		s.RiskCoverage >= min.RiskCoverage &&
+		s.NonGoalQuality >= min.NonGoalQuality &&
+		s.VerificationQuality >= min.VerificationQuality &&
+		s.StorySliceQuality >= min.StorySliceQuality &&
+		s.AgentExecutability >= min.AgentExecutability &&
+		s.ArtifactSimplicity >= min.ArtifactSimplicity &&
+		s.UserEffortCost >= min.UserEffortCost
+}
+
+func LoadBenchmarkFixtures() ([]BenchmarkFixture, error) {
+	dir, err := benchmarkFixtureDir()
+	if err != nil {
+		return nil, err
+	}
+	return LoadBenchmarkFixturesFromDir(dir)
+}
+
+func LoadBenchmarkFixturesFromDir(dir string) ([]BenchmarkFixture, error) {
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return nil, fmt.Errorf("read benchmark fixtures: %w", err)
+	}
+	var fixtures []BenchmarkFixture
+	for _, entry := range entries {
+		if entry.IsDir() || filepath.Ext(entry.Name()) != ".json" {
+			continue
+		}
+		raw, err := os.ReadFile(filepath.Join(dir, entry.Name()))
+		if err != nil {
+			return nil, fmt.Errorf("read benchmark fixture %s: %w", entry.Name(), err)
+		}
+		var fixture BenchmarkFixture
+		if err := json.Unmarshal(raw, &fixture); err != nil {
+			return nil, fmt.Errorf("parse benchmark fixture %s: %w", entry.Name(), err)
+		}
+		if strings.TrimSpace(fixture.Slug) == "" || strings.TrimSpace(fixture.Candidate) == "" {
+			return nil, fmt.Errorf("benchmark fixture %s is missing required content", entry.Name())
+		}
+		fixtures = append(fixtures, fixture)
+	}
+	sort.Slice(fixtures, func(i, j int) bool {
+		return fixtures[i].Slug < fixtures[j].Slug
+	})
+	return fixtures, nil
+}
+
+func EvaluateBenchmarkFixture(fixture BenchmarkFixture) BenchmarkEvaluation {
+	candidate := fixture.Candidate
+	clarity := scoreClarity(candidate)
+	boundedness := scoreBoundedness(candidate)
+	riskCoverage := scoreRiskCoverage(candidate)
+	nonGoalQuality := scoreNonGoalQuality(candidate)
+	verificationQuality := scoreVerificationQuality(candidate)
+	storySliceQuality := scoreStorySliceQuality(candidate)
+	agentExecutability := clampScore((clarity+boundedness+verificationQuality)/3 + boolScore(hasStrongSection(candidate, "Solution Shape") || hasStrongSection(candidate, "Description")), 0, 5)
+	artifactSimplicity := scoreArtifactSimplicity(candidate)
+	userEffortCost := scoreUserEffortCost(candidate)
+
+	return BenchmarkEvaluation{
+		Fixture: fixture,
+		Scores: RubricScores{
+			Clarity:             clarity,
+			Boundedness:         boundedness,
+			RiskCoverage:        riskCoverage,
+			NonGoalQuality:      nonGoalQuality,
+			VerificationQuality: verificationQuality,
+			StorySliceQuality:   storySliceQuality,
+			AgentExecutability:  agentExecutability,
+			ArtifactSimplicity:  artifactSimplicity,
+			UserEffortCost:      userEffortCost,
+		},
+	}
+}
+
+func benchmarkFixtureDir() (string, error) {
+	_, file, _, ok := runtime.Caller(0)
+	if !ok {
+		return "", fmt.Errorf("resolve benchmark fixture dir")
+	}
+	root := filepath.Dir(filepath.Dir(filepath.Dir(file)))
+	return filepath.Join(root, "testdata", "evals", "fixtures"), nil
+}
+
+func scoreClarity(candidate string) int {
+	score := 0
+	if hasStrongSection(candidate, "Problem") {
+		score += 2
+	}
+	if hasStrongSection(candidate, "Goals") {
+		score += 2
+	}
+	if hasStrongSection(candidate, "Why") || hasStrongSection(candidate, "Outcome") {
+		score++
+	}
+	return clampScore(score, 0, 5)
+}
+
+func scoreBoundedness(candidate string) int {
+	score := 0
+	if hasStrongSection(candidate, "Constraints") {
+		score++
+	}
+	if hasStrongSection(candidate, "Non-Goals") {
+		score += 2
+	}
+	if hasStrongSection(candidate, "Scope Boundary") || hasStrongSection(candidate, "Appetite") {
+		score += 2
+	}
+	return clampScore(score, 0, 5)
+}
+
+func scoreRiskCoverage(candidate string) int {
+	score := 0
+	risks := notes.ExtractSection(candidate, "Risks / Open Questions")
+	if strings.TrimSpace(risks) != "" {
+		score += 2
+	}
+	if !sectionLooksThin(risks) {
+		score++
+	}
+	if containsAny(strings.ToLower(candidate), []string{"risk", "rollback", "failure", "assumption", "rabbit hole", "dependency"}) {
+		score += 2
+	}
+	return clampScore(score, 0, 5)
+}
+
+func scoreNonGoalQuality(candidate string) int {
+	nonGoals := notes.ExtractSection(candidate, "Non-Goals")
+	score := 0
+	if strings.TrimSpace(nonGoals) != "" {
+		score += 2
+	}
+	if !sectionLooksThin(nonGoals) {
+		score += 2
+	}
+	if containsAny(strings.ToLower(nonGoals), []string{"not", "exclude", "avoid", "no "}) {
+		score++
+	}
+	return clampScore(score, 0, 5)
+}
+
+func scoreVerificationQuality(candidate string) int {
+	verification := notes.ExtractSection(candidate, "Verification")
+	score := 0
+	if strings.TrimSpace(verification) != "" {
+		score += 2
+	}
+	if !sectionLooksThin(verification) {
+		score++
+	}
+	if containsAny(strings.ToLower(verification), []string{"test", "validate", "manual", "verify", "assert", "check"}) {
+		score += 2
+	}
+	return clampScore(score, 0, 5)
+}
+
+func scoreStorySliceQuality(candidate string) int {
+	score := 0
+	if hasStrongSection(candidate, "Story Breakdown") || hasStrongSection(candidate, "Acceptance Criteria") {
+		score += 2
+	}
+	if bulletCount(candidate) >= 3 {
+		score++
+	}
+	if containsAny(strings.ToLower(candidate), []string{"story", "slice", "increment", "acceptance"}) {
+		score += 2
+	}
+	return clampScore(score, 0, 5)
+}
+
+func scoreArtifactSimplicity(candidate string) int {
+	score := 5
+	if headingCount(candidate) > 18 {
+		score--
+	}
+	if len(strings.Fields(candidate)) > 350 {
+		score--
+	}
+	if bulletCount(candidate) > 25 {
+		score--
+	}
+	return clampScore(score, 1, 5)
+}
+
+func scoreUserEffortCost(candidate string) int {
+	score := 5
+	if headingCount(candidate) > 16 {
+		score--
+	}
+	if len(strings.Fields(candidate)) > 300 {
+		score--
+	}
+	if bulletCount(candidate) > 20 {
+		score--
+	}
+	return clampScore(score, 1, 5)
+}
+
+func hasStrongSection(candidate, heading string) bool {
+	section := notes.ExtractSection(candidate, heading)
+	if strings.TrimSpace(section) == "" {
+		return false
+	}
+	return !sectionLooksThin(section)
+}
+
+func headingCount(candidate string) int {
+	count := 0
+	for _, line := range strings.Split(candidate, "\n") {
+		if strings.HasPrefix(strings.TrimSpace(line), "#") {
+			count++
+		}
+	}
+	return count
+}
+
+func bulletCount(candidate string) int {
+	count := 0
+	for _, line := range strings.Split(candidate, "\n") {
+		trimmed := strings.TrimSpace(line)
+		if strings.HasPrefix(trimmed, "- ") || strings.HasPrefix(trimmed, "* ") || strings.HasPrefix(trimmed, "1. ") {
+			count++
+		}
+	}
+	return count
+}
+
+func clampScore(value, min, max int) int {
+	switch {
+	case value < min:
+		return min
+	case value > max:
+		return max
+	default:
+		return value
+	}
+}
+
+func boolScore(ok bool) int {
+	if ok {
+		return 1
+	}
+	return 0
+}

--- a/internal/planning/evals_test.go
+++ b/internal/planning/evals_test.go
@@ -1,0 +1,40 @@
+package planning
+
+import "testing"
+
+func TestLoadBenchmarkFixtures(t *testing.T) {
+	fixtures, err := LoadBenchmarkFixtures()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(fixtures) < 3 {
+		t.Fatalf("expected at least 3 benchmark fixtures, got %d", len(fixtures))
+	}
+}
+
+func TestRubricEvaluationIsDeterministic(t *testing.T) {
+	fixtures, err := LoadBenchmarkFixtures()
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, fixture := range fixtures {
+		first := EvaluateBenchmarkFixture(fixture)
+		second := EvaluateBenchmarkFixture(fixture)
+		if first.Scores != second.Scores {
+			t.Fatalf("expected deterministic scores for %s: %+v != %+v", fixture.Slug, first.Scores, second.Scores)
+		}
+	}
+}
+
+func TestBenchmarkFixturesSatisfyMinimumScores(t *testing.T) {
+	fixtures, err := LoadBenchmarkFixtures()
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, fixture := range fixtures {
+		evaluation := EvaluateBenchmarkFixture(fixture)
+		if !evaluation.Scores.MeetsMinimum(fixture.MinimumScores) {
+			t.Fatalf("fixture %s failed minimum scores: got %+v want %+v", fixture.Slug, evaluation.Scores, fixture.MinimumScores)
+		}
+	}
+}

--- a/internal/planning/refinement.go
+++ b/internal/planning/refinement.go
@@ -78,16 +78,16 @@ func (m *Manager) UpdateBrainstormRefinement(brainstormSlug string, input Brains
 		current.UserValue = strings.TrimSpace(input.UserValue)
 	}
 	if strings.TrimSpace(input.Constraints) != "" {
-		current.Constraints = normalizeBrainstormList(input.Constraints)
+		current.Constraints = normalizeBulletList(input.Constraints)
 	}
 	if strings.TrimSpace(input.Appetite) != "" {
 		current.Appetite = strings.TrimSpace(input.Appetite)
 	}
 	if strings.TrimSpace(input.RemainingOpenQuestions) != "" {
-		current.RemainingOpenQuestions = normalizeBrainstormList(input.RemainingOpenQuestions)
+		current.RemainingOpenQuestions = normalizeBulletList(input.RemainingOpenQuestions)
 	}
 	if strings.TrimSpace(input.CandidateApproaches) != "" {
-		current.CandidateApproaches = normalizeBrainstormList(input.CandidateApproaches)
+		current.CandidateApproaches = normalizeBulletList(input.CandidateApproaches)
 	}
 	if strings.TrimSpace(input.DecisionSnapshot) != "" {
 		current.DecisionSnapshot = strings.TrimSpace(input.DecisionSnapshot)
@@ -111,13 +111,13 @@ func (m *Manager) UpdateBrainstormRefinement(brainstormSlug string, input Brains
 
 func extractBrainstormRefinement(note *notes.Note) BrainstormRefinement {
 	return BrainstormRefinement{
-		Problem:                notes.ExtractSection(note.Content, "Problem"),
-		UserValue:              notes.ExtractSection(note.Content, "User / Value"),
+		Problem:                extractSubsection(note.Content, "Refinement", "Problem"),
+		UserValue:              extractSubsection(note.Content, "Refinement", "User / Value"),
 		Constraints:            notes.ExtractSection(note.Content, "Constraints"),
-		Appetite:               notes.ExtractSection(note.Content, "Appetite"),
-		RemainingOpenQuestions: notes.ExtractSection(note.Content, "Open Questions"),
-		CandidateApproaches:    notes.ExtractSection(note.Content, "Candidate Approaches"),
-		DecisionSnapshot:       notes.ExtractSection(note.Content, "Decision Snapshot"),
+		Appetite:               extractSubsection(note.Content, "Refinement", "Appetite"),
+		RemainingOpenQuestions: extractSubsection(note.Content, "Refinement", "Remaining Open Questions"),
+		CandidateApproaches:    extractSubsection(note.Content, "Refinement", "Candidate Approaches"),
+		DecisionSnapshot:       extractSubsection(note.Content, "Refinement", "Decision Snapshot"),
 	}
 }
 
@@ -130,31 +130,4 @@ func renderBrainstormRefinement(refinement BrainstormRefinement) string {
 	appendSubsection(&lines, "Candidate Approaches", refinement.CandidateApproaches)
 	appendSubsection(&lines, "Decision Snapshot", refinement.DecisionSnapshot)
 	return strings.Join(lines, "\n")
-}
-
-func appendSubsection(lines *[]string, heading, body string) {
-	if len(*lines) > 0 {
-		*lines = append(*lines, "")
-	}
-	*lines = append(*lines, "### "+heading, "")
-	body = strings.TrimSpace(body)
-	if body == "" {
-		return
-	}
-	*lines = append(*lines, strings.Split(body, "\n")...)
-}
-
-func normalizeBrainstormList(body string) string {
-	var items []string
-	for _, line := range strings.Split(strings.TrimSpace(body), "\n") {
-		line = strings.TrimSpace(strings.TrimPrefix(strings.TrimPrefix(line, "- "), "* "))
-		if line == "" {
-			continue
-		}
-		items = append(items, "- "+line)
-	}
-	if len(items) == 0 {
-		return ""
-	}
-	return strings.Join(items, "\n")
 }

--- a/internal/planning/sections.go
+++ b/internal/planning/sections.go
@@ -1,0 +1,95 @@
+package planning
+
+import (
+	"slices"
+	"strings"
+
+	"plan/internal/notes"
+)
+
+func appendSubsection(lines *[]string, heading, body string) {
+	if len(*lines) > 0 {
+		*lines = append(*lines, "")
+	}
+	*lines = append(*lines, "### "+heading, "")
+	body = strings.TrimSpace(body)
+	if body == "" {
+		return
+	}
+	*lines = append(*lines, strings.Split(body, "\n")...)
+}
+
+func normalizeBulletList(body string) string {
+	var items []string
+	for _, line := range strings.Split(strings.TrimSpace(body), "\n") {
+		line = strings.TrimSpace(strings.TrimPrefix(strings.TrimPrefix(line, "- "), "* "))
+		if line == "" {
+			continue
+		}
+		items = append(items, "- "+line)
+	}
+	if len(items) == 0 {
+		return ""
+	}
+	return strings.Join(items, "\n")
+}
+
+func extractSubsection(content, parentHeading, childHeading string) string {
+	if strings.TrimSpace(parentHeading) == "" {
+		return notes.ExtractSection(content, childHeading)
+	}
+	return notes.ExtractNestedSection(content, parentHeading, childHeading)
+}
+
+func replaceNamedSubsection(sectionBody, heading, body string) string {
+	names := []string{heading}
+	for _, name := range allNamedSubsections(sectionBody) {
+		if name != heading {
+			names = append(names, name)
+		}
+	}
+	slices.Sort(names)
+
+	sections := map[string]string{heading: strings.TrimSpace(body)}
+	for _, name := range allNamedSubsections(sectionBody) {
+		if name == heading {
+			continue
+		}
+		sections[name] = notes.ExtractSection(sectionBody, name)
+	}
+	return renderNamedSubsections(names, sections)
+}
+
+func renderNamedSubsections(order []string, sections map[string]string) string {
+	var lines []string
+	for _, name := range order {
+		body := strings.TrimSpace(sections[name])
+		if body == "" {
+			continue
+		}
+		appendSubsection(&lines, name, body)
+	}
+	return strings.Join(lines, "\n")
+}
+
+func allNamedSubsections(sectionBody string) []string {
+	lines := strings.Split(sectionBody, "\n")
+	seen := map[string]struct{}{}
+	var out []string
+	for _, line := range lines {
+		trimmed := strings.TrimSpace(line)
+		if !strings.HasPrefix(trimmed, "### ") {
+			continue
+		}
+		name := strings.TrimSpace(strings.TrimPrefix(trimmed, "### "))
+		if name == "" {
+			continue
+		}
+		if _, ok := seen[name]; ok {
+			continue
+		}
+		seen[name] = struct{}{}
+		out = append(out, name)
+	}
+	return out
+}

--- a/internal/planning/shape.go
+++ b/internal/planning/shape.go
@@ -1,0 +1,133 @@
+package planning
+
+import (
+	"fmt"
+	"path/filepath"
+	"strings"
+
+	"plan/internal/notes"
+)
+
+type EpicShape struct {
+	Path          string
+	Appetite      string
+	Outcome       string
+	ScopeBoundary string
+	OutOfScope    string
+	SuccessSignal string
+}
+
+type EpicShapeInput struct {
+	Appetite      string
+	Outcome       string
+	ScopeBoundary string
+	OutOfScope    string
+	SuccessSignal string
+}
+
+func (s EpicShape) HasGaps() bool {
+	return strings.TrimSpace(s.Appetite) == "" ||
+		strings.TrimSpace(s.Outcome) == "" ||
+		strings.TrimSpace(s.ScopeBoundary) == "" ||
+		strings.TrimSpace(s.OutOfScope) == "" ||
+		strings.TrimSpace(s.SuccessSignal) == ""
+}
+
+func (m *Manager) ReadEpicShape(epicSlug string) (*EpicShape, error) {
+	info, err := m.workspace.EnsureInitialized()
+	if err != nil {
+		return nil, err
+	}
+	note, err := notes.Read(filepath.Join(info.EpicsDir, slugify(epicSlug)+".md"))
+	if err != nil {
+		return nil, err
+	}
+	if note.Type != "epic" {
+		return nil, fmt.Errorf("%s is not an epic note", note.Path)
+	}
+	state := extractEpicShape(note)
+	state.Path = rel(info.ProjectDir, note.Path)
+	return &state, nil
+}
+
+func (m *Manager) UpdateEpicShape(epicSlug string, input EpicShapeInput) (*notes.Note, error) {
+	info, err := m.workspace.EnsureInitialized()
+	if err != nil {
+		return nil, err
+	}
+	path := filepath.Join(info.EpicsDir, slugify(epicSlug)+".md")
+	note, err := notes.Read(path)
+	if err != nil {
+		return nil, err
+	}
+	if note.Type != "epic" {
+		return nil, fmt.Errorf("%s is not an epic note", note.Path)
+	}
+
+	current := extractEpicShape(note)
+	if strings.TrimSpace(input.Appetite) != "" {
+		current.Appetite = strings.TrimSpace(input.Appetite)
+	}
+	if strings.TrimSpace(input.Outcome) != "" {
+		current.Outcome = strings.TrimSpace(input.Outcome)
+	}
+	if strings.TrimSpace(input.ScopeBoundary) != "" {
+		current.ScopeBoundary = strings.TrimSpace(input.ScopeBoundary)
+	}
+	if strings.TrimSpace(input.OutOfScope) != "" {
+		current.OutOfScope = normalizeBulletList(input.OutOfScope)
+	}
+	if strings.TrimSpace(input.SuccessSignal) != "" {
+		current.SuccessSignal = strings.TrimSpace(input.SuccessSignal)
+	}
+
+	body := note.Content
+	if strings.TrimSpace(current.Outcome) != "" {
+		body = notes.SetSection(body, "Outcome", current.Outcome)
+	}
+	if scopeSummary := renderEpicScopeSummary(current.ScopeBoundary, current.OutOfScope); scopeSummary != "" {
+		body = notes.SetSection(body, "Scope Boundary", scopeSummary)
+	}
+	body = notes.SetSection(body, "Shape", renderEpicShape(current))
+
+	updated, err := notes.Update(path, notes.UpdateInput{Body: &body})
+	if err != nil {
+		return nil, err
+	}
+	return m.relNote(updated, info.ProjectDir), nil
+}
+
+func extractEpicShape(note *notes.Note) EpicShape {
+	return EpicShape{
+		Appetite:      extractSubsection(note.Content, "Shape", "Appetite"),
+		Outcome:       extractSubsection(note.Content, "Shape", "Outcome"),
+		ScopeBoundary: extractSubsection(note.Content, "Shape", "Scope Boundary"),
+		OutOfScope:    extractSubsection(note.Content, "Shape", "Out of Scope"),
+		SuccessSignal: extractSubsection(note.Content, "Shape", "Success Signal"),
+	}
+}
+
+func renderEpicShape(shape EpicShape) string {
+	var lines []string
+	appendSubsection(&lines, "Appetite", shape.Appetite)
+	appendSubsection(&lines, "Outcome", shape.Outcome)
+	appendSubsection(&lines, "Scope Boundary", shape.ScopeBoundary)
+	appendSubsection(&lines, "Out of Scope", shape.OutOfScope)
+	appendSubsection(&lines, "Success Signal", shape.SuccessSignal)
+	return strings.Join(lines, "\n")
+}
+
+func renderEpicScopeSummary(scopeBoundary, outOfScope string) string {
+	scopeBoundary = strings.TrimSpace(scopeBoundary)
+	outOfScope = strings.TrimSpace(outOfScope)
+	switch {
+	case scopeBoundary == "" && outOfScope == "":
+		return ""
+	case outOfScope == "":
+		return scopeBoundary
+	case scopeBoundary == "":
+		return "Not in scope:\n\n" + outOfScope
+	default:
+		return scopeBoundary + "\n\nNot in scope:\n\n" + outOfScope
+	}
+}

--- a/internal/planning/shape_test.go
+++ b/internal/planning/shape_test.go
@@ -1,0 +1,46 @@
+package planning
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"plan/internal/notes"
+	"plan/internal/workspace"
+)
+
+func TestUpdateEpicShapeWritesShapeSectionAndMirrorsSummary(t *testing.T) {
+	root := t.TempDir()
+	ws := workspace.New(root)
+	if _, err := ws.Init(); err != nil {
+		t.Fatal(err)
+	}
+	manager := New(ws)
+
+	if _, err := manager.CreateEpic("Billing", ""); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := manager.UpdateEpicShape("billing", EpicShapeInput{
+		Appetite:      "One extra shaping pass before spec approval.",
+		Outcome:       "Make epics feel like bounded bets.",
+		ScopeBoundary: "Capture appetite and out-of-scope decisions for each epic.",
+		OutOfScope:    "Do not build tracker sync\nDo not add hosted services",
+		SuccessSignal: "Specs inherit clearer boundaries without extra artifact types.",
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	note, err := notes.Read(filepath.Join(root, ".plan", "epics", "billing.md"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(note.Content, "## Shape") || !strings.Contains(note.Content, "### Appetite") {
+		t.Fatalf("expected shape section:\n%s", note.Content)
+	}
+	if !strings.Contains(note.Content, "## Outcome\n\nMake epics feel like bounded bets.") {
+		t.Fatalf("expected mirrored top-level outcome:\n%s", note.Content)
+	}
+	if !strings.Contains(note.Content, "Not in scope:\n\n- Do not build tracker sync") {
+		t.Fatalf("expected mirrored out-of-scope summary:\n%s", note.Content)
+	}
+}

--- a/internal/skills/install_test.go
+++ b/internal/skills/install_test.go
@@ -196,6 +196,31 @@ func TestInstallRepairsLegacyInstallCleanly(t *testing.T) {
 	}
 }
 
+func TestSourceTreeBundleInstallsModelGuidanceFiles(t *testing.T) {
+	RegisterBundle(nil)
+
+	home := t.TempDir()
+	installer := NewInstaller(home)
+	if _, err := installer.Install(InstallRequest{
+		Scope:  ScopeGlobal,
+		Agents: []string{"codex"},
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	skillDir := filepath.Join(home, ".codex", "skills", "plan")
+	for _, rel := range []string{
+		"SKILL.md",
+		filepath.Join("agents", "openai.yaml"),
+		filepath.Join("agents", "gpt-style.yaml"),
+		filepath.Join("agents", "reasoning.yaml"),
+	} {
+		if _, err := os.Stat(filepath.Join(skillDir, rel)); err != nil {
+			t.Fatalf("expected installed skill file %s: %v", rel, err)
+		}
+	}
+}
+
 func registerTestBundle(t *testing.T) string {
 	t.Helper()
 

--- a/internal/templates/brainstorm.md
+++ b/internal/templates/brainstorm.md
@@ -27,3 +27,15 @@ Started: {{ .Now }}
 ### Candidate Approaches
 
 ### Decision Snapshot
+
+## Challenge
+
+### Rabbit Holes
+
+### No-Gos
+
+### Assumptions
+
+### Likely Overengineering
+
+### Simpler Alternative

--- a/internal/templates/epic.md
+++ b/internal/templates/epic.md
@@ -6,6 +6,18 @@ Created: {{ .Now }}
 
 ## Why Now
 
+## Shape
+
+### Appetite
+
+### Outcome
+
+### Scope Boundary
+
+### Out of Scope
+
+### Success Signal
+
 ## Scope Boundary
 
 ## Spec

--- a/internal/templates/spec.md
+++ b/internal/templates/spec.md
@@ -40,6 +40,8 @@ Created: {{ .Now }}
 
 ### Recommended Revisions
 
+## Checklist
+
 ## Resources
 
 ## Notes

--- a/skills/plan/SKILL.md
+++ b/skills/plan/SKILL.md
@@ -40,10 +40,13 @@ When a repo uses `plan`:
 - `plan brainstorm start --project . "<topic>"`
 - `plan brainstorm idea --project . <brainstorm-slug> --body "<idea>"`
 - `plan brainstorm refine --project . <brainstorm-slug>`
+- `plan brainstorm challenge --project . <brainstorm-slug>`
 - `plan epic create --project . "<title>"`
 - `plan epic promote --project . <brainstorm-slug>`
+- `plan epic shape --project . <epic-slug>`
 - `plan spec show --project . <epic-slug>`
 - `plan spec analyze --project . <epic-slug>`
+- `plan spec checklist --project . <epic-slug> --profile general`
 - `plan spec status --project . <epic-slug> --set approved`
 - `plan story create --project . <epic-slug> "<title>" --criteria "<criterion>" --verify "<step>"`
 - `plan story update --project . <story-slug> --status in_progress`
@@ -55,7 +58,50 @@ When a repo uses `plan`:
 - Brainstorms are discovery material, not the canonical hierarchy.
 - Canonical hierarchy is `Epic -> Spec -> Story`.
 - `brainstorm refine` should reduce ambiguity before promotion.
+- `brainstorm challenge` should pressure-test risk, no-gos, and overengineering before promotion.
+- `epic shape` should turn an epic into a bounded bet with appetite and success signal.
 - `spec analyze` should pressure-test a spec without rewriting its canonical sections.
+- `spec checklist` should add profile-driven rigor without mutating the canonical sections.
 - Keep roadmap guidance lightweight.
 - Do not add tasks beneath stories as first-class objects unless the project explicitly asks for that system.
 - Keep planning separate from memory, retrieval, or context management systems.
+
+## Planning Modes
+
+Use the smallest pass that resolves the current planning gap:
+
+1. `brainstorm refine` for ambiguity reduction
+2. `brainstorm challenge` for rabbit holes, no-gos, and simplification pressure
+3. `epic shape` for appetite and scope boundaries
+4. `spec analyze` for general refinement gaps
+5. `spec checklist` for domain-specific review
+
+## Model Guidance
+
+### GPT-style Models
+
+- prefer explicit step order
+- restate the artifact you are editing before making changes
+- keep output contracts concrete and named
+- ask clarifying questions only when ambiguity would materially damage the plan
+- use the lightest shaping pass that can resolve the gap
+
+### Reasoning-Heavy Models
+
+- start from the product goal and current artifact quality
+- search for second-order issues such as missing non-goals, hidden dependencies, and rollout gaps
+- keep recommendations bounded; do not sprawl into new systems
+- verify the artifact remains simple after adding rigor
+
+## Completion Contract
+
+- specs stay canonical
+- shaping passes stay additive
+- optional rigor must not make the default path ceremonial
+- every recommendation should improve clarity, boundedness, verification, or executability
+
+## Ambiguity Handling
+
+- if the next shaping pass is obvious, run it
+- if two passes could apply, choose the lighter one first
+- do not turn `plan` into memory, context, or execution orchestration

--- a/skills/plan/agents/gpt-style.yaml
+++ b/skills/plan/agents/gpt-style.yaml
@@ -1,0 +1,18 @@
+name: plan-gpt-style
+description: Explicit, step-ordered planning guidance for GPT-style models.
+style:
+  - instructions_first
+  - clear_separators
+  - explicit_completion_contract
+  - examples_before_abstraction
+workflow:
+  - identify the artifact and current gap
+  - choose the lightest useful pass
+  - gather missing detail with explicit prompts
+  - write additive updates only
+  - verify that the artifact is still bounded and execution-ready
+checks:
+  - clarity
+  - boundedness
+  - verification_quality
+  - simplicity

--- a/skills/plan/agents/openai.yaml
+++ b/skills/plan/agents/openai.yaml
@@ -1,2 +1,33 @@
 name: plan
-description: Local-first planning guidance for repos using the `plan` CLI.
+description: Model-aware planning guidance for repos using the `plan` CLI.
+default_mode: guided
+families:
+  gpt_style:
+    use_when:
+      - The model benefits from explicit step ordering and stronger output contracts.
+      - The planning pass is interactive and should stay tightly scaffolded.
+    behavior:
+      - Name the current artifact before editing it.
+      - Prefer one planning pass at a time: refine, challenge, shape, analyze, or checklist.
+      - Keep completion criteria concrete and verification-aware.
+      - If ambiguity remains, ask only the smallest clarifying question required to keep the plan sound.
+  reasoning_heavy:
+    use_when:
+      - The model can infer structure from higher-level goals but still needs strong boundaries.
+      - The task is pressure-testing plan quality rather than filling a blank template.
+    behavior:
+      - Start from the product goal and the artifact's current gaps.
+      - Search for risk, boundedness, and verification failures before proposing new surface area.
+      - Prefer simpler alternatives when the current idea looks overbuilt.
+      - Keep the resulting artifact easy for a later implementation agent to execute.
+passes:
+  - brainstorm_refine
+  - brainstorm_challenge
+  - epic_shape
+  - spec_analyze
+  - spec_checklist
+guardrails:
+  - plan is planning-only
+  - specs remain canonical
+  - optional rigor must stay optional
+  - do not drift into memory or context management

--- a/skills/plan/agents/reasoning.yaml
+++ b/skills/plan/agents/reasoning.yaml
@@ -1,0 +1,16 @@
+name: plan-reasoning
+description: Higher-level planning guidance for reasoning-heavy models.
+style:
+  - goal_first
+  - pressure_test_second_order_risks
+  - preserve_local_first_boundaries
+workflow:
+  - inspect the artifact and identify its weakest planning dimension
+  - choose one additive shaping pass
+  - challenge overengineering and missing non-goals
+  - preserve a clean handoff for later execution
+checks:
+  - risk_coverage
+  - non_goal_quality
+  - agent_executability
+  - artifact_simplicity

--- a/testdata/evals/fixtures/agent-auth-reset.json
+++ b/testdata/evals/fixtures/agent-auth-reset.json
@@ -1,0 +1,18 @@
+{
+  "slug": "agent-auth-reset",
+  "title": "Agent Auth Reset",
+  "artifact_type": "spec",
+  "scenario": "Tight auth reset flow with clear verification and risk coverage.",
+  "candidate": "# Agent Auth Reset\n\n## Why\n\nPassword reset is error-prone for small teams using shared environments.\n\n## Problem\n\nAgents cannot guide password reset safely when the reset flow lacks clear boundaries and verification.\n\n## Goals\n\n- make password reset safe and clear\n- keep the reset path local-first and supportable\n\n## Non-Goals\n\n- redesigning all account settings\n- adding hosted auth dependencies\n\n## Constraints\n\n- keep the flow local-first\n- avoid extra artifact types\n\n## Solution Shape\n\nAdd a reset request screen, a token verification step, and a bounded admin fallback.\n\n## Flows\n\n1. Open the reset request screen.\n2. Submit the reset form.\n3. Follow the token verification step.\n\n## Data / Interfaces\n\n- reset token payload\n- local reset audit log\n\n## Risks / Open Questions\n\n- token expiry failures\n- admin fallback misuse\n- rollback if the token validation path regresses\n\n## Rollout\n\n- ship behind a flag\n- monitor reset failures and rollback on elevated error rate\n\n## Verification\n\n- run focused auth reset tests\n- manually verify the reset screen flow end to end\n\n## Story Breakdown\n\n- request reset token\n- validate token\n- confirm password change\n",
+  "minimum_scores": {
+    "clarity": 5,
+    "boundedness": 3,
+    "risk_coverage": 4,
+    "non_goal_quality": 4,
+    "verification_quality": 4,
+    "story_slice_quality": 4,
+    "agent_executability": 4,
+    "artifact_simplicity": 3,
+    "user_effort_cost": 3
+  }
+}

--- a/testdata/evals/fixtures/billing-api-export.json
+++ b/testdata/evals/fixtures/billing-api-export.json
@@ -1,0 +1,18 @@
+{
+  "slug": "billing-api-export",
+  "title": "Billing API Export",
+  "artifact_type": "spec",
+  "scenario": "External billing export with rollout and dependency risks called out.",
+  "candidate": "# Billing API Export\n\n## Why\n\nBilling exports are needed for downstream reconciliation.\n\n## Problem\n\nThe current billing export path is manual and easy to misconfigure.\n\n## Goals\n\n- publish reliable billing exports\n- keep the contract visible to agents and humans\n\n## Non-Goals\n\n- replacing the entire billing backend\n- redesigning unrelated billing screens\n\n## Constraints\n\n- keep the first version low-risk\n- document the external dependency clearly\n\n## Solution Shape\n\nAdd a background export job, an API client, and delivery monitoring.\n\n## Flows\n\n1. Trigger export from the billing UI.\n2. Queue the export job.\n3. Deliver the payload to the external endpoint.\n\n## Data / Interfaces\n\n- external API endpoint and payload contract\n- retry-safe job payload\n\n## Risks / Open Questions\n\n- auth token expiry\n- retry exhaustion\n- contract drift with the external API\n\n## Rollout\n\n- ship behind a flag\n- keep a fallback manual export path\n- monitor failure rate and rollback if retries spike\n\n## Verification\n\n- run export integration tests\n- validate the delivered payload against the API contract\n\n## Story Breakdown\n\n- trigger export\n- queue export job\n- validate export delivery\n",
+  "minimum_scores": {
+    "clarity": 5,
+    "boundedness": 3,
+    "risk_coverage": 4,
+    "non_goal_quality": 4,
+    "verification_quality": 4,
+    "story_slice_quality": 4,
+    "agent_executability": 4,
+    "artifact_simplicity": 3,
+    "user_effort_cost": 3
+  }
+}

--- a/testdata/evals/fixtures/reporting-data-migration.json
+++ b/testdata/evals/fixtures/reporting-data-migration.json
@@ -1,0 +1,18 @@
+{
+  "slug": "reporting-data-migration",
+  "title": "Reporting Data Migration",
+  "artifact_type": "spec",
+  "scenario": "Migration-heavy reporting feature with bounded scope and validation detail.",
+  "candidate": "# Reporting Data Migration\n\n## Why\n\nReporting cannot scale until old rollup data is migrated into the new schema.\n\n## Problem\n\nThe reporting system depends on legacy tables that block the next reporting features.\n\n## Goals\n\n- migrate reporting data safely\n- preserve reporting correctness during rollout\n\n## Non-Goals\n\n- rebuilding every reporting query in one pass\n- changing unrelated admin tooling\n\n## Constraints\n\n- keep the migration reversible\n- support a staged rollout\n\n## Solution Shape\n\nAdd a schema migration, a backfill job, and a temporary dual-read path.\n\n## Flows\n\n1. Apply the schema migration.\n2. Run the backfill job.\n3. Validate reports through the dual-read path.\n\n## Data / Interfaces\n\n- reporting schema migration\n- backfill job payload\n- dual-read reporting contract\n\n## Risks / Open Questions\n\n- backfill duration\n- rollback safety\n- stale data during the dual-read window\n\n## Rollout\n\n- rehearse on staging\n- batch the backfill\n- rollback if integrity checks fail\n\n## Verification\n\n- validate migrated row counts\n- check reporting data integrity after the backfill\n- run focused reporting tests\n\n## Story Breakdown\n\n- add migration\n- run backfill\n- validate dual-read results\n",
+  "minimum_scores": {
+    "clarity": 5,
+    "boundedness": 3,
+    "risk_coverage": 4,
+    "non_goal_quality": 4,
+    "verification_quality": 4,
+    "story_slice_quality": 4,
+    "agent_executability": 4,
+    "artifact_simplicity": 3,
+    "user_effort_cost": 3
+  }
+}


### PR DESCRIPTION
## Summary

- add the v5 shaping commands: `plan brainstorm challenge`, `plan epic shape`, and `plan spec checklist`
- add note schema support, tests, and command coverage for challenge, shape, and checklist passes
- expand the bundled `plan` skill with model-aware guidance and add benchmark fixtures plus a rubric eval harness
- update the `.plan` workspace so the v5 epics/specs/stories are complete and the roadmap now points at v6

## Testing

- [x] `go test ./...`
- [x] `go build ./...`
- [x] Other:
  - `go run . --help`
  - `go run . brainstorm --help`
  - `go run . epic --help`
  - `go run . spec --help`
  - `go run . status --project .`
  - `git diff --check`

## Release Notes

- User-facing change: add challenge, epic shaping, and profile-driven spec checklist passes to the `plan` CLI
- Planning or workflow impact: v5 is now complete, including model-aware skill guidance and a local benchmark/eval foundation
- Follow-up work: start the v6 loop for story slicing, story critique, and execution-readiness checks

## Planning

- Related epic/spec/story: `v5` `Model-Aware Planning Skills`, `Benchmark Fixtures and Rubric Evals`, `Brainstorm Challenge`, `Epic Shaping`, `Spec Checklist Profiles`
