### PR TITLE
feat: complete v6 story slicing workflow

### DIFF
--- a/.plan/ROADMAP.md
+++ b/.plan/ROADMAP.md
@@ -50,9 +50,9 @@ Current focus:
 Goal: Make the spec-to-story transition materially better before reintroducing
 larger-plan power.
 
-- [ ] Story Slice Preview and Apply Flow
-- [ ] Story Critique and Rejection Rules
-- [ ] Execution-Readiness Integration in `plan check`
+- [x] Story Slice Preview and Apply Flow
+- [x] Story Critique and Rejection Rules
+- [x] Execution-Readiness Integration in `plan check`
 
 Summary:
 - add `plan story slice`

--- a/.plan/epics/execution-readiness-integration-in-plan-check.md
+++ b/.plan/epics/execution-readiness-integration-in-plan-check.md
@@ -1,0 +1,73 @@
+---
+created_at: "2026-04-17T20:58:34Z"
+project: plan
+slug: execution-readiness-integration-in-plan-check
+spec: execution-readiness-integration-in-plan-check
+title: Execution-Readiness Integration in plan check
+type: epic
+updated_at: "2026-04-17T20:58:34Z"
+---
+
+# Execution-Readiness Integration in plan check
+
+Created: 2026-04-17T20:58:34Z
+
+## Outcome
+Teach `plan check` to inspect the spec-to-story handoff, not just note sections
+in isolation.
+
+## Why Now
+Current checks can pass even when an approved spec has no useful story
+breakdown or when story coverage does not match the spec state. `v6` should
+close that gap before bigger workflow power returns.
+
+## Shape
+
+### Appetite
+One pass that adds cross-artifact readiness rules while keeping `plan check`
+deterministic, local, and readable at project scale.
+
+### Outcome
+Maintainers can run `plan check` and quickly see whether a spec is actually
+ready to become executable stories or whether the handoff still has holes.
+
+### Scope Boundary
+- spec-to-story readiness rules in `plan check`
+- cross-artifact findings for approved and implementing specs
+- deterministic project, epic, and spec scope reporting
+- severity calibration between blocking errors and guidance warnings
+
+### Out of Scope
+- dependency scheduling or queue management
+- mandatory critique before work can start
+- external CI or tracker integrations
+
+### Success Signal
+`plan check` catches the most common v6 handoff failures before they turn into
+weak or missing stories.
+
+## Scope Boundary
+- readiness findings for spec `## Story Breakdown`
+- child-story coverage and status alignment
+- command output that stays readable at larger scopes
+
+Not in scope:
+
+- project scheduling features
+- automatic story creation
+- remote enforcement
+
+## Spec
+- [Draft Spec](../specs/execution-readiness-integration-in-plan-check.md)
+
+## Resources
+- [Product Direction](../PRODUCT.md)
+- [Roadmap](../ROADMAP.md)
+
+## Progress
+- Target version: `v6`
+- Status: planned
+
+## Notes
+Checks should stay concrete and useful. Noise would undercut the whole `v6`
+readiness push.

--- a/.plan/epics/story-critique-and-rejection-rules.md
+++ b/.plan/epics/story-critique-and-rejection-rules.md
@@ -1,0 +1,72 @@
+---
+created_at: "2026-04-17T20:58:34Z"
+project: plan
+slug: story-critique-and-rejection-rules
+spec: story-critique-and-rejection-rules
+title: Story Critique and Rejection Rules
+type: epic
+updated_at: "2026-04-17T20:58:34Z"
+---
+
+# Story Critique and Rejection Rules
+
+Created: 2026-04-17T20:58:34Z
+
+## Outcome
+Add an optional critique pass that pressures stories before implementation and
+makes rewrite or reslice decisions durable.
+
+## Why Now
+Current story checks enforce section presence, but they do not catch stories
+that are still too broad, unclear, or risky to start. `v6` should tighten that
+execution boundary.
+
+## Shape
+
+### Appetite
+One local critique loop that records findings inside the story note and helps a
+maintainer decide whether the story should proceed, be rewritten, or be split.
+
+### Outcome
+Stories gain a durable critique section and a repeatable command for finding
+scope leaks, missing inputs, and weak verification before work starts.
+
+### Scope Boundary
+- `plan story critique <story-slug>`
+- durable critique content stored on the story note
+- explicit keep, rewrite, or reslice guidance
+- rejection rules grounded in execution readiness, not reviewer bureaucracy
+
+### Out of Scope
+- multi-reviewer approval workflows
+- new permanent story lifecycle states such as `rejected`
+- external issue-tracker integrations
+
+### Success Signal
+Maintainers can run one critique pass and know whether a story is ready to
+start or needs another slicing/editing pass first.
+
+## Scope Boundary
+- story note schema additions
+- critique command flow
+- rejection heuristics for too-broad or under-specified stories
+
+Not in scope:
+
+- mandatory critique before every story update
+- automated story dependencies
+- remote policy engines
+
+## Spec
+- [Draft Spec](../specs/story-critique-and-rejection-rules.md)
+
+## Resources
+- [Product Direction](../PRODUCT.md)
+- [Roadmap](../ROADMAP.md)
+
+## Progress
+- Target version: `v6`
+- Status: planned
+
+## Notes
+Critique should sharpen stories, not turn `plan` into a review queue tool.

--- a/.plan/epics/story-slice-preview-and-apply-flow.md
+++ b/.plan/epics/story-slice-preview-and-apply-flow.md
@@ -1,0 +1,75 @@
+---
+created_at: "2026-04-17T20:58:34Z"
+project: plan
+slug: story-slice-preview-and-apply-flow
+spec: story-slice-preview-and-apply-flow
+title: Story Slice Preview and Apply Flow
+type: epic
+updated_at: "2026-04-17T20:58:34Z"
+---
+
+# Story Slice Preview and Apply Flow
+
+Created: 2026-04-17T20:58:34Z
+
+## Outcome
+Give approved specs a durable path to turn story ideas into execution-ready
+story notes with a preview step before files are written.
+
+## Why Now
+The workflow gets strong up through spec approval, then drops back to manual
+copying when stories need to be created. `v6` should make that handoff feel as
+deliberate as the earlier shaping passes.
+
+## Shape
+
+### Appetite
+One small `v6` pass: approved spec in, candidate slices previewed, selected
+stories written safely to `.plan/stories/`.
+
+### Outcome
+Users can inspect the first-pass story set before apply, then create linked
+todo stories without hand-copying titles, criteria, and verification steps.
+
+### Scope Boundary
+- `plan story slice <epic-slug>`
+- preview-first terminal flow for candidate stories
+- apply flow that writes story notes and refreshes spec story links
+- slice data shaped around title, description, acceptance criteria, and
+  verification
+
+### Out of Scope
+- hosted AI slicing services
+- dependency graph generation
+- removing manual `plan story create`
+
+### Success Signal
+An approved spec can be turned into a clean first-pass story backlog in one
+local loop without losing the canonical spec contract.
+
+## Scope Boundary
+- approved spec to story transition
+- preview and apply UX
+- story note creation helpers
+- spec Story Breakdown updates after apply
+
+Not in scope:
+
+- story critique rules
+- broader project orchestration
+- external tracker sync
+
+## Spec
+- [Draft Spec](../specs/story-slice-preview-and-apply-flow.md)
+
+## Resources
+- [Product Direction](../PRODUCT.md)
+- [Roadmap](../ROADMAP.md)
+
+## Progress
+- Target version: `v6`
+- Status: planned
+
+## Notes
+The preview matters. `v6` should help maintainers inspect the slice before the
+repo gains new story files.

--- a/.plan/specs/execution-readiness-integration-in-plan-check.md
+++ b/.plan/specs/execution-readiness-integration-in-plan-check.md
@@ -1,0 +1,110 @@
+---
+created_at: "2026-04-17T20:58:34Z"
+epic: execution-readiness-integration-in-plan-check
+project: plan
+slug: execution-readiness-integration-in-plan-check
+status: approved
+target_version: v6
+title: Execution-Readiness Integration in plan check Spec
+type: spec
+updated_at: "2026-04-17T20:58:34Z"
+---
+
+# Execution-Readiness Integration in plan check Spec
+
+Created: 2026-04-17T20:58:34Z
+
+## Why
+`plan check` already validates spec and story sections. `v6` should extend that
+work so the transition from approved spec to executable stories is checked too.
+
+## Problem
+The current checker can report a clean project even when an approved spec still
+has a placeholder `## Story Breakdown`, no sliced stories, or story coverage
+that does not match the spec's implementation state.
+
+## Goals
+- extend `plan check` with spec-to-story readiness rules
+- detect approved specs that are not slice-ready or have thin `## Story
+  Breakdown` guidance
+- report cross-artifact gaps between spec status and linked story coverage
+- keep output simple and consistent across project, epic, spec, and story
+  scopes
+
+## Non-Goals
+- full project scheduling or dependency solving
+- mandatory critique before any work begins
+- remote sync or CI-only enforcement features
+
+## Constraints
+- checks must remain deterministic and local
+- new findings must fit the existing `CheckFinding` model and formatter
+- project-scope output must stay readable
+- rules should distinguish blocking errors from guidance warnings
+
+## Solution Shape
+- add story-slicing readiness checks for approved and implementing specs
+- compare spec status, `## Story Breakdown`, and child story presence together
+- surface critique-aware or execution-ready guidance where available without
+  requiring critique
+- extend command and planning tests to cover the new findings
+
+## Flows
+1. User runs `plan check`.
+2. `plan` loads specs, stories, and the spec-to-story relationships for the
+   selected scope.
+3. The report flags missing slice coverage, placeholder breakdown content, or
+   status mismatches with clear fixes.
+4. User strengthens the spec or stories before implementation continues.
+
+## Data / Interfaces
+- new `CheckFinding` rules for story-slice readiness and coverage
+- helper logic that reads spec `## Story Breakdown` content alongside child
+  stories
+- existing `plan check` command output, extended with the new findings only
+
+## Risks / Open Questions
+- false positives on specs intentionally approved before slicing begins
+- how aggressive blocking severity should be for missing story coverage
+- whether project-scope output stays readable once cross-artifact findings grow
+
+## Rollout
+- land epic and spec scope readiness rules first
+- calibrate severity in tests before widening to project scope
+- only make issues blocking where the existing lifecycle already expects
+  execution-ready stories
+
+## Verification
+- an approved spec with placeholder `## Story Breakdown` content produces
+  readiness findings
+- an implementing spec with missing or orphaned stories produces cross-artifact
+  findings
+- project and epic scope output remain deterministic and readable
+- command and planning tests cover the new rules directly
+
+## Story Breakdown
+- [ ] [Add spec-to-story readiness rules in plan check](../stories/add-spec-to-story-readiness-rules-in-plan-check.md)
+- [ ] [Add cross-artifact check coverage for v6 readiness](../stories/add-cross-artifact-check-coverage-for-v6-readiness.md)
+- [ ] [Document v6 execution-readiness check workflow](../stories/document-v6-execution-readiness-check-workflow.md)
+
+## Analysis
+
+### Missing Constraints
+
+### Success Criteria Gaps
+
+### Hidden Dependencies
+
+### Risk Gaps
+
+### What/Why vs How Leakage
+
+### Recommended Revisions
+
+## Checklist
+
+## Resources
+- [Epic](../epics/execution-readiness-integration-in-plan-check.md)
+- [Product Direction](../PRODUCT.md)
+
+## Notes

--- a/.plan/specs/execution-readiness-integration-in-plan-check.md
+++ b/.plan/specs/execution-readiness-integration-in-plan-check.md
@@ -3,11 +3,11 @@ created_at: "2026-04-17T20:58:34Z"
 epic: execution-readiness-integration-in-plan-check
 project: plan
 slug: execution-readiness-integration-in-plan-check
-status: approved
+status: done
 target_version: v6
 title: Execution-Readiness Integration in plan check Spec
 type: spec
-updated_at: "2026-04-17T20:58:34Z"
+updated_at: "2026-04-17T23:36:00Z"
 ---
 
 # Execution-Readiness Integration in plan check Spec
@@ -83,9 +83,9 @@ that does not match the spec's implementation state.
 - command and planning tests cover the new rules directly
 
 ## Story Breakdown
-- [ ] [Add spec-to-story readiness rules in plan check](../stories/add-spec-to-story-readiness-rules-in-plan-check.md)
-- [ ] [Add cross-artifact check coverage for v6 readiness](../stories/add-cross-artifact-check-coverage-for-v6-readiness.md)
-- [ ] [Document v6 execution-readiness check workflow](../stories/document-v6-execution-readiness-check-workflow.md)
+- [x] [Add spec-to-story readiness rules in plan check](../stories/add-spec-to-story-readiness-rules-in-plan-check.md)
+- [x] [Add cross-artifact check coverage for v6 readiness](../stories/add-cross-artifact-check-coverage-for-v6-readiness.md)
+- [x] [Document v6 execution-readiness check workflow](../stories/document-v6-execution-readiness-check-workflow.md)
 
 ## Analysis
 

--- a/.plan/specs/story-critique-and-rejection-rules.md
+++ b/.plan/specs/story-critique-and-rejection-rules.md
@@ -1,0 +1,107 @@
+---
+created_at: "2026-04-17T20:58:34Z"
+epic: story-critique-and-rejection-rules
+project: plan
+slug: story-critique-and-rejection-rules
+status: approved
+target_version: v6
+title: Story Critique and Rejection Rules Spec
+type: spec
+updated_at: "2026-04-17T20:58:34Z"
+---
+
+# Story Critique and Rejection Rules Spec
+
+Created: 2026-04-17T20:58:34Z
+
+## Why
+Story notes now have basic execution-readiness checks, but `v6` should also add
+an optional pass that pressures scope and quality before implementation starts.
+
+## Problem
+Stories can satisfy the current section-level checks and still be too broad,
+missing hidden inputs, or weak enough that they should be rewritten before any
+agent or human starts coding.
+
+## Goals
+- ship `plan story critique`
+- add a durable `## Critique` section to story notes
+- record keep, rewrite, or reslice guidance without adding new hierarchy
+  objects
+- make critique findings useful before a story moves into active execution
+
+## Non-Goals
+- multi-reviewer approval workflows
+- new story metadata states such as `rejected`
+- replacing `plan check` with an interactive critique command
+
+## Constraints
+- critique must stay additive to the story note structure
+- reruns should update critique safely without damaging the rest of the story
+- rejection rules should stay local, explicit, and readable in markdown
+- the default flow must still allow direct execution without requiring critique
+
+## Solution Shape
+- extend the story template with a durable `## Critique` section
+- add `plan story critique <story-slug>` to collect findings about scope fit,
+  hidden dependencies, missing contract details, and verification quality
+- record a clear recommendation to keep the story, rewrite it, or reslice it
+- keep the command grounded in note updates and terminal output rather than new
+  workflow objects
+
+## Flows
+1. User creates or slices a story from an approved spec.
+2. User runs `plan story critique <story-slug>`.
+3. `plan` captures critique findings and records the recommended next step.
+4. User either keeps the story, rewrites it, or reslices it before starting
+   implementation.
+
+## Data / Interfaces
+- story template additions under `## Critique`
+- critique input and output model in planning code
+- `plan story critique <story-slug>`
+- note update helpers that preserve the rest of the story body
+
+## Risks / Open Questions
+- how to keep critique useful without becoming ceremony
+- whether the first version should include explicit scoring or only structured
+  findings
+- how to phrase rejection guidance clearly without adding a new lifecycle state
+
+## Rollout
+- land the note schema and command in `v6`
+- keep critique optional but discoverable next to story slicing
+- use critique output to inform later `plan check` readiness work
+
+## Verification
+- new or existing stories can hold durable critique content
+- critique command updates the correct sections without damaging story notes
+- critique output clearly distinguishes keep versus rewrite or reslice guidance
+- tests cover first-run and rerun critique behavior
+
+## Story Breakdown
+- [ ] [Add story critique section schema](../stories/add-story-critique-section-schema.md)
+- [ ] [Implement story critique command flow](../stories/implement-story-critique-command-flow.md)
+- [ ] [Add story critique tests and docs](../stories/add-story-critique-tests-and-docs.md)
+
+## Analysis
+
+### Missing Constraints
+
+### Success Criteria Gaps
+
+### Hidden Dependencies
+
+### Risk Gaps
+
+### What/Why vs How Leakage
+
+### Recommended Revisions
+
+## Checklist
+
+## Resources
+- [Epic](../epics/story-critique-and-rejection-rules.md)
+- [Product Direction](../PRODUCT.md)
+
+## Notes

--- a/.plan/specs/story-critique-and-rejection-rules.md
+++ b/.plan/specs/story-critique-and-rejection-rules.md
@@ -3,11 +3,11 @@ created_at: "2026-04-17T20:58:34Z"
 epic: story-critique-and-rejection-rules
 project: plan
 slug: story-critique-and-rejection-rules
-status: approved
+status: done
 target_version: v6
 title: Story Critique and Rejection Rules Spec
 type: spec
-updated_at: "2026-04-17T20:58:34Z"
+updated_at: "2026-04-17T23:36:00Z"
 ---
 
 # Story Critique and Rejection Rules Spec
@@ -80,9 +80,9 @@ agent or human starts coding.
 - tests cover first-run and rerun critique behavior
 
 ## Story Breakdown
-- [ ] [Add story critique section schema](../stories/add-story-critique-section-schema.md)
-- [ ] [Implement story critique command flow](../stories/implement-story-critique-command-flow.md)
-- [ ] [Add story critique tests and docs](../stories/add-story-critique-tests-and-docs.md)
+- [x] [Add story critique section schema](../stories/add-story-critique-section-schema.md)
+- [x] [Implement story critique command flow](../stories/implement-story-critique-command-flow.md)
+- [x] [Add story critique tests and docs](../stories/add-story-critique-tests-and-docs.md)
 
 ## Analysis
 

--- a/.plan/specs/story-slice-preview-and-apply-flow.md
+++ b/.plan/specs/story-slice-preview-and-apply-flow.md
@@ -1,0 +1,110 @@
+---
+created_at: "2026-04-17T20:58:34Z"
+epic: story-slice-preview-and-apply-flow
+project: plan
+slug: story-slice-preview-and-apply-flow
+status: approved
+target_version: v6
+title: Story Slice Preview and Apply Flow Spec
+type: spec
+updated_at: "2026-04-17T20:58:34Z"
+---
+
+# Story Slice Preview and Apply Flow Spec
+
+Created: 2026-04-17T20:58:34Z
+
+## Why
+`v6` should make the spec-to-story handoff materially better. Right now the
+workflow gets to an approved spec, then falls back to manual story creation.
+
+## Problem
+Approved specs can describe the right work and still leave maintainers to
+hand-copy titles, criteria, and verification into separate story notes. That
+invites drift and makes the last planning step feel weaker than the shaping
+passes that came before it.
+
+## Goals
+- ship `plan story slice`
+- preview proposed story notes before writing files
+- create todo stories with descriptions, acceptance criteria, verification, and
+  canonical spec links
+- keep the spec canonical while refreshing `## Story Breakdown` with linked
+  story entries after apply
+
+## Non-Goals
+- hosted or remote slicing services
+- automatic dependency scheduling between stories
+- deleting or rewriting existing stories without explicit user action
+
+## Constraints
+- only approved specs may be sliced into stories
+- preview must work without writing files
+- apply must be safe to rerun and avoid duplicate story creation
+- manual `plan story create` must remain valid for edge cases
+
+## Solution Shape
+- add a candidate slice model with title, description, acceptance criteria, and
+  verification
+- add `plan story slice <epic-slug>` with preview-first terminal flow and
+  explicit apply confirmation
+- reuse the existing story template and lifecycle rules when writing notes
+- update the spec `## Story Breakdown` with linked story entries after apply
+
+## Flows
+1. User approves a spec with concrete implementation guidance.
+2. User runs `plan story slice <epic-slug>`.
+3. `plan` collects or derives candidate slices and prints a preview.
+4. User confirms apply.
+5. `plan` creates todo stories and refreshes the spec `## Story Breakdown`
+   entries to link to the created notes.
+
+## Data / Interfaces
+- `StorySliceInput` or equivalent candidate slice struct in planning code
+- `plan story slice <epic-slug>`
+- spec `## Story Breakdown` entries that can be rewritten as linked checklists
+- story creation helpers reused by slice apply
+
+## Risks / Open Questions
+- how much slice data should be parsed from `## Story Breakdown` versus
+  collected interactively
+- how reruns should behave when some target story slugs already exist
+- whether preview should allow partial apply in the first version
+
+## Rollout
+- land preview and apply together in `v6`
+- keep manual story creation untouched as fallback
+- use the command output to inform later readiness checks
+
+## Verification
+- preview shows candidate stories without writing files
+- apply creates story notes with required sections and canonical spec links
+- rerun behavior avoids duplicate story files and preserves deliberate edits
+- focused command and planning tests cover first-run and rerun flows
+
+## Story Breakdown
+- [ ] [Add story slice candidate model and preview formatting](../stories/add-story-slice-candidate-model-and-preview-formatting.md)
+- [ ] [Implement story slice apply flow](../stories/implement-story-slice-apply-flow.md)
+- [ ] [Add story slice tests and rerun coverage](../stories/add-story-slice-tests-and-rerun-coverage.md)
+
+## Analysis
+
+### Missing Constraints
+
+### Success Criteria Gaps
+
+### Hidden Dependencies
+
+### Risk Gaps
+
+### What/Why vs How Leakage
+
+### Recommended Revisions
+
+## Checklist
+
+## Resources
+- [Epic](../epics/story-slice-preview-and-apply-flow.md)
+- [Product Direction](../PRODUCT.md)
+
+## Notes

--- a/.plan/specs/story-slice-preview-and-apply-flow.md
+++ b/.plan/specs/story-slice-preview-and-apply-flow.md
@@ -3,11 +3,11 @@ created_at: "2026-04-17T20:58:34Z"
 epic: story-slice-preview-and-apply-flow
 project: plan
 slug: story-slice-preview-and-apply-flow
-status: approved
+status: done
 target_version: v6
 title: Story Slice Preview and Apply Flow Spec
 type: spec
-updated_at: "2026-04-17T20:58:34Z"
+updated_at: "2026-04-17T23:36:00Z"
 ---
 
 # Story Slice Preview and Apply Flow Spec
@@ -83,9 +83,9 @@ passes that came before it.
 - focused command and planning tests cover first-run and rerun flows
 
 ## Story Breakdown
-- [ ] [Add story slice candidate model and preview formatting](../stories/add-story-slice-candidate-model-and-preview-formatting.md)
-- [ ] [Implement story slice apply flow](../stories/implement-story-slice-apply-flow.md)
-- [ ] [Add story slice tests and rerun coverage](../stories/add-story-slice-tests-and-rerun-coverage.md)
+- [x] [Add story slice candidate model and preview formatting](../stories/add-story-slice-candidate-model-and-preview-formatting.md)
+- [x] [Implement story slice apply flow](../stories/implement-story-slice-apply-flow.md)
+- [x] [Add story slice tests and rerun coverage](../stories/add-story-slice-tests-and-rerun-coverage.md)
 
 ## Analysis
 

--- a/.plan/stories/add-cross-artifact-check-coverage-for-v6-readiness.md
+++ b/.plan/stories/add-cross-artifact-check-coverage-for-v6-readiness.md
@@ -1,0 +1,31 @@
+---
+created_at: "2026-04-17T21:02:45Z"
+epic: execution-readiness-integration-in-plan-check
+project: plan
+slug: add-cross-artifact-check-coverage-for-v6-readiness
+spec: execution-readiness-integration-in-plan-check
+status: todo
+title: Add cross-artifact check coverage for v6 readiness
+type: story
+updated_at: "2026-04-17T21:02:45Z"
+---
+
+# Add cross-artifact check coverage for v6 readiness
+
+Created: 2026-04-17T21:02:45Z
+
+## Description
+
+Add tests and helper coverage for cross-artifact checks that compare spec status, Story Breakdown, and child story presence.
+## Acceptance Criteria
+
+- [ ] Tests cover approved specs with placeholder story breakdowns and implementing specs with missing or orphaned story coverage.
+
+- [ ] Epic and project scope checks remain deterministic with the new readiness rules.
+## Verification
+
+- Run cross-artifact check coverage tests.
+## Resources
+
+- [Canonical Spec](../specs/execution-readiness-integration-in-plan-check.md)
+## Notes

--- a/.plan/stories/add-cross-artifact-check-coverage-for-v6-readiness.md
+++ b/.plan/stories/add-cross-artifact-check-coverage-for-v6-readiness.md
@@ -4,10 +4,10 @@ epic: execution-readiness-integration-in-plan-check
 project: plan
 slug: add-cross-artifact-check-coverage-for-v6-readiness
 spec: execution-readiness-integration-in-plan-check
-status: todo
+status: done
 title: Add cross-artifact check coverage for v6 readiness
 type: story
-updated_at: "2026-04-17T21:02:45Z"
+updated_at: "2026-04-17T23:36:00Z"
 ---
 
 # Add cross-artifact check coverage for v6 readiness

--- a/.plan/stories/add-spec-to-story-readiness-rules-in-plan-check.md
+++ b/.plan/stories/add-spec-to-story-readiness-rules-in-plan-check.md
@@ -1,0 +1,31 @@
+---
+created_at: "2026-04-17T21:02:45Z"
+epic: execution-readiness-integration-in-plan-check
+project: plan
+slug: add-spec-to-story-readiness-rules-in-plan-check
+spec: execution-readiness-integration-in-plan-check
+status: todo
+title: Add spec-to-story readiness rules in plan check
+type: story
+updated_at: "2026-04-17T21:02:45Z"
+---
+
+# Add spec-to-story readiness rules in plan check
+
+Created: 2026-04-17T21:02:45Z
+
+## Description
+
+Extend plan check so approved and implementing specs are checked for slice readiness and meaningful Story Breakdown content.
+## Acceptance Criteria
+
+- [ ] plan check reports findings when an approved or implementing spec lacks meaningful story-slicing guidance.
+
+- [ ] New findings fit the existing check output model and severity handling.
+## Verification
+
+- Run plan check readiness rule tests.
+## Resources
+
+- [Canonical Spec](../specs/execution-readiness-integration-in-plan-check.md)
+## Notes

--- a/.plan/stories/add-spec-to-story-readiness-rules-in-plan-check.md
+++ b/.plan/stories/add-spec-to-story-readiness-rules-in-plan-check.md
@@ -4,10 +4,10 @@ epic: execution-readiness-integration-in-plan-check
 project: plan
 slug: add-spec-to-story-readiness-rules-in-plan-check
 spec: execution-readiness-integration-in-plan-check
-status: todo
+status: done
 title: Add spec-to-story readiness rules in plan check
 type: story
-updated_at: "2026-04-17T21:02:45Z"
+updated_at: "2026-04-17T23:36:00Z"
 ---
 
 # Add spec-to-story readiness rules in plan check

--- a/.plan/stories/add-story-critique-section-schema.md
+++ b/.plan/stories/add-story-critique-section-schema.md
@@ -4,10 +4,10 @@ epic: story-critique-and-rejection-rules
 project: plan
 slug: add-story-critique-section-schema
 spec: story-critique-and-rejection-rules
-status: todo
+status: done
 title: Add story critique section schema
 type: story
-updated_at: "2026-04-17T21:02:45Z"
+updated_at: "2026-04-17T23:36:00Z"
 ---
 
 # Add story critique section schema

--- a/.plan/stories/add-story-critique-section-schema.md
+++ b/.plan/stories/add-story-critique-section-schema.md
@@ -1,0 +1,31 @@
+---
+created_at: "2026-04-17T21:02:45Z"
+epic: story-critique-and-rejection-rules
+project: plan
+slug: add-story-critique-section-schema
+spec: story-critique-and-rejection-rules
+status: todo
+title: Add story critique section schema
+type: story
+updated_at: "2026-04-17T21:02:45Z"
+---
+
+# Add story critique section schema
+
+Created: 2026-04-17T21:02:45Z
+
+## Description
+
+Extend story notes with a durable Critique section that can hold execution-readiness findings and next-step guidance.
+## Acceptance Criteria
+
+- [ ] The story template includes a Critique section with stable headings for findings and recommended action.
+
+- [ ] Existing story notes can be updated with critique content without damaging other sections.
+## Verification
+
+- Run story template and note update tests.
+## Resources
+
+- [Canonical Spec](../specs/story-critique-and-rejection-rules.md)
+## Notes

--- a/.plan/stories/add-story-critique-tests-and-docs.md
+++ b/.plan/stories/add-story-critique-tests-and-docs.md
@@ -1,0 +1,31 @@
+---
+created_at: "2026-04-17T21:02:45Z"
+epic: story-critique-and-rejection-rules
+project: plan
+slug: add-story-critique-tests-and-docs
+spec: story-critique-and-rejection-rules
+status: todo
+title: Add story critique tests and docs
+type: story
+updated_at: "2026-04-17T21:02:45Z"
+---
+
+# Add story critique tests and docs
+
+Created: 2026-04-17T21:02:45Z
+
+## Description
+
+Cover critique schema and command behavior in tests and document how critique should be used in the v6 loop.
+## Acceptance Criteria
+
+- [ ] Tests cover first-run and rerun critique behavior plus rejection-style guidance output.
+
+- [ ] Maintainer docs explain when to critique a story and how to act on rewrite or reslice guidance.
+## Verification
+
+- Run critique tests and doc verification checks.
+## Resources
+
+- [Canonical Spec](../specs/story-critique-and-rejection-rules.md)
+## Notes

--- a/.plan/stories/add-story-critique-tests-and-docs.md
+++ b/.plan/stories/add-story-critique-tests-and-docs.md
@@ -4,10 +4,10 @@ epic: story-critique-and-rejection-rules
 project: plan
 slug: add-story-critique-tests-and-docs
 spec: story-critique-and-rejection-rules
-status: todo
+status: done
 title: Add story critique tests and docs
 type: story
-updated_at: "2026-04-17T21:02:45Z"
+updated_at: "2026-04-17T23:36:00Z"
 ---
 
 # Add story critique tests and docs

--- a/.plan/stories/add-story-slice-candidate-model-and-preview-formatting.md
+++ b/.plan/stories/add-story-slice-candidate-model-and-preview-formatting.md
@@ -4,10 +4,10 @@ epic: story-slice-preview-and-apply-flow
 project: plan
 slug: add-story-slice-candidate-model-and-preview-formatting
 spec: story-slice-preview-and-apply-flow
-status: todo
+status: done
 title: Add story slice candidate model and preview formatting
 type: story
-updated_at: "2026-04-17T21:02:45Z"
+updated_at: "2026-04-17T23:36:00Z"
 ---
 
 # Add story slice candidate model and preview formatting

--- a/.plan/stories/add-story-slice-candidate-model-and-preview-formatting.md
+++ b/.plan/stories/add-story-slice-candidate-model-and-preview-formatting.md
@@ -1,0 +1,31 @@
+---
+created_at: "2026-04-17T21:02:45Z"
+epic: story-slice-preview-and-apply-flow
+project: plan
+slug: add-story-slice-candidate-model-and-preview-formatting
+spec: story-slice-preview-and-apply-flow
+status: todo
+title: Add story slice candidate model and preview formatting
+type: story
+updated_at: "2026-04-17T21:02:45Z"
+---
+
+# Add story slice candidate model and preview formatting
+
+Created: 2026-04-17T21:02:45Z
+
+## Description
+
+Add the slice data model and preview rendering so approved specs can show candidate stories before apply.
+## Acceptance Criteria
+
+- [ ] Candidate slices capture title, description, acceptance criteria, and verification in one reusable planning shape.
+
+- [ ] Preview output shows multiple candidate stories clearly without writing files.
+## Verification
+
+- Run slice model and preview formatting tests.
+## Resources
+
+- [Canonical Spec](../specs/story-slice-preview-and-apply-flow.md)
+## Notes

--- a/.plan/stories/add-story-slice-tests-and-rerun-coverage.md
+++ b/.plan/stories/add-story-slice-tests-and-rerun-coverage.md
@@ -4,10 +4,10 @@ epic: story-slice-preview-and-apply-flow
 project: plan
 slug: add-story-slice-tests-and-rerun-coverage
 spec: story-slice-preview-and-apply-flow
-status: todo
+status: done
 title: Add story slice tests and rerun coverage
 type: story
-updated_at: "2026-04-17T21:02:45Z"
+updated_at: "2026-04-17T23:36:00Z"
 ---
 
 # Add story slice tests and rerun coverage

--- a/.plan/stories/add-story-slice-tests-and-rerun-coverage.md
+++ b/.plan/stories/add-story-slice-tests-and-rerun-coverage.md
@@ -1,0 +1,31 @@
+---
+created_at: "2026-04-17T21:02:45Z"
+epic: story-slice-preview-and-apply-flow
+project: plan
+slug: add-story-slice-tests-and-rerun-coverage
+spec: story-slice-preview-and-apply-flow
+status: todo
+title: Add story slice tests and rerun coverage
+type: story
+updated_at: "2026-04-17T21:02:45Z"
+---
+
+# Add story slice tests and rerun coverage
+
+Created: 2026-04-17T21:02:45Z
+
+## Description
+
+Expand command and manager tests for preview and apply flow, duplicate protection, and reruns against existing stories.
+## Acceptance Criteria
+
+- [ ] Tests cover preview-only runs, successful apply, and rerun behavior when story slugs already exist.
+
+- [ ] Verification confirms created stories satisfy the required execution sections.
+## Verification
+
+- Run the v6 story slice test suite.
+## Resources
+
+- [Canonical Spec](../specs/story-slice-preview-and-apply-flow.md)
+## Notes

--- a/.plan/stories/document-v6-execution-readiness-check-workflow.md
+++ b/.plan/stories/document-v6-execution-readiness-check-workflow.md
@@ -1,0 +1,31 @@
+---
+created_at: "2026-04-17T21:02:45Z"
+epic: execution-readiness-integration-in-plan-check
+project: plan
+slug: document-v6-execution-readiness-check-workflow
+spec: execution-readiness-integration-in-plan-check
+status: todo
+title: Document v6 execution-readiness check workflow
+type: story
+updated_at: "2026-04-17T21:02:45Z"
+---
+
+# Document v6 execution-readiness check workflow
+
+Created: 2026-04-17T21:02:45Z
+
+## Description
+
+Update docs so maintainers know how story slice, critique, and plan check fit together in the v6 loop.
+## Acceptance Criteria
+
+- [ ] Maintainer docs describe the v6 execution-readiness workflow and the expected check entry points.
+
+- [ ] Documentation examples match the commands and readiness findings supported by the repo.
+## Verification
+
+- Run documentation-related workflow verification tests.
+## Resources
+
+- [Canonical Spec](../specs/execution-readiness-integration-in-plan-check.md)
+## Notes

--- a/.plan/stories/document-v6-execution-readiness-check-workflow.md
+++ b/.plan/stories/document-v6-execution-readiness-check-workflow.md
@@ -4,10 +4,10 @@ epic: execution-readiness-integration-in-plan-check
 project: plan
 slug: document-v6-execution-readiness-check-workflow
 spec: execution-readiness-integration-in-plan-check
-status: todo
+status: done
 title: Document v6 execution-readiness check workflow
 type: story
-updated_at: "2026-04-17T21:02:45Z"
+updated_at: "2026-04-17T23:36:00Z"
 ---
 
 # Document v6 execution-readiness check workflow

--- a/.plan/stories/implement-story-critique-command-flow.md
+++ b/.plan/stories/implement-story-critique-command-flow.md
@@ -4,10 +4,10 @@ epic: story-critique-and-rejection-rules
 project: plan
 slug: implement-story-critique-command-flow
 spec: story-critique-and-rejection-rules
-status: todo
+status: done
 title: Implement story critique command flow
 type: story
-updated_at: "2026-04-17T21:02:45Z"
+updated_at: "2026-04-17T23:36:00Z"
 ---
 
 # Implement story critique command flow

--- a/.plan/stories/implement-story-critique-command-flow.md
+++ b/.plan/stories/implement-story-critique-command-flow.md
@@ -1,0 +1,31 @@
+---
+created_at: "2026-04-17T21:02:45Z"
+epic: story-critique-and-rejection-rules
+project: plan
+slug: implement-story-critique-command-flow
+spec: story-critique-and-rejection-rules
+status: todo
+title: Implement story critique command flow
+type: story
+updated_at: "2026-04-17T21:02:45Z"
+---
+
+# Implement story critique command flow
+
+Created: 2026-04-17T21:02:45Z
+
+## Description
+
+Add interactive critique capture for story scope, hidden dependencies, verification quality, and keep versus rewrite guidance.
+## Acceptance Criteria
+
+- [ ] plan story critique records critique findings and a keep, rewrite, or reslice recommendation on the story note.
+
+- [ ] Reruns update critique content safely and leave the rest of the story intact.
+## Verification
+
+- Run story critique command tests.
+## Resources
+
+- [Canonical Spec](../specs/story-critique-and-rejection-rules.md)
+## Notes

--- a/.plan/stories/implement-story-slice-apply-flow.md
+++ b/.plan/stories/implement-story-slice-apply-flow.md
@@ -1,0 +1,31 @@
+---
+created_at: "2026-04-17T21:02:45Z"
+epic: story-slice-preview-and-apply-flow
+project: plan
+slug: implement-story-slice-apply-flow
+spec: story-slice-preview-and-apply-flow
+status: todo
+title: Implement story slice apply flow
+type: story
+updated_at: "2026-04-17T21:02:45Z"
+---
+
+# Implement story slice apply flow
+
+Created: 2026-04-17T21:02:45Z
+
+## Description
+
+Add the command path that takes approved-spec slice candidates, confirms apply, and creates linked todo stories safely.
+## Acceptance Criteria
+
+- [ ] plan story slice can apply selected slices into story notes with canonical spec links.
+
+- [ ] Apply updates spec Story Breakdown with links and avoids duplicate story creation on rerun.
+## Verification
+
+- Run story slice command flow tests.
+## Resources
+
+- [Canonical Spec](../specs/story-slice-preview-and-apply-flow.md)
+## Notes

--- a/.plan/stories/implement-story-slice-apply-flow.md
+++ b/.plan/stories/implement-story-slice-apply-flow.md
@@ -4,10 +4,10 @@ epic: story-slice-preview-and-apply-flow
 project: plan
 slug: implement-story-slice-apply-flow
 spec: story-slice-preview-and-apply-flow
-status: todo
+status: done
 title: Implement story slice apply flow
 type: story
-updated_at: "2026-04-17T21:02:45Z"
+updated_at: "2026-04-17T23:36:00Z"
 ---
 
 # Implement story slice apply flow

--- a/README.md
+++ b/README.md
@@ -91,6 +91,10 @@ plan story create --project . newsletter-system "Build template editor" \
 plan status --project .
 ```
 
+Full guide:
+
+- [Using plan](docs/using-plan.md)
+
 ## Current Command Surface
 
 - `plan init`

--- a/README.md
+++ b/README.md
@@ -34,7 +34,8 @@ Workflow entry:
 5. Shape the epic
 6. Write and approve spec
 7. Analyze or checklist the spec
-8. Split into stories
+8. Slice into stories
+9. Critique story readiness
 
 The default path stays small. New shaping passes should improve the same
 artifacts rather than add new top-level planning objects.
@@ -85,10 +86,11 @@ plan spec show --project . newsletter-system
 plan spec analyze --project . newsletter-system
 plan spec checklist --project . newsletter-system --profile general
 plan spec status --project . newsletter-system --set approved
-plan story create --project . newsletter-system "Build template editor" \
-  --criteria "Templates can be created and edited" \
-  --verify "go test ./..."
+plan story slice --project . newsletter-system
+plan story slice --project . newsletter-system --apply
+plan story critique --project . build-template-editor
 plan status --project .
+plan check --project .
 ```
 
 Full guide:
@@ -105,7 +107,7 @@ Full guide:
 - `plan brainstorm challenge`
 - `plan epic create|promote|list|show|shape`
 - `plan spec show|edit|status|analyze|checklist`
-- `plan story create|update|list|show`
+- `plan story create|update|list|show|slice|critique`
 - `plan roadmap show|edit`
 - `plan check`
 - `plan status`
@@ -161,8 +163,9 @@ plan skills targets --scope both --agent codex --project .
 
 ## Evaluating Prompt And Workflow Changes
 
-`v5` adds a local benchmark and rubric harness for maintainers. The initial
-workflow is test-driven:
+`v5` adds a local benchmark and rubric harness for maintainers. `v6` adds
+story slicing, critique, and stronger spec-to-story readiness checks. The
+benchmark workflow is test-driven:
 
 ```bash
 go test ./internal/planning -run TestBenchmarkFixturesSatisfyMinimumScores

--- a/cmd/check_test.go
+++ b/cmd/check_test.go
@@ -201,6 +201,10 @@ func createHealthyPlanFixture(t *testing.T, root string, manager *planning.Manag
 		"- run focused billing tests",
 		"- generate a sample invoice export locally",
 		"",
+		"## Story Breakdown",
+		"",
+		"- [ ] [Implement invoices](../stories/implement-invoices.md)",
+		"",
 	}, "\n")
 	if _, err := manager.UpdateSpec("billing", notes.UpdateInput{
 		Body: &specBody,
@@ -220,5 +224,94 @@ func createHealthyPlanFixture(t *testing.T, root string, manager *planning.Manag
 		nil,
 	); err != nil {
 		t.Fatal(err)
+	}
+}
+
+func TestCheckCommandFlagsImplementingSpecWithoutStoryCoverage(t *testing.T) {
+	root := t.TempDir()
+	ws := workspace.New(root)
+	if _, err := ws.Init(); err != nil {
+		t.Fatal(err)
+	}
+	manager := planning.New(ws)
+
+	if _, err := manager.CreateEpic("Billing", ""); err != nil {
+		t.Fatal(err)
+	}
+	specBody := strings.Join([]string{
+		"# Billing Spec",
+		"",
+		"Created: now",
+		"",
+		"## Why",
+		"",
+		"Billing needs stronger execution readiness.",
+		"",
+		"## Problem",
+		"",
+		"Specs can claim implementation without stories.",
+		"",
+		"## Goals",
+		"",
+		"- catch missing story coverage",
+		"",
+		"## Non-Goals",
+		"",
+		"- scheduling systems",
+		"",
+		"## Constraints",
+		"",
+		"- keep checks local",
+		"",
+		"## Solution Shape",
+		"",
+		"Add readiness checks across specs and stories.",
+		"",
+		"## Flows",
+		"",
+		"1. Mark spec implementing.",
+		"2. Run checks.",
+		"",
+		"## Data / Interfaces",
+		"",
+		"- spec/story linkage",
+		"",
+		"## Risks / Open Questions",
+		"",
+		"- false positives",
+		"",
+		"## Rollout",
+		"",
+		"- dogfood locally",
+		"",
+		"## Verification",
+		"",
+		"- run check tests",
+		"",
+		"## Story Breakdown",
+		"",
+		"- Trigger export job",
+		"",
+	}, "\n")
+	if _, err := manager.UpdateSpec("billing", notes.UpdateInput{
+		Body: &specBody,
+		Metadata: map[string]any{
+			"status": "implementing",
+		},
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	var buf bytes.Buffer
+	command := newRootCmd()
+	command.SetOut(&buf)
+	command.SetErr(&buf)
+	command.SetArgs([]string{"--project", root, "check", "spec", "billing"})
+	err := command.Execute()
+	if err == nil {
+		t.Fatalf("expected readiness findings to fail command:\n%s", buf.String())
+	}
+	if !strings.Contains(buf.String(), "no child stories are linked to it") {
+		t.Fatalf("expected missing story coverage finding:\n%s", buf.String())
 	}
 }

--- a/cmd/story.go
+++ b/cmd/story.go
@@ -1,7 +1,10 @@
 package cmd
 
 import (
+	"bufio"
 	"fmt"
+	"io"
+	"strings"
 
 	"plan/internal/planning"
 
@@ -105,6 +108,163 @@ func newStoryCommand() *cobra.Command {
 		},
 	}
 
-	cmd.AddCommand(create, update, list, show)
+	var apply bool
+	slice := &cobra.Command{
+		Use:   "slice <epic-slug>",
+		Short: "Preview or apply first-pass story slices from an approved spec",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			preview, err := planningManager().PreviewStorySlices(args[0])
+			if err != nil {
+				return err
+			}
+			printStorySlicePreview(cmd.OutOrStdout(), preview)
+			if !apply {
+				return nil
+			}
+			ok, err := confirmStorySliceApply(bufio.NewReader(cmd.InOrStdin()), cmd.OutOrStdout())
+			if err != nil {
+				return err
+			}
+			if !ok {
+				fmt.Fprintln(cmd.OutOrStdout(), "Apply canceled.")
+				return nil
+			}
+			result, err := planningManager().ApplyStorySlices(args[0])
+			if err != nil {
+				return err
+			}
+			printStorySliceApplyResult(cmd.OutOrStdout(), result)
+			return nil
+		},
+	}
+	slice.Flags().BoolVar(&apply, "apply", false, "write missing story notes after preview and confirmation")
+
+	critique := &cobra.Command{
+		Use:   "critique <story-slug>",
+		Short: "Interactively critique a story for execution readiness",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			reader := bufio.NewReader(cmd.InOrStdin())
+			out := cmd.OutOrStdout()
+
+			state, err := planningManager().ReadStoryCritique(args[0])
+			if err != nil {
+				return err
+			}
+
+			if err := runRefinementCluster(
+				reader,
+				out,
+				"cluster 1/3: scope fit and vertical slice check",
+				state.ScopeFit == "",
+				"Scope Fit",
+				"Describe whether this story is the right size and shape for the intended implementation slice.",
+				&state.ScopeFit,
+				state.VerticalSliceCheck == "",
+				"Vertical Slice Check",
+				"Describe whether this story delivers a vertical slice of value rather than only horizontal plumbing.",
+				&state.VerticalSliceCheck,
+			); err != nil {
+				return err
+			}
+			if _, err := planningManager().UpdateStoryCritique(args[0], planning.StoryCritiqueInput{
+				ScopeFit:           state.ScopeFit,
+				VerticalSliceCheck: state.VerticalSliceCheck,
+			}); err != nil {
+				return err
+			}
+
+			if err := runRefinementCluster(
+				reader,
+				out,
+				"cluster 2/3: hidden prerequisites and verification gaps",
+				state.HiddenPrerequisites == "",
+				"Hidden Prerequisites",
+				"List prerequisites or missing inputs this story depends on. Enter one per line.",
+				&state.HiddenPrerequisites,
+				state.VerificationGaps == "",
+				"Verification Gaps",
+				"List any verification gaps or weak checks. Enter one per line.",
+				&state.VerificationGaps,
+			); err != nil {
+				return err
+			}
+			if _, err := planningManager().UpdateStoryCritique(args[0], planning.StoryCritiqueInput{
+				HiddenPrerequisites: state.HiddenPrerequisites,
+				VerificationGaps:    state.VerificationGaps,
+			}); err != nil {
+				return err
+			}
+
+			if state.RewriteRecommendation == "" {
+				value, err := promptSectionValue(reader, out, "Rewrite Recommendation", "Enter one of: keep, rewrite, reslice.")
+				if err != nil {
+					return err
+				}
+				state.RewriteRecommendation = value
+			} else {
+				fmt.Fprintf(out, "Skipping Rewrite Recommendation; already captured.\n")
+			}
+			if _, err := planningManager().UpdateStoryCritique(args[0], planning.StoryCritiqueInput{
+				RewriteRecommendation: state.RewriteRecommendation,
+			}); err != nil {
+				return err
+			}
+
+			if state.HasGaps() {
+				fmt.Fprintf(out, "Critique saved for %s with remaining gaps.\n", state.Path)
+				return nil
+			}
+			fmt.Fprintf(out, "Critique saved for %s\n", state.Path)
+			if state.HasBlockingRecommendation() {
+				return fmt.Errorf("story critique recommends %s", state.RecommendationAction())
+			}
+			return nil
+		},
+	}
+
+	cmd.AddCommand(create, update, list, show, slice, critique)
 	return cmd
+}
+
+func printStorySlicePreview(out io.Writer, preview *planning.StorySlicePreview) {
+	fmt.Fprintf(out, "story_slice_preview: %s\n", preview.SpecPath)
+	fmt.Fprintf(out, "candidates: %d\n", len(preview.Candidates))
+	for _, candidate := range preview.Candidates {
+		status := "new"
+		if candidate.StoryPath != "" {
+			status = "existing:" + candidate.Status
+		}
+		fmt.Fprintf(out, "- %s [%s]\n", candidate.Title, status)
+		fmt.Fprintf(out, "  description: %s\n", candidate.Description)
+		for _, item := range candidate.AcceptanceCriteria {
+			fmt.Fprintf(out, "  criteria: %s\n", item)
+		}
+		for _, item := range candidate.Verification {
+			fmt.Fprintf(out, "  verify: %s\n", item)
+		}
+	}
+}
+
+func printStorySliceApplyResult(out io.Writer, result *planning.StorySliceApplyResult) {
+	fmt.Fprintf(out, "story_slice_apply: %s\n", result.SpecPath)
+	fmt.Fprintf(out, "created: %d\n", len(result.CreatedPaths))
+	fmt.Fprintf(out, "reused: %d\n", len(result.SkippedPaths))
+	for _, path := range result.CreatedPaths {
+		fmt.Fprintf(out, "- created %s\n", path)
+	}
+	for _, path := range result.SkippedPaths {
+		fmt.Fprintf(out, "- reused %s\n", path)
+	}
+}
+
+func confirmStorySliceApply(reader *bufio.Reader, out io.Writer) (bool, error) {
+	fmt.Fprint(out, "Apply these slices? [y/N]: ")
+	line, err := reader.ReadString('\n')
+	if err != nil && err != io.EOF {
+		return false, err
+	}
+	answer := strings.ToLower(strings.TrimSpace(line))
+	return answer == "y" || answer == "yes", nil
 }

--- a/cmd/story_test.go
+++ b/cmd/story_test.go
@@ -2,9 +2,11 @@ package cmd
 
 import (
 	"bytes"
+	"path/filepath"
 	"strings"
 	"testing"
 
+	"plan/internal/notes"
 	"plan/internal/planning"
 	"plan/internal/workspace"
 )
@@ -50,5 +52,161 @@ func TestStoryListSupportsEpicAndStatusFilters(t *testing.T) {
 	}
 	if strings.Contains(output, "Implement invoices") {
 		t.Fatalf("expected filters to remove billing story:\n%s", output)
+	}
+}
+
+func TestStorySlicePreviewAndApplyFlow(t *testing.T) {
+	root := t.TempDir()
+	ws := workspace.New(root)
+	if _, err := ws.Init(); err != nil {
+		t.Fatal(err)
+	}
+	manager := planning.New(ws)
+	if _, err := manager.CreateEpic("Billing", ""); err != nil {
+		t.Fatal(err)
+	}
+	body := strings.Join([]string{
+		"# Billing Spec",
+		"",
+		"Created: now",
+		"",
+		"## Why",
+		"",
+		"Billing handoff needs stronger slicing.",
+		"",
+		"## Problem",
+		"",
+		"Stories are still created manually.",
+		"",
+		"## Goals",
+		"",
+		"- create first-pass stories",
+		"",
+		"## Non-Goals",
+		"",
+		"- tracker integration",
+		"",
+		"## Constraints",
+		"",
+		"- keep it local-first",
+		"",
+		"## Solution Shape",
+		"",
+		"Use Story Breakdown to seed slice candidates.",
+		"",
+		"## Flows",
+		"",
+		"1. Approve spec.",
+		"2. Slice stories.",
+		"",
+		"## Data / Interfaces",
+		"",
+		"- slice candidate model",
+		"",
+		"## Risks / Open Questions",
+		"",
+		"- duplicate slugs",
+		"",
+		"## Rollout",
+		"",
+		"- dogfood locally",
+		"",
+		"## Verification",
+		"",
+		"- run story slice tests",
+		"",
+		"## Story Breakdown",
+		"",
+		"- Trigger export job",
+		"- Deliver export payload",
+		"",
+	}, "\n")
+	if _, err := manager.UpdateSpec("billing", notes.UpdateInput{
+		Body: &body,
+		Metadata: map[string]any{
+			"status": "approved",
+		},
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	var preview bytes.Buffer
+	command := newRootCmd()
+	command.SetOut(&preview)
+	command.SetErr(&preview)
+	command.SetArgs([]string{"--project", root, "story", "slice", "billing"})
+	if err := command.Execute(); err != nil {
+		t.Fatalf("expected preview to succeed: %v\n%s", err, preview.String())
+	}
+	if !strings.Contains(preview.String(), "story_slice_preview: .plan/specs/billing.md") {
+		t.Fatalf("expected preview header:\n%s", preview.String())
+	}
+
+	var apply bytes.Buffer
+	command = newRootCmd()
+	command.SetOut(&apply)
+	command.SetErr(&apply)
+	command.SetIn(strings.NewReader("y\n"))
+	command.SetArgs([]string{"--project", root, "story", "slice", "billing", "--apply"})
+	if err := command.Execute(); err != nil {
+		t.Fatalf("expected apply to succeed: %v\n%s", err, apply.String())
+	}
+	if !strings.Contains(apply.String(), "created: 2") {
+		t.Fatalf("expected created stories in output:\n%s", apply.String())
+	}
+	if _, err := notes.Read(filepath.Join(root, ".plan", "stories", "trigger-export-job.md")); err != nil {
+		t.Fatalf("expected sliced story note: %v", err)
+	}
+}
+
+func TestStoryCritiqueCommandWritesCritiqueAndFailsOnRewrite(t *testing.T) {
+	root := t.TempDir()
+	ws := workspace.New(root)
+	if _, err := ws.Init(); err != nil {
+		t.Fatal(err)
+	}
+	manager := planning.New(ws)
+	if _, err := manager.CreateEpic("Billing", ""); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := manager.SetSpecStatus("billing", "approved"); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := manager.CreateStory("billing", "Trigger export job", "Create export trigger path", []string{"Users can trigger exports"}, []string{"Run export trigger tests"}, nil); err != nil {
+		t.Fatal(err)
+	}
+
+	input := strings.Join([]string{
+		"The story is close to the right size.",
+		"",
+		"It spans one vertical slice.",
+		"",
+		"Feature flag must already exist.",
+		"",
+		"No manual verification step is listed.",
+		"",
+		"rewrite",
+		"",
+	}, "\n")
+	var buf bytes.Buffer
+	command := newRootCmd()
+	command.SetOut(&buf)
+	command.SetErr(&buf)
+	command.SetIn(strings.NewReader(input))
+	command.SetArgs([]string{"--project", root, "story", "critique", "trigger-export-job"})
+	err := command.Execute()
+	if err == nil {
+		t.Fatalf("expected rewrite recommendation to fail command:\n%s", buf.String())
+	}
+	if !strings.Contains(err.Error(), "story critique recommends rewrite") {
+		t.Fatalf("unexpected critique error: %v", err)
+	}
+
+	note, err := notes.Read(filepath.Join(root, ".plan", "stories", "trigger-export-job.md"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(note.Content, "## Critique") || !strings.Contains(note.Content, "### Rewrite Recommendation\n\nrewrite") {
+		t.Fatalf("expected critique section in story note:\n%s", note.Content)
 	}
 }

--- a/docs/using-plan.md
+++ b/docs/using-plan.md
@@ -9,13 +9,12 @@ ideas.
 
 Right now:
 
-- the shipped CLI surface is `v5`
-- `v6` is the next approved backlog
-- this branch carries the `v6` planning artifacts, but not the `v6` feature
-  implementation yet
+- the shipped CLI surface includes the `v4`, `v5`, and `v6` planning passes
+- `story slice` and `story critique` are part of the current workflow
+- `plan check` validates the spec-to-story handoff more aggressively than it
+  did in earlier versions
 
-So this guide covers what you can do today, and the end of the guide calls out
-what is still missing for `v6`.
+So this guide covers the current command surface as it exists today.
 
 ## What `plan` Is
 
@@ -46,7 +45,9 @@ Workflow entry:
 5. `Shape the epic`
 6. `Write and approve spec`
 7. `Analyze or checklist the spec`
-8. `Create and execute stories`
+8. `Slice stories from the spec`
+9. `Critique stories before execution`
+10. `Create or execute stories`
 
 ## Workspace Layout
 
@@ -317,7 +318,38 @@ Current spec statuses:
 - `implementing`
 - `done`
 
-### 10. Create Stories
+### 10. Slice Stories From The Spec
+
+If the approved spec already has a strong `Story Breakdown`, preview the first
+pass slice set:
+
+```bash
+plan story slice --project . newsletter-system
+```
+
+This reads the canonical spec and produces a deterministic preview of the
+candidate stories it can derive from `## Story Breakdown`.
+
+Behavior:
+
+- preview-first by default
+- uses the story breakdown as the source of truth
+- derives acceptance criteria and verification from the spec when needed
+- protects against duplicate story creation on reruns
+
+Apply the slice set:
+
+```bash
+plan story slice --project . newsletter-system --apply
+```
+
+This creates any missing story notes and rewrites `## Story Breakdown` with
+linked checklist entries.
+
+Manual `story create` still works. Slicing is an optional accelerator, not a
+mandatory ceremony.
+
+### 11. Create Stories Manually
 
 Create a story from an approved spec:
 
@@ -350,7 +382,29 @@ plan story list --project . --epic newsletter-system
 plan story list --project . --status blocked
 ```
 
-### 11. Update Story Status
+### 12. Critique Story Readiness
+
+Pressure-test a story before implementation:
+
+```bash
+plan story critique --project . build-template-editor
+```
+
+This writes the `## Critique` section in the story note:
+
+- `Scope Fit`
+- `Vertical Slice Check`
+- `Hidden Prerequisites`
+- `Verification Gaps`
+- `Rewrite Recommendation`
+
+Behavior:
+
+- interactive, TTY-first
+- additive to the story note
+- returns non-zero when the recommendation is `rewrite` or `reslice`
+
+### 13. Update Story Status
 
 Update story progress:
 
@@ -468,40 +522,30 @@ Current state means:
 
 - no memory or context-management features
 - no external tracker sync
-- no story slicing command yet
-- no story critique command yet
 - no cloud-first workflow
 
 Those are roadmap questions, not current usage.
 
-## What Is Left For `v6`
+## `v6` Execution-Readiness Workflow
 
-`v6` is not feature-complete yet. The approved backlog on this branch is:
+The main `v6` additions are about making the spec-to-story handoff stronger.
 
-### Story Slice Preview and Apply Flow
+Recommended flow:
 
-- add the story slice candidate model and preview formatting
-- implement `plan story slice`
-- add rerun and duplicate-protection coverage
+1. Approve the spec.
+2. Make sure `## Story Breakdown` contains meaningful slice candidates.
+3. Run `plan story slice --project . <epic-slug>` to preview the first pass.
+4. Run `plan story slice --project . <epic-slug> --apply` when the preview is sound.
+5. Run `plan story critique --project . <story-slug>` on the stories that need pressure-testing.
+6. Run `plan check --project .` to validate the spec-to-story handoff.
 
-### Story Critique and Rejection Rules
+`plan check` now looks for readiness problems such as:
 
-- add the `## Critique` section schema to story notes
-- implement `plan story critique`
-- add critique docs and test coverage
-
-### Execution-Readiness Integration in `plan check`
-
-- add spec-to-story readiness rules in `plan check`
-- add cross-artifact readiness coverage
-- document the `v6` execution-readiness workflow
-
-In practical terms, `v6` becomes feature-complete when these three capabilities
-exist together:
-
-- a spec can be sliced into candidate stories with a preview-first flow
-- a story can be critiqued and given keep/rewrite/reslice guidance
-- `plan check` can validate the handoff from spec to stories across artifacts
+- implementing specs with no story breakdown
+- implementing specs with no child stories
+- linked story breakdown entries that point to missing files
+- story sets that exist but are not reflected in the canonical breakdown
+- implementing specs whose stories are all still `todo`
 
 ## Practical Rules
 
@@ -511,7 +555,8 @@ exist together:
 - Use `shape` when the epic boundary is weak.
 - Use `analyze` for general spec pressure-testing.
 - Use `checklist` when the spec has domain-specific risk.
-- Approve the spec before creating stories.
+- Approve the spec before creating or slicing stories.
+- Use `story critique` when a slice feels too broad or verification-thin.
 - Keep stories small, concrete, and verification-aware.
 
 ## Current Command Surface

--- a/docs/using-plan.md
+++ b/docs/using-plan.md
@@ -1,0 +1,542 @@
+# Using `plan`
+
+This guide describes how to use `plan` as it exists right now.
+
+It is based on the current command surface on `main`, not on older roadmap
+ideas.
+
+## Current Product State
+
+Right now:
+
+- the shipped CLI surface is `v5`
+- `v6` is the next approved backlog
+- this branch carries the `v6` planning artifacts, but not the `v6` feature
+  implementation yet
+
+So this guide covers what you can do today, and the end of the guide calls out
+what is still missing for `v6`.
+
+## What `plan` Is
+
+`plan` is a local-first planning CLI for software projects.
+
+It stores planning material in `.plan/` and focuses on one job:
+
+- turn rough ideas into shaped planning artifacts
+- make specs stronger before implementation starts
+- make stories execution-ready before coding begins
+
+`plan` does not handle memory, retrieval, or context management.
+
+## Core Model
+
+Canonical hierarchy:
+
+1. `Epic`
+2. `Spec`
+3. `Story`
+
+Workflow entry:
+
+1. `Brainstorm`
+2. `Refine`
+3. `Challenge`
+4. `Promote to epic`
+5. `Shape the epic`
+6. `Write and approve spec`
+7. `Analyze or checklist the spec`
+8. `Create and execute stories`
+
+## Workspace Layout
+
+`plan` keeps its durable planning material under `.plan/`:
+
+```text
+.plan/
+  PROJECT.md
+  ROADMAP.md
+  brainstorms/
+  epics/
+  specs/
+  stories/
+  .meta/
+    workspace.json
+    migrations.json
+```
+
+Meaning:
+
+- `PROJECT.md`: product direction and project rules
+- `ROADMAP.md`: version/phase planning
+- `brainstorms/`: discovery notes
+- `epics/`: outcome boundaries
+- `specs/`: canonical execution contracts
+- `stories/`: execution-ready slices
+- `.meta/`: tool-owned state only
+
+## New Repo Setup
+
+Initialize a new workspace:
+
+```bash
+plan init --project .
+```
+
+Check workspace health:
+
+```bash
+plan doctor --project .
+```
+
+Repair or normalize tool-owned state:
+
+```bash
+plan update --project .
+```
+
+## Existing Repo Setup
+
+If the repo already exists and you want `plan` to manage it:
+
+```bash
+plan adopt --project .
+plan doctor --project .
+```
+
+## Step-By-Step Workflow
+
+### 1. Start a Brainstorm
+
+Create a brainstorm:
+
+```bash
+plan brainstorm start --project . "Newsletter system"
+```
+
+Add notes or ideas:
+
+```bash
+plan brainstorm idea --project . newsletter-system --body "Use versioned templates"
+plan brainstorm idea --project . newsletter-system --section constraints --body "Keep it local-first"
+plan brainstorm idea --project . newsletter-system --section open-questions --body "How should previews work?"
+```
+
+Show the brainstorm:
+
+```bash
+plan brainstorm show --project . newsletter-system
+```
+
+### 2. Refine the Brainstorm
+
+Run the guided refinement pass:
+
+```bash
+plan brainstorm refine --project . newsletter-system
+```
+
+This writes the `## Refinement` section in the brainstorm note:
+
+- `Problem`
+- `User / Value`
+- `Appetite`
+- `Remaining Open Questions`
+- `Candidate Approaches`
+- `Decision Snapshot`
+
+Behavior:
+
+- interactive, TTY-first
+- saves after each cluster
+- reruns are resumable
+
+### 3. Challenge the Brainstorm
+
+Pressure-test the idea before it hardens:
+
+```bash
+plan brainstorm challenge --project . newsletter-system
+```
+
+This writes the `## Challenge` section:
+
+- `Rabbit Holes`
+- `No-Gos`
+- `Assumptions`
+- `Likely Overengineering`
+- `Simpler Alternative`
+
+Use this when you want to force scope discipline before promotion.
+
+### 4. Promote to an Epic
+
+If the brainstorm is ready, promote it:
+
+```bash
+plan epic promote --project . newsletter-system
+```
+
+This creates:
+
+- `.plan/epics/newsletter-system.md`
+- `.plan/specs/newsletter-system.md`
+
+You can also create an epic directly without a brainstorm:
+
+```bash
+plan epic create --project . "Newsletter system"
+```
+
+List epics:
+
+```bash
+plan epic list --project .
+```
+
+Show an epic:
+
+```bash
+plan epic show --project . newsletter-system
+```
+
+### 5. Shape the Epic
+
+Run the epic shaping pass:
+
+```bash
+plan epic shape --project . newsletter-system
+```
+
+This writes the `## Shape` section:
+
+- `Appetite`
+- `Outcome`
+- `Scope Boundary`
+- `Out of Scope`
+- `Success Signal`
+
+It also mirrors key shape output back into the epic summary sections where it
+helps readability.
+
+### 6. Work the Spec
+
+Show the canonical spec:
+
+```bash
+plan spec show --project . newsletter-system
+```
+
+Edit the spec with your editor:
+
+```bash
+plan spec edit --project . newsletter-system
+```
+
+Or replace the body directly:
+
+```bash
+plan spec edit --project . newsletter-system --body "$(cat my-spec.md)"
+```
+
+The spec is the canonical execution contract. It should contain:
+
+- `Why`
+- `Problem`
+- `Goals`
+- `Non-Goals`
+- `Constraints`
+- `Solution Shape`
+- `Flows`
+- `Data / Interfaces`
+- `Risks / Open Questions`
+- `Rollout`
+- `Verification`
+- `Story Breakdown`
+
+### 7. Analyze the Spec
+
+Run the general analysis pass:
+
+```bash
+plan spec analyze --project . newsletter-system
+```
+
+This writes the `## Analysis` section with findings for:
+
+- `Missing Constraints`
+- `Success Criteria Gaps`
+- `Hidden Dependencies`
+- `Risk Gaps`
+- `What/Why vs How Leakage`
+- `Recommended Revisions`
+
+Behavior:
+
+- non-destructive to the canonical spec sections
+- returns non-zero when blocking findings exist
+
+### 8. Run a Spec Checklist
+
+Run a profile-specific pass:
+
+```bash
+plan spec checklist --project . newsletter-system --profile general
+```
+
+Current profiles:
+
+- `general`
+- `ui-flow`
+- `api-integration`
+- `data-migration`
+
+This writes the `## Checklist` section in the spec and stores results under the
+chosen profile heading.
+
+Behavior:
+
+- non-destructive to canonical sections
+- deterministic for the same input
+- returns non-zero when the selected profile reports blocking issues
+
+### 9. Approve the Spec
+
+Stories can only be created from an approved spec.
+
+Approve it:
+
+```bash
+plan spec status --project . newsletter-system --set approved
+```
+
+Current spec statuses:
+
+- `draft`
+- `approved`
+- `implementing`
+- `done`
+
+### 10. Create Stories
+
+Create a story from an approved spec:
+
+```bash
+plan story create --project . newsletter-system "Build template editor" \
+  --body "Create the template editing flow." \
+  --criteria "Templates can be created and edited" \
+  --criteria "Template validation errors are visible" \
+  --verify "go test ./..." \
+  --verify "Manually verify the editor flow"
+```
+
+Important rules:
+
+- a story requires at least one acceptance criterion
+- a story requires at least one verification step
+- story creation is blocked until the spec is `approved`
+
+Show a story:
+
+```bash
+plan story show --project . build-template-editor
+```
+
+List stories:
+
+```bash
+plan story list --project .
+plan story list --project . --epic newsletter-system
+plan story list --project . --status blocked
+```
+
+### 11. Update Story Status
+
+Update story progress:
+
+```bash
+plan story update --project . build-template-editor --status in_progress
+plan story update --project . build-template-editor --status done
+```
+
+Append more detail later:
+
+```bash
+plan story update --project . build-template-editor \
+  --criteria "Editor preserves template formatting" \
+  --verify "Run template editor tests"
+```
+
+Current story statuses:
+
+- `todo`
+- `in_progress`
+- `blocked`
+- `done`
+
+## Quality Commands
+
+Run checks across the repo:
+
+```bash
+plan check --project .
+```
+
+Or narrow checks to one artifact:
+
+```bash
+plan check epic newsletter-system --project .
+plan check spec newsletter-system --project .
+plan check story build-template-editor --project .
+```
+
+Use status to see overall project planning progress:
+
+```bash
+plan status --project .
+```
+
+## Roadmap Commands
+
+Show roadmap:
+
+```bash
+plan roadmap show --project .
+```
+
+Edit roadmap:
+
+```bash
+plan roadmap edit --project .
+```
+
+## Skill Installation
+
+Install the `plan` skill globally:
+
+```bash
+plan skills install --scope global --agent codex
+```
+
+Install locally in the repo:
+
+```bash
+plan skills install --scope local --agent codex --project .
+```
+
+Preview targets without writing:
+
+```bash
+plan skills targets --scope both --agent codex --project .
+```
+
+You can repeat `--agent` for multiple targets.
+
+## End-To-End Example
+
+```bash
+plan init --project .
+
+plan brainstorm start --project . "Billing export"
+plan brainstorm idea --project . billing-export --body "Export billing data to an external API"
+plan brainstorm refine --project . billing-export
+plan brainstorm challenge --project . billing-export
+
+plan epic promote --project . billing-export
+plan epic shape --project . billing-export
+
+plan spec show --project . billing-export
+plan spec analyze --project . billing-export
+plan spec checklist --project . billing-export --profile api-integration
+plan spec status --project . billing-export --set approved
+
+plan story create --project . billing-export "Trigger export job" \
+  --criteria "Export job can be triggered from billing UI" \
+  --verify "Run focused billing export tests"
+
+plan story create --project . billing-export "Deliver export payload" \
+  --criteria "Payload matches the external API contract" \
+  --verify "Validate payload against fixture contract"
+
+plan status --project .
+plan check --project .
+```
+
+## What `plan` Does Not Do Right Now
+
+Current state means:
+
+- no memory or context-management features
+- no external tracker sync
+- no story slicing command yet
+- no story critique command yet
+- no cloud-first workflow
+
+Those are roadmap questions, not current usage.
+
+## What Is Left For `v6`
+
+`v6` is not feature-complete yet. The approved backlog on this branch is:
+
+### Story Slice Preview and Apply Flow
+
+- add the story slice candidate model and preview formatting
+- implement `plan story slice`
+- add rerun and duplicate-protection coverage
+
+### Story Critique and Rejection Rules
+
+- add the `## Critique` section schema to story notes
+- implement `plan story critique`
+- add critique docs and test coverage
+
+### Execution-Readiness Integration in `plan check`
+
+- add spec-to-story readiness rules in `plan check`
+- add cross-artifact readiness coverage
+- document the `v6` execution-readiness workflow
+
+In practical terms, `v6` becomes feature-complete when these three capabilities
+exist together:
+
+- a spec can be sliced into candidate stories with a preview-first flow
+- a story can be critiqued and given keep/rewrite/reslice guidance
+- `plan check` can validate the handoff from spec to stories across artifacts
+
+## Practical Rules
+
+- Start with the smallest useful pass.
+- Use `refine` when the idea is fuzzy.
+- Use `challenge` when the idea is too comfortable or too broad.
+- Use `shape` when the epic boundary is weak.
+- Use `analyze` for general spec pressure-testing.
+- Use `checklist` when the spec has domain-specific risk.
+- Approve the spec before creating stories.
+- Keep stories small, concrete, and verification-aware.
+
+## Current Command Surface
+
+Top-level commands available today:
+
+- `plan init`
+- `plan adopt`
+- `plan doctor`
+- `plan update`
+- `plan brainstorm`
+- `plan epic`
+- `plan spec`
+- `plan story`
+- `plan roadmap`
+- `plan check`
+- `plan status`
+- `plan skills`
+
+If you need the exact current help text, run:
+
+```bash
+plan --help
+plan brainstorm --help
+plan epic --help
+plan spec --help
+plan story --help
+```

--- a/internal/planning/check.go
+++ b/internal/planning/check.go
@@ -2,6 +2,7 @@ package planning
 
 import (
 	"fmt"
+	"os"
 	"path/filepath"
 	"strings"
 
@@ -61,6 +62,10 @@ func (m *Manager) Check(input CheckInput) (*CheckReport, error) {
 		return nil, err
 	}
 	report := &CheckReport{Project: info.ProjectName}
+	storyInfos, err := m.ListStories("", "")
+	if err != nil {
+		return nil, err
+	}
 
 	specs, err := m.specNotesForCheck(info, input)
 	if err != nil {
@@ -68,6 +73,7 @@ func (m *Manager) Check(input CheckInput) (*CheckReport, error) {
 	}
 	for _, spec := range specs {
 		report.Findings = append(report.Findings, checkSpecNote(rel(info.ProjectDir, spec.Path), spec)...)
+		report.Findings = append(report.Findings, checkSpecStoryReadiness(info, spec, storyInfos)...)
 	}
 	stories, err := m.storyNotesForCheck(info, input)
 	if err != nil {
@@ -292,6 +298,151 @@ func sectionLooksThin(content string) bool {
 		return false
 	}
 	return totalWords < 6
+}
+
+func checkSpecStoryReadiness(info *workspace.Info, spec *notes.Note, stories []StoryInfo) []CheckFinding {
+	status := stringValue(spec.Metadata["status"])
+	if status != "approved" && status != "implementing" {
+		return nil
+	}
+
+	path := rel(info.ProjectDir, spec.Path)
+	section := notes.ExtractSection(spec.Content, "Story Breakdown")
+	parsed := parseStoryBreakdownCandidates(section)
+	meaningful := meaningfulStoryBreakdownCandidates(parsed)
+	var findings []CheckFinding
+
+	if len(meaningful) == 0 {
+		severity := "warn"
+		if status == "implementing" {
+			severity = "error"
+		}
+		findings = append(findings, CheckFinding{
+			Severity:      severity,
+			Rule:          "spec.story_breakdown_missing",
+			ArtifactType:  "spec",
+			ArtifactPath:  path,
+			ArtifactTitle: spec.Title,
+			Section:       "Story Breakdown",
+			Message:       fmt.Sprintf("Spec is %q but ## Story Breakdown does not contain meaningful slice guidance.", status),
+			Suggestion:    "Add concrete story slice entries under ## Story Breakdown or use plan story slice once the spec is ready.",
+		})
+		return findings
+	}
+
+	specSlug := slugFromPath(spec.Path)
+	var childStories []StoryInfo
+	for _, story := range stories {
+		if story.Spec == specSlug {
+			childStories = append(childStories, story)
+		}
+	}
+
+	if status == "implementing" && len(childStories) == 0 {
+		findings = append(findings, CheckFinding{
+			Severity:      "error",
+			Rule:          "spec.story_coverage_missing",
+			ArtifactType:  "spec",
+			ArtifactPath:  path,
+			ArtifactTitle: spec.Title,
+			Section:       "Story Breakdown",
+			Message:       "Spec is \"implementing\" but no child stories are linked to it.",
+			Suggestion:    "Create stories from the approved spec or correct the spec/story linkage before continuing implementation.",
+		})
+	}
+
+	if len(childStories) > 0 && !storyBreakdownHasLinks(meaningful) {
+		findings = append(findings, CheckFinding{
+			Severity:      "warn",
+			Rule:          "spec.story_breakdown_unlinked",
+			ArtifactType:  "spec",
+			ArtifactPath:  path,
+			ArtifactTitle: spec.Title,
+			Section:       "Story Breakdown",
+			Message:       "Child stories exist, but ## Story Breakdown has not been refreshed with story links.",
+			Suggestion:    "Refresh ## Story Breakdown with linked story entries so the spec-to-story handoff stays durable.",
+		})
+	}
+
+	knownStorySlugs := map[string]struct{}{}
+	anyStarted := false
+	for _, story := range childStories {
+		knownStorySlugs[slugFromPath(story.Path)] = struct{}{}
+		if story.Status == "in_progress" || story.Status == "blocked" || story.Status == "done" {
+			anyStarted = true
+		}
+	}
+
+	if status == "implementing" && len(childStories) > 0 && !anyStarted {
+		findings = append(findings, CheckFinding{
+			Severity:      "warn",
+			Rule:          "spec.story_status_mismatch",
+			ArtifactType:  "spec",
+			ArtifactPath:  path,
+			ArtifactTitle: spec.Title,
+			Section:       "Story Breakdown",
+			Message:       "Spec is \"implementing\" but all linked stories are still todo.",
+			Suggestion:    "Either start the relevant story work or move the spec back to approved until implementation begins.",
+		})
+	}
+
+	expectedSlugs := map[string]struct{}{}
+	for _, candidate := range meaningful {
+		expectedSlugs[slugify(candidate.Title)] = struct{}{}
+		if candidate.LinkTarget == "" {
+			continue
+		}
+		linkedPath := filepath.Clean(filepath.Join(filepath.Dir(spec.Path), filepath.FromSlash(candidate.LinkTarget)))
+		if _, err := os.Stat(linkedPath); err != nil {
+			findings = append(findings, CheckFinding{
+				Severity:      "error",
+				Rule:          "spec.story_link_missing",
+				ArtifactType:  "spec",
+				ArtifactPath:  path,
+				ArtifactTitle: spec.Title,
+				Section:       "Story Breakdown",
+				Message:       fmt.Sprintf("Story Breakdown links to %s, but that story file is missing.", filepath.ToSlash(linkedPath)),
+				Suggestion:    "Remove the broken story link or recreate the missing story note.",
+			})
+		}
+	}
+	for _, story := range childStories {
+		if _, ok := expectedSlugs[slugFromPath(story.Path)]; ok {
+			continue
+		}
+		findings = append(findings, CheckFinding{
+			Severity:      "warn",
+			Rule:          "spec.story_orphaned",
+			ArtifactType:  "spec",
+			ArtifactPath:  path,
+			ArtifactTitle: spec.Title,
+			Section:       "Story Breakdown",
+			Message:       fmt.Sprintf("Story %s is linked to this spec but is not represented in ## Story Breakdown.", story.Path),
+			Suggestion:    "Refresh ## Story Breakdown so it matches the stories currently linked to the spec.",
+		})
+	}
+
+	return findings
+}
+
+func meaningfulStoryBreakdownCandidates(items []parsedStorySliceCandidate) []parsedStorySliceCandidate {
+	var out []parsedStorySliceCandidate
+	for _, item := range items {
+		if item.Title == "" || strings.EqualFold(item.Title, seededStoryBreakdownPlaceholder) {
+			continue
+		}
+		out = append(out, item)
+	}
+	return out
+}
+
+func storyBreakdownHasLinks(items []parsedStorySliceCandidate) bool {
+	for _, item := range items {
+		if strings.TrimSpace(item.LinkTarget) != "" {
+			return true
+		}
+	}
+	return false
 }
 
 func normalizeSectionLine(line string) string {

--- a/internal/planning/critique.go
+++ b/internal/planning/critique.go
@@ -1,0 +1,132 @@
+package planning
+
+import (
+	"fmt"
+	"path/filepath"
+	"strings"
+
+	"plan/internal/notes"
+)
+
+type StoryCritique struct {
+	Path                  string
+	ScopeFit              string
+	VerticalSliceCheck    string
+	HiddenPrerequisites   string
+	VerificationGaps      string
+	RewriteRecommendation string
+}
+
+type StoryCritiqueInput struct {
+	ScopeFit              string
+	VerticalSliceCheck    string
+	HiddenPrerequisites   string
+	VerificationGaps      string
+	RewriteRecommendation string
+}
+
+func (c StoryCritique) HasGaps() bool {
+	return strings.TrimSpace(c.ScopeFit) == "" ||
+		strings.TrimSpace(c.VerticalSliceCheck) == "" ||
+		strings.TrimSpace(c.HiddenPrerequisites) == "" ||
+		strings.TrimSpace(c.VerificationGaps) == "" ||
+		strings.TrimSpace(c.RewriteRecommendation) == ""
+}
+
+func (c StoryCritique) RecommendationAction() string {
+	value := strings.ToLower(strings.TrimSpace(c.RewriteRecommendation))
+	switch value {
+	case "keep", "rewrite", "reslice":
+		return value
+	default:
+		return ""
+	}
+}
+
+func (c StoryCritique) HasBlockingRecommendation() bool {
+	switch c.RecommendationAction() {
+	case "rewrite", "reslice":
+		return true
+	default:
+		return false
+	}
+}
+
+func (m *Manager) ReadStoryCritique(storySlug string) (*StoryCritique, error) {
+	info, err := m.workspace.EnsureInitialized()
+	if err != nil {
+		return nil, err
+	}
+	note, err := notes.Read(filepath.Join(info.StoriesDir, slugify(storySlug)+".md"))
+	if err != nil {
+		return nil, err
+	}
+	if note.Type != "story" {
+		return nil, fmt.Errorf("%s is not a story note", note.Path)
+	}
+	state := extractStoryCritique(note)
+	state.Path = rel(info.ProjectDir, note.Path)
+	return &state, nil
+}
+
+func (m *Manager) UpdateStoryCritique(storySlug string, input StoryCritiqueInput) (*notes.Note, error) {
+	info, err := m.workspace.EnsureInitialized()
+	if err != nil {
+		return nil, err
+	}
+	path := filepath.Join(info.StoriesDir, slugify(storySlug)+".md")
+	note, err := notes.Read(path)
+	if err != nil {
+		return nil, err
+	}
+	if note.Type != "story" {
+		return nil, fmt.Errorf("%s is not a story note", note.Path)
+	}
+
+	current := extractStoryCritique(note)
+	if strings.TrimSpace(input.ScopeFit) != "" {
+		current.ScopeFit = strings.TrimSpace(input.ScopeFit)
+	}
+	if strings.TrimSpace(input.VerticalSliceCheck) != "" {
+		current.VerticalSliceCheck = strings.TrimSpace(input.VerticalSliceCheck)
+	}
+	if strings.TrimSpace(input.HiddenPrerequisites) != "" {
+		current.HiddenPrerequisites = normalizeBulletList(input.HiddenPrerequisites)
+	}
+	if strings.TrimSpace(input.VerificationGaps) != "" {
+		current.VerificationGaps = normalizeBulletList(input.VerificationGaps)
+	}
+	if strings.TrimSpace(input.RewriteRecommendation) != "" {
+		current.RewriteRecommendation = strings.ToLower(strings.TrimSpace(input.RewriteRecommendation))
+	}
+	if current.RecommendationAction() == "" && strings.TrimSpace(current.RewriteRecommendation) != "" {
+		return nil, fmt.Errorf("invalid rewrite recommendation %q", current.RewriteRecommendation)
+	}
+
+	body := notes.SetSection(note.Content, "Critique", renderStoryCritique(current))
+	updated, err := notes.Update(path, notes.UpdateInput{Body: &body})
+	if err != nil {
+		return nil, err
+	}
+	return m.relNote(updated, info.ProjectDir), nil
+}
+
+func extractStoryCritique(note *notes.Note) StoryCritique {
+	return StoryCritique{
+		ScopeFit:              extractSubsection(note.Content, "Critique", "Scope Fit"),
+		VerticalSliceCheck:    extractSubsection(note.Content, "Critique", "Vertical Slice Check"),
+		HiddenPrerequisites:   extractSubsection(note.Content, "Critique", "Hidden Prerequisites"),
+		VerificationGaps:      extractSubsection(note.Content, "Critique", "Verification Gaps"),
+		RewriteRecommendation: extractSubsection(note.Content, "Critique", "Rewrite Recommendation"),
+	}
+}
+
+func renderStoryCritique(critique StoryCritique) string {
+	var lines []string
+	appendSubsection(&lines, "Scope Fit", critique.ScopeFit)
+	appendSubsection(&lines, "Vertical Slice Check", critique.VerticalSliceCheck)
+	appendSubsection(&lines, "Hidden Prerequisites", critique.HiddenPrerequisites)
+	appendSubsection(&lines, "Verification Gaps", critique.VerificationGaps)
+	appendSubsection(&lines, "Rewrite Recommendation", critique.RewriteRecommendation)
+	return strings.Join(lines, "\n")
+}

--- a/internal/planning/critique_test.go
+++ b/internal/planning/critique_test.go
@@ -1,0 +1,55 @@
+package planning
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"plan/internal/notes"
+	"plan/internal/workspace"
+)
+
+func TestUpdateStoryCritiqueWritesIdempotentCritiqueSection(t *testing.T) {
+	root := t.TempDir()
+	ws := workspace.New(root)
+	if _, err := ws.Init(); err != nil {
+		t.Fatal(err)
+	}
+	manager := New(ws)
+
+	if _, err := manager.CreateEpic("Billing", ""); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := manager.SetSpecStatus("billing", "approved"); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := manager.CreateStory("billing", "Trigger export job", "Create export trigger path", []string{"Users can trigger exports"}, []string{"Run export trigger tests"}, nil); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := manager.UpdateStoryCritique("trigger-export-job", StoryCritiqueInput{
+		ScopeFit:              "This story is small enough for one implementation pass.",
+		VerticalSliceCheck:    "It includes the UI trigger and the initial backend handoff.",
+		HiddenPrerequisites:   "External export flag must exist",
+		VerificationGaps:      "No manual verification step is listed",
+		RewriteRecommendation: "rewrite",
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := manager.UpdateStoryCritique("trigger-export-job", StoryCritiqueInput{
+		RewriteRecommendation: "rewrite",
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	note, err := notes.Read(filepath.Join(root, ".plan", "stories", "trigger-export-job.md"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := strings.Count(note.Content, "## Critique"); got != 1 {
+		t.Fatalf("expected one critique section, got %d:\n%s", got, note.Content)
+	}
+	if !strings.Contains(note.Content, "### Rewrite Recommendation\n\nrewrite") {
+		t.Fatalf("expected rewrite recommendation in note:\n%s", note.Content)
+	}
+}

--- a/internal/planning/story_slice.go
+++ b/internal/planning/story_slice.go
@@ -1,0 +1,290 @@
+package planning
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"plan/internal/notes"
+	"plan/internal/workspace"
+)
+
+const seededStoryBreakdownPlaceholder = "Split approved spec into execution-ready stories"
+
+type StorySliceCandidate struct {
+	Title              string
+	Slug               string
+	Description        string
+	AcceptanceCriteria []string
+	Verification       []string
+	StoryPath          string
+	Status             string
+}
+
+type StorySlicePreview struct {
+	Project    string
+	EpicSlug   string
+	SpecPath   string
+	SpecTitle  string
+	Candidates []StorySliceCandidate
+}
+
+type StorySliceApplyResult struct {
+	Project      string
+	EpicSlug     string
+	SpecPath     string
+	Candidates   []StorySliceCandidate
+	CreatedPaths []string
+	SkippedPaths []string
+}
+
+func (m *Manager) PreviewStorySlices(epicSlug string) (*StorySlicePreview, error) {
+	info, epic, spec, err := m.loadEpicAndSpec(epicSlug)
+	if err != nil {
+		return nil, err
+	}
+	if status := stringValue(spec.Metadata["status"]); status != "approved" {
+		if status == "" {
+			status = "draft"
+		}
+		return nil, fmt.Errorf("spec %s is %q; approve the spec before slicing stories", rel(info.ProjectDir, spec.Path), status)
+	}
+
+	candidates, err := deriveStorySliceCandidates(info, epic, spec)
+	if err != nil {
+		return nil, err
+	}
+	if len(candidates) == 0 {
+		return nil, fmt.Errorf("spec %s has no slice-ready Story Breakdown entries", rel(info.ProjectDir, spec.Path))
+	}
+	return &StorySlicePreview{
+		Project:    info.ProjectName,
+		EpicSlug:   slugFromPath(epic.Path),
+		SpecPath:   rel(info.ProjectDir, spec.Path),
+		SpecTitle:  spec.Title,
+		Candidates: candidates,
+	}, nil
+}
+
+func (m *Manager) ApplyStorySlices(epicSlug string) (*StorySliceApplyResult, error) {
+	preview, err := m.PreviewStorySlices(epicSlug)
+	if err != nil {
+		return nil, err
+	}
+	info, _, spec, err := m.loadEpicAndSpec(epicSlug)
+	if err != nil {
+		return nil, err
+	}
+
+	result := &StorySliceApplyResult{
+		Project:    preview.Project,
+		EpicSlug:   preview.EpicSlug,
+		SpecPath:   preview.SpecPath,
+		Candidates: append([]StorySliceCandidate(nil), preview.Candidates...),
+	}
+
+	for i, candidate := range result.Candidates {
+		if candidate.StoryPath != "" {
+			result.SkippedPaths = append(result.SkippedPaths, candidate.StoryPath)
+			continue
+		}
+		note, err := m.CreateStory(epicSlug, candidate.Title, candidate.Description, candidate.AcceptanceCriteria, candidate.Verification, nil)
+		if err != nil {
+			return nil, err
+		}
+		result.Candidates[i].StoryPath = note.Path
+		result.Candidates[i].Status = "todo"
+		result.CreatedPaths = append(result.CreatedPaths, note.Path)
+	}
+
+	breakdown := renderStoryBreakdownLinks(info.ProjectDir, spec.Path, result.Candidates)
+	body := notes.SetSection(spec.Content, "Story Breakdown", breakdown)
+	updatedSpec, err := notes.Update(spec.Path, notes.UpdateInput{Body: &body})
+	if err != nil {
+		return nil, err
+	}
+	result.SpecPath = rel(info.ProjectDir, updatedSpec.Path)
+	return result, nil
+}
+
+func deriveStorySliceCandidates(info *workspace.Info, epic, spec *notes.Note) ([]StorySliceCandidate, error) {
+	rawCandidates := parseStoryBreakdownCandidates(notes.ExtractSection(spec.Content, "Story Breakdown"))
+	verificationDefaults := storySliceVerificationDefaults(spec)
+	var candidates []StorySliceCandidate
+	for _, raw := range rawCandidates {
+		if raw.Title == "" || strings.EqualFold(raw.Title, seededStoryBreakdownPlaceholder) {
+			continue
+		}
+		candidate := StorySliceCandidate{
+			Title:              raw.Title,
+			Slug:               slugify(raw.Title),
+			Description:        strings.TrimSpace(raw.Description),
+			AcceptanceCriteria: trimmedItems(raw.AcceptanceCriteria),
+			Verification:       trimmedItems(raw.Verification),
+			Status:             "todo",
+		}
+		if candidate.Description == "" {
+			candidate.Description = fmt.Sprintf("Deliver the %q slice described by the canonical spec.", candidate.Title)
+		}
+		if len(candidate.AcceptanceCriteria) == 0 {
+			candidate.AcceptanceCriteria = []string{candidate.Title}
+		}
+		if len(candidate.Verification) == 0 {
+			candidate.Verification = append([]string(nil), verificationDefaults...)
+		}
+		storyPath := filepath.Join(info.StoriesDir, candidate.Slug+".md")
+		existing, err := notes.Read(storyPath)
+		if err == nil {
+			if stringValue(existing.Metadata["epic"]) != slugFromPath(epic.Path) || stringValue(existing.Metadata["spec"]) != slugFromPath(spec.Path) {
+				return nil, fmt.Errorf("story slug collision for %s: existing note %s belongs to epic=%s spec=%s", candidate.Slug, rel(info.ProjectDir, existing.Path), stringValue(existing.Metadata["epic"]), stringValue(existing.Metadata["spec"]))
+			}
+			candidate.StoryPath = rel(info.ProjectDir, existing.Path)
+			candidate.Status = stringValue(existing.Metadata["status"])
+			if candidate.Status == "" {
+				candidate.Status = "todo"
+			}
+		} else if !os.IsNotExist(err) {
+			return nil, err
+		}
+		candidates = append(candidates, candidate)
+	}
+	return candidates, nil
+}
+
+type parsedStorySliceCandidate struct {
+	Title              string
+	LinkTarget         string
+	Description        string
+	AcceptanceCriteria []string
+	Verification       []string
+}
+
+func parseStoryBreakdownCandidates(section string) []parsedStorySliceCandidate {
+	lines := strings.Split(strings.TrimSpace(section), "\n")
+	var candidates []parsedStorySliceCandidate
+	var current *parsedStorySliceCandidate
+	for _, line := range lines {
+		raw := strings.TrimRight(line, "\r")
+		if strings.TrimSpace(raw) == "" {
+			continue
+		}
+		if isTopLevelStoryBreakdownLine(raw) {
+			title, linkTarget := extractStoryBreakdownTitle(strings.TrimSpace(raw))
+			if title == "" {
+				current = nil
+				continue
+			}
+			candidate := parsedStorySliceCandidate{Title: title, LinkTarget: linkTarget}
+			candidates = append(candidates, candidate)
+			current = &candidates[len(candidates)-1]
+			continue
+		}
+		if current == nil || !isIndentedStoryBreakdownLine(raw) {
+			continue
+		}
+		trimmed := strings.TrimSpace(strings.TrimPrefix(strings.TrimPrefix(strings.TrimSpace(raw), "- "), "* "))
+		lower := strings.ToLower(trimmed)
+		switch {
+		case strings.HasPrefix(lower, "desc:"), strings.HasPrefix(lower, "description:"):
+			current.Description = strings.TrimSpace(afterColon(trimmed))
+		case strings.HasPrefix(lower, "accept:"), strings.HasPrefix(lower, "criteria:"), strings.HasPrefix(lower, "criterion:"):
+			if value := strings.TrimSpace(afterColon(trimmed)); value != "" {
+				current.AcceptanceCriteria = append(current.AcceptanceCriteria, value)
+			}
+		case strings.HasPrefix(lower, "verify:"), strings.HasPrefix(lower, "verification:"):
+			if value := strings.TrimSpace(afterColon(trimmed)); value != "" {
+				current.Verification = append(current.Verification, value)
+			}
+		}
+	}
+	return candidates
+}
+
+func isTopLevelStoryBreakdownLine(line string) bool {
+	if strings.TrimLeft(line, " \t") != line {
+		return false
+	}
+	trimmed := strings.TrimSpace(line)
+	return strings.HasPrefix(trimmed, "- ") || strings.HasPrefix(trimmed, "* ")
+}
+
+func isIndentedStoryBreakdownLine(line string) bool {
+	return strings.HasPrefix(line, "  ") || strings.HasPrefix(line, "\t")
+}
+
+func extractStoryBreakdownTitle(line string) (string, string) {
+	line = strings.TrimSpace(line)
+	line = strings.TrimPrefix(line, "- [ ] ")
+	line = strings.TrimPrefix(line, "- [x] ")
+	line = strings.TrimPrefix(line, "- ")
+	line = strings.TrimPrefix(line, "* ")
+	line = strings.TrimSpace(line)
+	if strings.HasPrefix(line, "[") {
+		if end := strings.Index(line, "]("); end > 1 {
+			target := ""
+			rest := line[end+2:]
+			if close := strings.Index(rest, ")"); close >= 0 {
+				target = strings.TrimSpace(rest[:close])
+			}
+			return strings.TrimSpace(line[1:end]), target
+		}
+	}
+	return line, ""
+}
+
+func afterColon(value string) string {
+	parts := strings.SplitN(value, ":", 2)
+	if len(parts) != 2 {
+		return ""
+	}
+	return parts[1]
+}
+
+func storySliceVerificationDefaults(spec *notes.Note) []string {
+	section := notes.ExtractSection(spec.Content, "Verification")
+	var out []string
+	for _, line := range strings.Split(section, "\n") {
+		trimmed := normalizeSectionLine(line)
+		if trimmed == "" {
+			continue
+		}
+		out = append(out, trimmed)
+	}
+	if len(out) == 0 {
+		return []string{"Validate the slice against the canonical spec."}
+	}
+	return out
+}
+
+func renderStoryBreakdownLinks(projectDir, specPath string, candidates []StorySliceCandidate) string {
+	var lines []string
+	for _, candidate := range candidates {
+		if candidate.StoryPath == "" {
+			continue
+		}
+		absStoryPath := filepath.Join(projectDir, filepath.FromSlash(candidate.StoryPath))
+		check := "[ ]"
+		if candidate.Status == "done" {
+			check = "[x]"
+		}
+		lines = append(lines, fmt.Sprintf("- %s [%s](%s)", check, candidate.Title, relativeLinkPath(filepath.Dir(specPath), absStoryPath)))
+	}
+	return strings.Join(lines, "\n")
+}
+
+func (m *Manager) loadEpicAndSpec(epicSlug string) (*workspace.Info, *notes.Note, *notes.Note, error) {
+	info, err := m.workspace.EnsureInitialized()
+	if err != nil {
+		return nil, nil, nil, err
+	}
+	epic, err := notes.Read(filepath.Join(info.EpicsDir, slugify(epicSlug)+".md"))
+	if err != nil {
+		return nil, nil, nil, err
+	}
+	spec, err := notes.Read(filepath.Join(info.SpecsDir, m.specSlugFromEpic(epic)+".md"))
+	if err != nil {
+		return nil, nil, nil, err
+	}
+	return info, epic, spec, nil
+}

--- a/internal/planning/story_slice_test.go
+++ b/internal/planning/story_slice_test.go
@@ -1,0 +1,217 @@
+package planning
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"plan/internal/notes"
+	"plan/internal/workspace"
+)
+
+func TestPreviewStorySlicesDerivesCandidatesFromStoryBreakdown(t *testing.T) {
+	root := t.TempDir()
+	ws := workspace.New(root)
+	if _, err := ws.Init(); err != nil {
+		t.Fatal(err)
+	}
+	manager := New(ws)
+
+	if _, err := manager.CreateEpic("Billing", ""); err != nil {
+		t.Fatal(err)
+	}
+	body := strings.Join([]string{
+		"# Billing Spec",
+		"",
+		"Created: now",
+		"",
+		"## Why",
+		"",
+		"Billing work needs a stronger handoff.",
+		"",
+		"## Problem",
+		"",
+		"The spec-to-story handoff is weak.",
+		"",
+		"## Goals",
+		"",
+		"- create stories from the spec",
+		"",
+		"## Non-Goals",
+		"",
+		"- rebuild the workflow engine",
+		"",
+		"## Constraints",
+		"",
+		"- keep it local-first",
+		"",
+		"## Solution Shape",
+		"",
+		"Slice approved specs into first-pass stories.",
+		"",
+		"## Flows",
+		"",
+		"1. Approve spec.",
+		"2. Preview slices.",
+		"",
+		"## Data / Interfaces",
+		"",
+		"- story slice candidate model",
+		"",
+		"## Risks / Open Questions",
+		"",
+		"- duplicate story slugs",
+		"",
+		"## Rollout",
+		"",
+		"- ship preview before apply",
+		"",
+		"## Verification",
+		"",
+		"- run story slice tests",
+		"",
+		"## Story Breakdown",
+		"",
+		"- Trigger export job",
+		"  - desc: Create the trigger path from the billing UI.",
+		"  - accept: Users can trigger a billing export.",
+		"  - verify: Run the billing export trigger tests.",
+		"- Deliver export payload",
+		"",
+	}, "\n")
+	if _, err := manager.UpdateSpec("billing", notes.UpdateInput{
+		Body: &body,
+		Metadata: map[string]any{
+			"status": "approved",
+		},
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	preview, err := manager.PreviewStorySlices("billing")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(preview.Candidates) != 2 {
+		t.Fatalf("expected 2 candidates, got %d", len(preview.Candidates))
+	}
+	if preview.Candidates[0].Description != "Create the trigger path from the billing UI." {
+		t.Fatalf("unexpected custom description: %+v", preview.Candidates[0])
+	}
+	if len(preview.Candidates[1].AcceptanceCriteria) != 1 || preview.Candidates[1].AcceptanceCriteria[0] != "Deliver export payload" {
+		t.Fatalf("expected default acceptance criteria from title: %+v", preview.Candidates[1])
+	}
+	if len(preview.Candidates[1].Verification) != 1 || preview.Candidates[1].Verification[0] != "run story slice tests" {
+		t.Fatalf("expected verification defaults from spec: %+v", preview.Candidates[1])
+	}
+}
+
+func TestApplyStorySlicesCreatesStoriesAndRefreshesStoryBreakdown(t *testing.T) {
+	root := t.TempDir()
+	ws := workspace.New(root)
+	if _, err := ws.Init(); err != nil {
+		t.Fatal(err)
+	}
+	manager := New(ws)
+
+	if _, err := manager.CreateEpic("Billing", ""); err != nil {
+		t.Fatal(err)
+	}
+	body := strings.Join([]string{
+		"# Billing Spec",
+		"",
+		"Created: now",
+		"",
+		"## Why",
+		"",
+		"Billing export needs slicing.",
+		"",
+		"## Problem",
+		"",
+		"Approved specs still require manual story creation.",
+		"",
+		"## Goals",
+		"",
+		"- create stories from the spec",
+		"",
+		"## Non-Goals",
+		"",
+		"- tracker sync",
+		"",
+		"## Constraints",
+		"",
+		"- keep it local-first",
+		"",
+		"## Solution Shape",
+		"",
+		"Slice stories from the approved spec.",
+		"",
+		"## Flows",
+		"",
+		"1. Approve spec.",
+		"2. Apply slices.",
+		"",
+		"## Data / Interfaces",
+		"",
+		"- story slice candidates",
+		"",
+		"## Risks / Open Questions",
+		"",
+		"- slug collisions",
+		"",
+		"## Rollout",
+		"",
+		"- dogfood it locally",
+		"",
+		"## Verification",
+		"",
+		"- run story slice tests",
+		"",
+		"## Story Breakdown",
+		"",
+		"- Trigger export job",
+		"- Deliver export payload",
+		"",
+	}, "\n")
+	if _, err := manager.UpdateSpec("billing", notes.UpdateInput{
+		Body: &body,
+		Metadata: map[string]any{
+			"status": "approved",
+		},
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	result, err := manager.ApplyStorySlices("billing")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(result.CreatedPaths) != 2 {
+		t.Fatalf("expected 2 created stories, got %+v", result)
+	}
+
+	spec, err := notes.Read(filepath.Join(root, ".plan", "specs", "billing.md"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	breakdown := notes.ExtractSection(spec.Content, "Story Breakdown")
+	if !strings.Contains(breakdown, "[Trigger export job](../stories/trigger-export-job.md)") {
+		t.Fatalf("expected linked story breakdown:\n%s", breakdown)
+	}
+
+	story, err := notes.Read(filepath.Join(root, ".plan", "stories", "trigger-export-job.md"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(story.Content, "## Acceptance Criteria") || !strings.Contains(story.Content, "## Verification") {
+		t.Fatalf("expected execution-ready story:\n%s", story.Content)
+	}
+
+	rerun, err := manager.ApplyStorySlices("billing")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(rerun.CreatedPaths) != 0 || len(rerun.SkippedPaths) != 2 {
+		t.Fatalf("expected rerun to reuse existing stories: %+v", rerun)
+	}
+}

--- a/internal/templates/story.md
+++ b/internal/templates/story.md
@@ -8,6 +8,18 @@ Created: {{ .Now }}
 
 ## Verification
 
+## Critique
+
+### Scope Fit
+
+### Vertical Slice Check
+
+### Hidden Prerequisites
+
+### Verification Gaps
+
+### Rewrite Recommendation
+
 ## Resources
 
 ## Notes

--- a/skills/plan/SKILL.md
+++ b/skills/plan/SKILL.md
@@ -48,6 +48,8 @@ When a repo uses `plan`:
 - `plan spec analyze --project . <epic-slug>`
 - `plan spec checklist --project . <epic-slug> --profile general`
 - `plan spec status --project . <epic-slug> --set approved`
+- `plan story slice --project . <epic-slug>`
+- `plan story critique --project . <story-slug>`
 - `plan story create --project . <epic-slug> "<title>" --criteria "<criterion>" --verify "<step>"`
 - `plan story update --project . <story-slug> --status in_progress`
 - `plan roadmap show --project .`
@@ -62,6 +64,8 @@ When a repo uses `plan`:
 - `epic shape` should turn an epic into a bounded bet with appetite and success signal.
 - `spec analyze` should pressure-test a spec without rewriting its canonical sections.
 - `spec checklist` should add profile-driven rigor without mutating the canonical sections.
+- `story slice` should stay preview-first and derive execution-ready slices from the canonical spec.
+- `story critique` should reject broad or verification-thin stories before implementation starts.
 - Keep roadmap guidance lightweight.
 - Do not add tasks beneath stories as first-class objects unless the project explicitly asks for that system.
 - Keep planning separate from memory, retrieval, or context management systems.
@@ -75,6 +79,8 @@ Use the smallest pass that resolves the current planning gap:
 3. `epic shape` for appetite and scope boundaries
 4. `spec analyze` for general refinement gaps
 5. `spec checklist` for domain-specific review
+6. `story slice` for turning approved spec breakdowns into first-pass story sets
+7. `story critique` for execution-readiness pressure before coding
 
 ## Model Guidance
 
@@ -99,6 +105,7 @@ Use the smallest pass that resolves the current planning gap:
 - shaping passes stay additive
 - optional rigor must not make the default path ceremonial
 - every recommendation should improve clarity, boundedness, verification, or executability
+- spec-to-story handoffs should stay checkable with `plan check`
 
 ## Ambiguity Handling
 

--- a/skills/plan/agents/gpt-style.yaml
+++ b/skills/plan/agents/gpt-style.yaml
@@ -11,8 +11,10 @@ workflow:
   - gather missing detail with explicit prompts
   - write additive updates only
   - verify that the artifact is still bounded and execution-ready
+  - if working from a spec, prefer story slice before inventing manual story sets
 checks:
   - clarity
   - boundedness
   - verification_quality
   - simplicity
+  - story_slice_quality

--- a/skills/plan/agents/openai.yaml
+++ b/skills/plan/agents/openai.yaml
@@ -8,7 +8,7 @@ families:
       - The planning pass is interactive and should stay tightly scaffolded.
     behavior:
       - Name the current artifact before editing it.
-      - Prefer one planning pass at a time: refine, challenge, shape, analyze, or checklist.
+      - Prefer one planning pass at a time: refine, challenge, shape, analyze, checklist, slice, or critique.
       - Keep completion criteria concrete and verification-aware.
       - If ambiguity remains, ask only the smallest clarifying question required to keep the plan sound.
   reasoning_heavy:
@@ -26,8 +26,11 @@ passes:
   - epic_shape
   - spec_analyze
   - spec_checklist
+  - story_slice
+  - story_critique
 guardrails:
   - plan is planning-only
   - specs remain canonical
   - optional rigor must stay optional
   - do not drift into memory or context management
+  - keep the spec-to-story handoff reviewable with plan check

--- a/skills/plan/agents/reasoning.yaml
+++ b/skills/plan/agents/reasoning.yaml
@@ -9,8 +9,10 @@ workflow:
   - choose one additive shaping pass
   - challenge overengineering and missing non-goals
   - preserve a clean handoff for later execution
+  - prefer critique when a story looks broad, horizontal, or verification-thin
 checks:
   - risk_coverage
   - non_goal_quality
   - agent_executability
   - artifact_simplicity
+  - story_readiness


### PR DESCRIPTION
## Summary

- add `plan story slice` with preview-first apply flow, duplicate protection, and spec story-breakdown link refresh
- add `plan story critique` with durable critique sections and rejection-style exit codes
- extend `plan check` with spec-to-story readiness validation and update docs/skills to reflect the shipped v6 surface

## Testing

- [x] `go test ./...`
- [x] `go build ./...`
- [x] Other:
  - `go run . story --help`
  - `go run . check --help`
  - `go run . check --project .`
  - `go run . status --project .`
  - `git diff --check`

## Release Notes

- User-facing change: `plan` now supports `story slice` and `story critique`, and `plan check` validates the spec-to-story handoff more aggressively.
- Planning or workflow impact: v6 is now feature-complete in the local planning loop, with all 40 stories marked done and the roadmap/spec breakdowns closed out.
- Follow-up work: shape `v7` only after deciding whether external sync is still worth the added surface area.

## Planning

- Related epic/spec/story: `Story Slice Preview and Apply Flow`, `Story Critique and Rejection Rules`, `Execution-Readiness Integration in plan check`
