### PR TITLE
feat: add GitHub issue-backed story execution

### DIFF
--- a/.plan/ROADMAP.md
+++ b/.plan/ROADMAP.md
@@ -63,14 +63,14 @@ Summary:
 
 Goal: Connect outward only after the local shaping loop is clearly excellent.
 
-- [ ] GitHub Projection Model
-- [ ] Issue and PR Linking
-- [ ] Selective Publish and Back-Sync
+- [ ] GitHub Story Backend and Preflight
+- [ ] Issue Contract and Planning Link Lifecycle
+- [ ] Dependency-Aware Issue Readiness
 
 Summary:
-- keep `.plan` canonical
-- treat external tools as projections, not source of truth
-- defer broader integrations until GitHub-only sync proves worthwhile
+- keep brainstorms, epics, and specs canonical in `.plan`
+- let GitHub Issues serve as the execution backend for stories when GitHub mode is enabled
+- derive blocked and ready work from planning-merge state plus issue dependencies
 
 ## Ordering Notes
 

--- a/.plan/brainstorms/github-issues-integration.md
+++ b/.plan/brainstorms/github-issues-integration.md
@@ -30,12 +30,6 @@ Publish execution work to GitHub issues while keeping brainstorms, epics, and sp
 - Should merged PRs be allowed to update local story status automatically?
 - Should issue publication happen only for selected stories, or for every approved story by default?
 - When, if ever, should milestones enter the model?
-
-- Should issue body edits ever sync back into local story notes, or should sync stay one-way at first?
-
-- Should merged PRs be allowed to update local story status automatically?
-
-- Should issue publication happen only for selected stories, or for every approved story by default?
 ## Ideas
 
 - Export approved stories to issues with stable links back to the local story note.

--- a/.plan/brainstorms/github-issues-integration.md
+++ b/.plan/brainstorms/github-issues-integration.md
@@ -5,7 +5,7 @@ slug: github-issues-integration
 status: active
 title: GitHub issues integration
 type: brainstorm
-updated_at: "2026-04-18T22:26:06Z"
+updated_at: "2026-04-19T00:29:01Z"
 ---
 
 # Brainstorm: GitHub issues integration
@@ -18,16 +18,24 @@ How should plan project local planning artifacts to GitHub issues without making
 ## Desired Outcome
 
 Publish execution work to GitHub issues while keeping brainstorms, epics, and specs local and canonical inside .plan.
+
 ## Constraints
 
 - GitHub issues should project stories or execution tasks, not replace local planning artifacts.
-
 - plan remains planning-only and local-first; GitHub stays external execution surface.
+
 ## Open Questions
 
-- Should issue edits ever sync back into local story notes, or should sync stay one-way at first?
+- Should issue body edits ever sync back into local story notes, or should sync stay one-way at first?
+- Should merged PRs be allowed to update local story status automatically?
+- Should issue publication happen only for selected stories, or for every approved story by default?
+- When, if ever, should milestones enter the model?
 
-- Should merged PRs be allowed to update story status automatically?
+- Should issue body edits ever sync back into local story notes, or should sync stay one-way at first?
+
+- Should merged PRs be allowed to update local story status automatically?
+
+- Should issue publication happen only for selected stories, or for every approved story by default?
 ## Ideas
 
 - Export approved stories to issues with stable links back to the local story note.
@@ -39,24 +47,59 @@ Publish execution work to GitHub issues while keeping brainstorms, epics, and sp
 
 ### Problem
 
+Teams using plan need a way to expose execution work in GitHub without moving planning authority out of the repo. Today the rich planning flow lives in .plan, but collaborators, PR links, and day-to-day execution often happen in GitHub issues.
+
 ### User / Value
+
+Indie developers and small teams keep the local-first planning depth they like, while still getting shareable GitHub-native execution tickets for collaborators, reviews, and repo automation.
 
 ### Appetite
 
+GitHub must not become source of truth. Brainstorms, epics, and specs stay local. First cut should stay GitHub-only, issue-focused, and smaller than full tracker sync. Publishing should be explicit and reversible in local notes.
+
 ### Remaining Open Questions
+
+- Should the first release support issue creation only, or issue update/reconciliation too?
+- Should local story status ever be derived from issue state, or only displayed alongside it?
+- Should milestone mapping wait until after basic story-to-issue publishing proves useful?
 
 ### Candidate Approaches
 
+- One-way story publish: approved or selected stories create/update linked GitHub issues, with local note metadata storing issue number and URL.
+- Read-only execution backfill: pull issue and PR state into local status views without letting issue body edits rewrite canonical local notes.
+- Selective publish model: let users choose which stories stay local-only and which ones project to GitHub.
+
 ### Decision Snapshot
+
+Keep .plan canonical. GitHub issues represent stories only. Start with explicit one-way publish plus optional read-only status backfill later.
 
 ## Challenge
 
 ### Rabbit Holes
 
+- Full bidirectional sync between issue bodies and local story notes.
+- Trying to map every plan artifact type into GitHub.
+- Automated label, milestone, project board, and sub-issue orchestration in the first cut.
+- Webhook-driven realtime sync from day one.
+
 ### No-Gos
+
+- Do not make GitHub canonical.
+- Do not export brainstorms, epics, or specs as first-class GitHub issues.
+- Do not support Jira/Linear-class tracker parity in the first cut.
+- Do not silently rewrite local planning notes from remote issue edits.
 
 ### Assumptions
 
+- Users already work in repos with GitHub Issues enabled.
+- Story titles and acceptance criteria can be rendered into useful issue bodies.
+- A local story can safely hold stable issue metadata and links.
+- Explicit publish/update commands are acceptable UX for v1.
+
 ### Likely Overengineering
 
+Trying to support two-way field sync, issue templates, milestone planning, PR automation, and multi-tracker abstractions at the same time. Most likely failure mode: building an integration platform before proving the one-way story projection loop.
+
 ### Simpler Alternative
+
+Export approved stories to GitHub issues with stable local links, optional label mapping, and no back-sync except maybe read-only status inspection. Everything above stories stays local.

--- a/.plan/brainstorms/github-issues-integration.md
+++ b/.plan/brainstorms/github-issues-integration.md
@@ -1,0 +1,62 @@
+---
+created_at: "2026-04-18T22:26:06Z"
+project: plan
+slug: github-issues-integration
+status: active
+title: GitHub issues integration
+type: brainstorm
+updated_at: "2026-04-18T22:26:06Z"
+---
+
+# Brainstorm: GitHub issues integration
+
+Started: 2026-04-18T22:26:06Z
+
+## Focus Question
+
+How should plan project local planning artifacts to GitHub issues without making GitHub the source of truth?
+## Desired Outcome
+
+Publish execution work to GitHub issues while keeping brainstorms, epics, and specs local and canonical inside .plan.
+## Constraints
+
+- GitHub issues should project stories or execution tasks, not replace local planning artifacts.
+
+- plan remains planning-only and local-first; GitHub stays external execution surface.
+## Open Questions
+
+- Should issue edits ever sync back into local story notes, or should sync stay one-way at first?
+
+- Should merged PRs be allowed to update story status automatically?
+## Ideas
+
+- Export approved stories to issues with stable links back to the local story note.
+
+- Optionally group issues under milestones mapped from roadmap phases later, not in the first cut.
+## Raw Notes
+
+## Refinement
+
+### Problem
+
+### User / Value
+
+### Appetite
+
+### Remaining Open Questions
+
+### Candidate Approaches
+
+### Decision Snapshot
+
+## Challenge
+
+### Rabbit Holes
+
+### No-Gos
+
+### Assumptions
+
+### Likely Overengineering
+
+### Simpler Alternative

--- a/.plan/brainstorms/github-issues-integration.md
+++ b/.plan/brainstorms/github-issues-integration.md
@@ -17,83 +17,94 @@ Started: 2026-04-18T22:26:06Z
 How should plan project local planning artifacts to GitHub issues without making GitHub the source of truth?
 ## Desired Outcome
 
-Publish execution work to GitHub issues while keeping brainstorms, epics, and specs local and canonical inside .plan.
+Keep brainstorms, epics, and specs local and canonical inside `.plan`, while execution work lives in GitHub issues with clear blockers, ready order, async-safe parallel lanes, and links back to the local docs.
 
 ## Constraints
 
-- GitHub issues should project stories or execution tasks, not replace local planning artifacts.
-- plan remains planning-only and local-first; GitHub stays external execution surface.
+- Brainstorms, epics, and specs stay local in `.plan/`.
+- If GitHub execution mode is enabled, stories should not be duplicated as first-class local markdown and GitHub issues at the same time.
+- GitHub issues must link to canonical local epic/spec markdown files in the repo.
+- Dependencies and blockers must make next-ready work obvious for humans and agents.
+- plan remains planning-first and local-first for shaping; GitHub becomes the execution surface.
 
 ## Open Questions
 
-- Should issue body edits ever sync back into local story notes, or should sync stay one-way at first?
-- Should merged PRs be allowed to update local story status automatically?
-- Should issue publication happen only for selected stories, or for every approved story by default?
+- How should dependencies be encoded in GitHub issues: native GitHub features when available, issue body sections, or a plan-owned metadata convention?
+- Should `plan` keep only minimal local issue metadata under `.plan/.meta/`, or some richer local index for readiness/status?
+- Should closing an issue or merging a PR automatically advance the next-ready work, or only make it visible?
+- Should GitHub execution mode be opt-in per repo or per epic/spec?
 - When, if ever, should milestones enter the model?
 ## Ideas
 
-- Export approved stories to issues with stable links back to the local story note.
-
-- Optionally group issues under milestones mapped from roadmap phases later, not in the first cut.
+- Use one GitHub issue per execution-ready story, with links to the canonical epic/spec markdown files.
+- Render acceptance criteria, verification, blockers, and async notes directly into the issue body.
+- Compute ready order from dependencies so the next executable issue is obvious.
+- Allow multiple ready issues at once when blockers do not overlap, so async human/agent work can proceed safely.
+- Store only issue metadata locally, not duplicate story notes.
+- Optionally group issues under milestones later, not in the first cut.
 ## Raw Notes
 
 ## Refinement
 
 ### Problem
 
-Teams using plan need a way to expose execution work in GitHub without moving planning authority out of the repo. Today the rich planning flow lives in .plan, but collaborators, PR links, and day-to-day execution often happen in GitHub issues.
+Teams using `plan` need local shaping depth and GitHub-native execution at the same time. Mirroring stories in both `.plan` and GitHub creates duplicated execution truth, weakens clarity, and makes it unclear where humans or agents should actually work from.
 
 ### User / Value
 
-Indie developers and small teams keep the local-first planning depth they like, while still getting shareable GitHub-native execution tickets for collaborators, reviews, and repo automation.
+Indie developers and small teams keep local-first planning for shaping, while humans and AI agents get GitHub-native execution units with clear ordering, blockers, async-safe parallel work, and direct links back to the local epic/spec docs.
 
 ### Appetite
 
-GitHub must not become source of truth. Brainstorms, epics, and specs stay local. First cut should stay GitHub-only, issue-focused, and smaller than full tracker sync. Publishing should be explicit and reversible in local notes.
+GitHub must not become source of truth for shaping. First cut should stay GitHub-issues-only, focused on issue-backed stories, blockers, ready order, and async flow. No full tracker parity. No duplicated local story notes.
 
 ### Remaining Open Questions
 
-- Should the first release support issue creation only, or issue update/reconciliation too?
-- Should local story status ever be derived from issue state, or only displayed alongside it?
-- Should milestone mapping wait until after basic story-to-issue publishing proves useful?
+- Should the first release support issue creation only, or creation plus update/reconciliation?
+- Should local status derive from issue state, or only surface issue state alongside epic/spec progress?
+- How much dependency logic can rely on native GitHub features versus issue body conventions?
+- Should milestone mapping wait until after issue-backed story flow proves useful?
 
 ### Candidate Approaches
 
-- One-way story publish: approved or selected stories create/update linked GitHub issues, with local note metadata storing issue number and URL.
-- Read-only execution backfill: pull issue and PR state into local status views without letting issue body edits rewrite canonical local notes.
-- Selective publish model: let users choose which stories stay local-only and which ones project to GitHub.
+- GitHub issue-backed stories: approved execution units materialize as GitHub issues, while `.plan` keeps only epic/spec/brainstorm docs plus issue metadata.
+- Read-only execution backfill: local status views read issue and PR state without letting remote edits rewrite canonical shaping docs.
+- Optional local-only mode remains for repos that do not enable GitHub execution.
 
 ### Decision Snapshot
 
-Keep .plan canonical. GitHub issues represent stories only. Start with explicit one-way publish plus optional read-only status backfill later.
+Keep `.plan` canonical for brainstorms, epics, and specs. If GitHub integration is enabled, stories live in GitHub issues, not duplicate local markdown files. Start with explicit issue creation/update plus dependency-driven ready visibility.
 
 ## Challenge
 
 ### Rabbit Holes
 
-- Full bidirectional sync between issue bodies and local story notes.
+- Duplicating story truth in both local markdown and GitHub issues.
 - Trying to map every plan artifact type into GitHub.
-- Automated label, milestone, project board, and sub-issue orchestration in the first cut.
-- Webhook-driven realtime sync from day one.
+- Building automation for labels, milestones, boards, projects, sub-issues, and realtime sync in the first cut.
+- Depending too hard on GitHub-specific surfaces before the issue-backed execution model proves itself.
 
 ### No-Gos
 
 - Do not make GitHub canonical.
+- Do not duplicate canonical stories in both `.plan` and GitHub issues.
 - Do not export brainstorms, epics, or specs as first-class GitHub issues.
 - Do not support Jira/Linear-class tracker parity in the first cut.
 - Do not silently rewrite local planning notes from remote issue edits.
+- Do not create dependency logic that is only visible in `plan` and invisible from the issue itself.
 
 ### Assumptions
 
 - Users already work in repos with GitHub Issues enabled.
-- Story titles and acceptance criteria can be rendered into useful issue bodies.
-- A local story can safely hold stable issue metadata and links.
-- Explicit publish/update commands are acceptable UX for v1.
+- Story titles, acceptance criteria, verification, and blockers can be rendered into useful issue bodies.
+- An issue can safely serve as the durable execution unit for a story.
+- Local epic/spec markdown links are useful inside issue bodies.
+- Explicit create/update commands are acceptable UX for v1.
 
 ### Likely Overengineering
 
-Trying to support two-way field sync, issue templates, milestone planning, PR automation, and multi-tracker abstractions at the same time. Most likely failure mode: building an integration platform before proving the one-way story projection loop.
+Trying to support two-way field sync, issue templates, milestone planning, project-board automation, PR automation, and multi-tracker abstractions at the same time. Most likely failure mode: building an integration platform before proving the issue-backed execution loop.
 
 ### Simpler Alternative
 
-Export approved stories to GitHub issues with stable local links, optional label mapping, and no back-sync except maybe read-only status inspection. Everything above stories stays local.
+Use GitHub issues as story storage, render blockers/spec links directly into the issue body, keep only minimal issue metadata locally, and compute ready work from dependencies without attempting full remote-local sync.

--- a/.plan/epics/dependency-aware-issue-readiness.md
+++ b/.plan/epics/dependency-aware-issue-readiness.md
@@ -1,0 +1,74 @@
+---
+created_at: "2026-04-19T01:16:45Z"
+project: plan
+slug: dependency-aware-issue-readiness
+spec: dependency-aware-issue-readiness
+title: Dependency-Aware Issue Readiness
+target_version: v7
+type: epic
+updated_at: "2026-04-19T01:16:45Z"
+---
+
+# Dependency-Aware Issue Readiness
+
+Created: 2026-04-19T01:16:45Z
+
+## Outcome
+Make blocked and ready work obvious for GitHub-backed stories so humans and AI
+agents can see execution order and parallel-safe work directly from the issue
+contract.
+
+## Why Now
+The value of GitHub-backed stories is not just storage. It is execution clarity.
+Without visible blockers and derived readiness, issue-backed stories still
+leave users guessing what comes next or what can run in parallel.
+
+## Shape
+
+### Appetite
+One `v7` epic: dependency encoding, derived ready state, async-safe parallel
+lanes, and optional reconcile-driven updates. No required GitHub workflow.
+
+### Outcome
+Issue-backed stories show blockers clearly, `plan` can compute ready work from
+planning-merge state plus dependency closure, and multiple ready issues can be
+worked in parallel when they do not conflict.
+
+### Scope Boundary
+- dependency representation for issue-backed stories
+- derived blocked and ready state
+- multiple ready issues when blockers do not overlap
+- CLI visibility into next-ready work
+- optional GitHub-visible readiness updates driven by the same CLI logic
+
+### Out of Scope
+- mandatory GitHub Actions setup
+- Jira/Linear-style scheduling features
+- project-board orchestration
+- invisible dependency logic that exists only in `.plan`
+
+### Success Signal
+Humans and agents can open the issue set and reliably tell what is blocked,
+what is ready now, and what can proceed in parallel without guessing.
+
+## Scope Boundary
+- dependency contract for issue-backed stories
+- readiness derivation rules
+- CLI reconcile/status surfaces
+- optional GitHub-visible updates such as labels or body markers
+
+## Spec
+- [Draft Spec](../specs/dependency-aware-issue-readiness.md)
+
+## Resources
+- [Product Direction](../PRODUCT.md)
+- [Roadmap](../ROADMAP.md)
+- [Source Brainstorm](../brainstorms/github-issues-integration.md)
+
+## Progress
+- Target version: `v7`
+- Status: planned
+
+## Notes
+Readiness should be derived, not manually toggled. Automation may call the same
+logic later, but the logic itself belongs inside `plan`.

--- a/.plan/epics/github-story-backend-and-preflight.md
+++ b/.plan/epics/github-story-backend-and-preflight.md
@@ -1,0 +1,73 @@
+---
+created_at: "2026-04-19T01:16:45Z"
+project: plan
+slug: github-story-backend-and-preflight
+spec: github-story-backend-and-preflight
+title: GitHub Story Backend and Preflight
+target_version: v7
+type: epic
+updated_at: "2026-04-19T01:16:45Z"
+---
+
+# GitHub Story Backend and Preflight
+
+Created: 2026-04-19T01:16:45Z
+
+## Outcome
+Add an opt-in GitHub execution backend where stories live in GitHub Issues,
+while brainstorms, epics, and specs remain canonical local markdown under
+`.plan/`.
+
+## Why Now
+The product direction is no longer "mirror local stories into GitHub." If issue
+execution is real, `plan` needs a clean backend boundary, explicit enablement,
+and hard preflight checks before it starts treating GitHub as story storage.
+
+## Shape
+
+### Appetite
+One contained `v7` epic: backend selection, preflight, and issue-backed story
+storage semantics. No dependency orchestration or workflow automation here.
+
+### Outcome
+Users can enable GitHub mode safely, verify repo/auth prerequisites up front,
+and create execution stories without duplicating them as local markdown notes.
+
+### Scope Boundary
+- `plan github enable`
+- `gh` presence and auth preflight
+- GitHub repo and Issues capability checks
+- explicit story backend selection: `local` or `github`
+- issue-backed story storage with minimal local metadata/index
+
+### Out of Scope
+- issue dependency readiness
+- planning PR link lifecycle
+- GitHub workflow installation
+- Jira/Linear or non-GitHub trackers
+
+### Success Signal
+GitHub mode can be enabled intentionally, fails safely when prerequisites are
+missing, and prevents duplicate story truth across `.plan` and GitHub Issues.
+
+## Scope Boundary
+- repo-level GitHub mode enablement
+- CLI preflight checks and error messages
+- backend-aware story create/update/list/show behavior
+- local metadata for issue-backed stories
+
+## Spec
+- [Draft Spec](../specs/github-story-backend-and-preflight.md)
+
+## Resources
+- [Product Direction](../PRODUCT.md)
+- [Roadmap](../ROADMAP.md)
+- [Source Brainstorm](../brainstorms/github-issues-integration.md)
+
+## Progress
+- Target version: `v7`
+- Status: planned
+
+## Notes
+Strict default: if GitHub mode is enabled, stories should not also exist as
+first-class local markdown notes.

--- a/.plan/epics/issue-contract-and-planning-link-lifecycle.md
+++ b/.plan/epics/issue-contract-and-planning-link-lifecycle.md
@@ -1,0 +1,73 @@
+---
+created_at: "2026-04-19T01:16:45Z"
+project: plan
+slug: issue-contract-and-planning-link-lifecycle
+spec: issue-contract-and-planning-link-lifecycle
+title: Issue Contract and Planning Link Lifecycle
+target_version: v7
+type: epic
+updated_at: "2026-04-19T01:16:45Z"
+---
+
+# Issue Contract and Planning Link Lifecycle
+
+Created: 2026-04-19T01:16:45Z
+
+## Outcome
+Define the issue body contract and lifecycle that links GitHub-backed stories
+to real local epic/spec docs before merge and after merge.
+
+## Why Now
+Issue-backed stories are only useful if the issue itself points to trustworthy
+planning docs. Planning often happens on a branch before the docs land on
+`main`, so the contract must handle branch-state links without making them
+fragile or misleading.
+
+## Shape
+
+### Appetite
+One `v7` epic: issue body schema, planning PR links, SHA permalinks before
+merge, and reconcile to canonical `main` links after merge.
+
+### Outcome
+Every GitHub-backed story issue clearly shows where the shaping docs live, what
+planning PR it depends on, and how those links normalize after merge.
+
+### Scope Boundary
+- visible issue body sections for epic/spec context
+- machine-readable metadata block in the issue body
+- planning PR links
+- commit-SHA permalink strategy before merge
+- reconcile flow that rewrites links to canonical `main` docs after merge
+
+### Out of Scope
+- issue dependency readiness rules
+- board or milestone automation
+- exporting brainstorms as issues
+- webhook-driven realtime sync
+
+### Success Signal
+Users can create issue-backed stories from a planning branch and still trust the
+links in the issue body before and after the planning PR merges.
+
+## Scope Boundary
+- issue body rendering
+- planning branch doc links
+- post-merge reconcile behavior
+- preserving readable issue text while keeping machine metadata stable
+
+## Spec
+- [Draft Spec](../specs/issue-contract-and-planning-link-lifecycle.md)
+
+## Resources
+- [Product Direction](../PRODUCT.md)
+- [Roadmap](../ROADMAP.md)
+- [Source Brainstorm](../brainstorms/github-issues-integration.md)
+
+## Progress
+- Target version: `v7`
+- Status: planned
+
+## Notes
+Branch-name links should not be treated as canonical. Commit-SHA permalinks
+before merge, then canonical `main` links after merge.

--- a/.plan/specs/dependency-aware-issue-readiness.md
+++ b/.plan/specs/dependency-aware-issue-readiness.md
@@ -3,11 +3,11 @@ created_at: "2026-04-19T01:16:45Z"
 epic: dependency-aware-issue-readiness
 project: plan
 slug: dependency-aware-issue-readiness
-status: approved
+status: done
 target_version: v7
 title: Dependency-Aware Issue Readiness Spec
 type: spec
-updated_at: "2026-04-19T01:54:55Z"
+updated_at: "2026-04-19T03:01:09Z"
 ---
 
 # Dependency-Aware Issue Readiness Spec

--- a/.plan/specs/dependency-aware-issue-readiness.md
+++ b/.plan/specs/dependency-aware-issue-readiness.md
@@ -1,0 +1,124 @@
+---
+created_at: "2026-04-19T01:16:45Z"
+epic: dependency-aware-issue-readiness
+project: plan
+slug: dependency-aware-issue-readiness
+status: draft
+target_version: v7
+title: Dependency-Aware Issue Readiness Spec
+type: spec
+updated_at: "2026-04-19T01:16:45Z"
+---
+
+# Dependency-Aware Issue Readiness Spec
+
+Created: 2026-04-19T01:16:45Z
+
+## Why
+If GitHub Issues are the execution backend for stories, they need to do more
+than exist. They need to expose sequencing and parallel-ready work clearly
+enough for humans and agents to act without hidden local knowledge.
+
+## Problem
+Today issue trackers easily devolve into flat queues. That breaks the promise
+of GitHub-backed stories for `plan`. Users need to know what is blocked, what
+becomes ready after merge, and what can safely proceed in parallel. If
+dependencies live only in local metadata, the issue itself stays ambiguous.
+
+## Goals
+- encode story dependencies in a way visible from the issue itself
+- derive issue readiness from planning-merge state plus dependency closure
+- allow multiple ready issues at once when blockers do not overlap
+- surface ready and blocked work in `plan` without requiring a GitHub workflow
+- optionally reflect derived readiness back into GitHub using the same CLI logic
+
+## Non-Goals
+- mandatory GitHub Actions or webhook automation
+- full project scheduling or enterprise resource planning
+- hidden dependency logic that only `plan` can see
+- milestone planning as a prerequisite for dependency-aware readiness
+
+## Constraints
+- readiness must be derived, not manually toggled
+- planning PR merge can block readiness before dependencies are even considered
+- dependency information must be visible in the issue body or another
+  GitHub-visible surface
+- the same readiness logic must work from the CLI without any workflow setup
+- optional automation must call the same underlying `plan` logic, not invent a
+  second implementation
+
+## Solution Shape
+- define a dependency contract for issue-backed stories
+- default to a `plan`-owned dependency section in the issue body, with optional
+  native GitHub dependency mirroring later if available and reliable
+- derive issue state from:
+  - planning merge status
+  - dependency issue closure
+- surface readiness in `plan status` and related GitHub-aware views
+- optionally update GitHub-visible markers such as labels, body sections, or
+  comments from explicit reconcile runs
+
+## Flows
+1. User creates issue-backed stories with blockers/dependencies.
+2. `plan` records dependency metadata in the issue contract.
+3. `plan github reconcile` reads planning merge state plus dependency closure.
+4. `plan` computes which issues are blocked, which are ready, and which are
+   parallel-safe.
+5. Users or agents pick any ready issue, while blocked issues clearly point to
+   what must close first.
+
+## Data / Interfaces
+- issue dependency section inside the issue contract
+- optional minimal local readiness cache/index
+- `plan github reconcile`
+- GitHub-aware status output and ready-work reporting
+
+## Risks / Open Questions
+- how much visible issue-body dependency structure is acceptable before it feels
+  noisy
+- whether labels are enough for readiness visibility or whether issue body
+  markers should stay primary
+- how to represent parallel-safe work without implying stronger scheduling than
+  the system can actually guarantee
+
+## Rollout
+- ship dependency encoding and CLI-derived readiness first
+- keep GitHub workflow automation optional
+- add GitHub-visible readiness updates only through the same reconcile path
+- revisit native GitHub dependency mirroring only after the body contract proves
+  stable
+
+## Verification
+- blocked issues clearly indicate which dependencies remain open
+- ready issues become visible when planning merge and dependency closure allow
+  execution
+- multiple ready issues can be surfaced at once for async work
+- no GitHub Actions setup is required to compute readiness correctly
+
+## Story Breakdown
+- [ ] Define the dependency contract for issue-backed stories
+- [ ] Compute derived ready and blocked state from merge plus dependency closure
+- [ ] Surface async-safe ready work in CLI and optional GitHub-visible updates
+
+## Analysis
+
+### Missing Constraints
+
+### Success Criteria Gaps
+
+### Hidden Dependencies
+
+### Risk Gaps
+
+### What/Why vs How Leakage
+
+### Recommended Revisions
+
+## Checklist
+
+## Resources
+- [Epic](../epics/dependency-aware-issue-readiness.md)
+- [Product Direction](../PRODUCT.md)
+- [Source Brainstorm](../brainstorms/github-issues-integration.md)
+
+## Notes

--- a/.plan/specs/dependency-aware-issue-readiness.md
+++ b/.plan/specs/dependency-aware-issue-readiness.md
@@ -3,11 +3,11 @@ created_at: "2026-04-19T01:16:45Z"
 epic: dependency-aware-issue-readiness
 project: plan
 slug: dependency-aware-issue-readiness
-status: draft
+status: approved
 target_version: v7
 title: Dependency-Aware Issue Readiness Spec
 type: spec
-updated_at: "2026-04-19T01:16:45Z"
+updated_at: "2026-04-19T01:54:55Z"
 ---
 
 # Dependency-Aware Issue Readiness Spec
@@ -96,9 +96,9 @@ dependencies live only in local metadata, the issue itself stays ambiguous.
 - no GitHub Actions setup is required to compute readiness correctly
 
 ## Story Breakdown
-- [ ] Define the dependency contract for issue-backed stories
-- [ ] Compute derived ready and blocked state from merge plus dependency closure
-- [ ] Surface async-safe ready work in CLI and optional GitHub-visible updates
+- [ ] [Define the dependency contract for issue-backed stories](../stories/define-the-dependency-contract-for-issue-backed-stories.md)
+- [ ] [Compute derived ready and blocked state from merge plus dependency closure](../stories/compute-derived-ready-and-blocked-state-from-merge-plus-dependency-closure.md)
+- [ ] [Surface async-safe ready work in CLI and optional GitHub-visible updates](../stories/surface-async-safe-ready-work-in-cli-and-optional-github-visible-updates.md)
 
 ## Analysis
 

--- a/.plan/specs/github-story-backend-and-preflight.md
+++ b/.plan/specs/github-story-backend-and-preflight.md
@@ -3,11 +3,11 @@ created_at: "2026-04-19T01:16:45Z"
 epic: github-story-backend-and-preflight
 project: plan
 slug: github-story-backend-and-preflight
-status: approved
+status: implementing
 target_version: v7
 title: GitHub Story Backend and Preflight Spec
 type: spec
-updated_at: "2026-04-19T01:54:55Z"
+updated_at: "2026-04-19T02:46:37Z"
 ---
 
 # GitHub Story Backend and Preflight Spec

--- a/.plan/specs/github-story-backend-and-preflight.md
+++ b/.plan/specs/github-story-backend-and-preflight.md
@@ -3,11 +3,11 @@ created_at: "2026-04-19T01:16:45Z"
 epic: github-story-backend-and-preflight
 project: plan
 slug: github-story-backend-and-preflight
-status: implementing
+status: done
 target_version: v7
 title: GitHub Story Backend and Preflight Spec
 type: spec
-updated_at: "2026-04-19T02:46:37Z"
+updated_at: "2026-04-19T02:52:42Z"
 ---
 
 # GitHub Story Backend and Preflight Spec

--- a/.plan/specs/github-story-backend-and-preflight.md
+++ b/.plan/specs/github-story-backend-and-preflight.md
@@ -3,11 +3,11 @@ created_at: "2026-04-19T01:16:45Z"
 epic: github-story-backend-and-preflight
 project: plan
 slug: github-story-backend-and-preflight
-status: draft
+status: approved
 target_version: v7
 title: GitHub Story Backend and Preflight Spec
 type: spec
-updated_at: "2026-04-19T01:16:45Z"
+updated_at: "2026-04-19T01:54:55Z"
 ---
 
 # GitHub Story Backend and Preflight Spec
@@ -94,9 +94,9 @@ half-GitHub workflow that confuses humans and agents.
 - local mode continues to create and manage `.plan/stories/` notes unchanged
 
 ## Story Breakdown
-- [ ] Add GitHub backend configuration and preflight checks
-- [ ] Enforce issue-backed story storage in GitHub mode
-- [ ] Add tests for local and GitHub story backend behavior
+- [ ] [Add GitHub backend configuration and preflight checks](../stories/add-github-backend-configuration-and-preflight-checks.md)
+- [ ] [Enforce issue-backed story storage in GitHub mode](../stories/enforce-issue-backed-story-storage-in-github-mode.md)
+- [ ] [Add tests for local and GitHub story backend behavior](../stories/add-tests-for-local-and-github-story-backend-behavior.md)
 
 ## Analysis
 

--- a/.plan/specs/github-story-backend-and-preflight.md
+++ b/.plan/specs/github-story-backend-and-preflight.md
@@ -1,0 +1,122 @@
+---
+created_at: "2026-04-19T01:16:45Z"
+epic: github-story-backend-and-preflight
+project: plan
+slug: github-story-backend-and-preflight
+status: draft
+target_version: v7
+title: GitHub Story Backend and Preflight Spec
+type: spec
+updated_at: "2026-04-19T01:16:45Z"
+---
+
+# GitHub Story Backend and Preflight Spec
+
+Created: 2026-04-19T01:16:45Z
+
+## Why
+If GitHub is going to be the execution backend for stories, `plan` needs a
+clear enablement model, hard safety checks, and an unambiguous boundary between
+local shaping docs and remote execution units.
+
+## Problem
+Right now `plan` assumes stories are local markdown under `.plan/stories/`.
+That does not fit the issue-backed model. Without a real backend switch, the
+product will either duplicate story truth or create a half-local,
+half-GitHub workflow that confuses humans and agents.
+
+## Goals
+- add an explicit GitHub story backend
+- add `plan github enable` with repo/auth preflight
+- require `gh` to be installed and logged in for GitHub mode
+- verify the current repo maps to a GitHub repo with Issues enabled
+- prevent duplicate local story markdown when GitHub mode is active
+- keep only minimal issue metadata locally when stories are GitHub-backed
+
+## Non-Goals
+- implementing issue dependency readiness in this spec
+- linking planning PRs and permalinks in issue bodies
+- installing GitHub Actions workflows
+- supporting non-GitHub trackers
+
+## Constraints
+- brainstorms, epics, and specs stay canonical in `.plan/`
+- GitHub mode must be opt-in
+- GitHub mode requires `gh` plus successful `gh auth status`
+- story commands must respect the configured backend
+- local-first repos that do not enable GitHub mode must keep current behavior
+
+## Solution Shape
+- add story backend config with `local` as default and `github` as opt-in
+- add `plan github enable` to run preflight and store backend configuration
+- preflight checks:
+  - `gh` exists on PATH
+  - `gh auth status` succeeds
+  - current git remote resolves to a GitHub repo
+  - GitHub Issues are enabled on the target repo
+- in GitHub mode, story create/update/list/show operate on issue-backed records
+  instead of local story markdown files
+- store only minimal issue metadata locally under `.plan/.meta/`
+
+## Flows
+1. User runs `plan github enable`.
+2. `plan` checks for `gh`, auth, repo mapping, and Issues support.
+3. `plan` stores GitHub backend configuration locally.
+4. User creates an execution story from an approved spec.
+5. `plan` creates or updates a GitHub issue-backed story and stores minimal
+   local metadata instead of writing a local story markdown note.
+
+## Data / Interfaces
+- `plan github enable`
+- story backend config in `.plan/.meta/`
+- minimal issue metadata/index in `.plan/.meta/`
+- backend-aware story create/update/list/show commands
+
+## Risks / Open Questions
+- whether backend selection should be repo-level only or later support per-epic
+  overrides
+- how much issue metadata should be cached locally versus fetched on demand
+- how to handle migration for repos that already have local stories when GitHub
+  mode is enabled later
+
+## Rollout
+- ship repo-level GitHub mode first
+- keep local story mode as the default
+- defer migration ergonomics until the backend model itself is solid
+- layer link lifecycle and readiness on top after backend enforcement exists
+
+## Verification
+- `plan github enable` fails with clear errors when `gh` is missing or not
+  authenticated
+- `plan github enable` fails when the repo does not resolve to a GitHub repo or
+  Issues are disabled
+- GitHub mode prevents local story markdown creation
+- local mode continues to create and manage `.plan/stories/` notes unchanged
+
+## Story Breakdown
+- [ ] Add GitHub backend configuration and preflight checks
+- [ ] Enforce issue-backed story storage in GitHub mode
+- [ ] Add tests for local and GitHub story backend behavior
+
+## Analysis
+
+### Missing Constraints
+
+### Success Criteria Gaps
+
+### Hidden Dependencies
+
+### Risk Gaps
+
+### What/Why vs How Leakage
+
+### Recommended Revisions
+
+## Checklist
+
+## Resources
+- [Epic](../epics/github-story-backend-and-preflight.md)
+- [Product Direction](../PRODUCT.md)
+- [Source Brainstorm](../brainstorms/github-issues-integration.md)
+
+## Notes

--- a/.plan/specs/issue-contract-and-planning-link-lifecycle.md
+++ b/.plan/specs/issue-contract-and-planning-link-lifecycle.md
@@ -3,11 +3,11 @@ created_at: "2026-04-19T01:16:45Z"
 epic: issue-contract-and-planning-link-lifecycle
 project: plan
 slug: issue-contract-and-planning-link-lifecycle
-status: approved
+status: done
 target_version: v7
 title: Issue Contract and Planning Link Lifecycle Spec
 type: spec
-updated_at: "2026-04-19T01:54:55Z"
+updated_at: "2026-04-19T02:55:44Z"
 ---
 
 # Issue Contract and Planning Link Lifecycle Spec

--- a/.plan/specs/issue-contract-and-planning-link-lifecycle.md
+++ b/.plan/specs/issue-contract-and-planning-link-lifecycle.md
@@ -3,11 +3,11 @@ created_at: "2026-04-19T01:16:45Z"
 epic: issue-contract-and-planning-link-lifecycle
 project: plan
 slug: issue-contract-and-planning-link-lifecycle
-status: draft
+status: approved
 target_version: v7
 title: Issue Contract and Planning Link Lifecycle Spec
 type: spec
-updated_at: "2026-04-19T01:16:45Z"
+updated_at: "2026-04-19T01:54:55Z"
 ---
 
 # Issue Contract and Planning Link Lifecycle Spec
@@ -98,9 +98,9 @@ which drift, disappear, or cannot be trusted after merge.
 - no branch-name link is required as the canonical reference path
 
 ## Story Breakdown
-- [ ] Define the issue body contract and metadata block
-- [ ] Publish planning-branch doc links and planning PR references
-- [ ] Reconcile issue links to canonical `main` docs after merge
+- [ ] [Define the issue body contract and metadata block](../stories/define-the-issue-body-contract-and-metadata-block.md)
+- [ ] [Publish planning-branch doc links and planning PR references](../stories/publish-planning-branch-doc-links-and-planning-pr-references.md)
+- [ ] [Reconcile issue links to canonical `main` docs after merge](../stories/reconcile-issue-links-to-canonical-main-docs-after-merge.md)
 
 ## Analysis
 

--- a/.plan/specs/issue-contract-and-planning-link-lifecycle.md
+++ b/.plan/specs/issue-contract-and-planning-link-lifecycle.md
@@ -1,0 +1,126 @@
+---
+created_at: "2026-04-19T01:16:45Z"
+epic: issue-contract-and-planning-link-lifecycle
+project: plan
+slug: issue-contract-and-planning-link-lifecycle
+status: draft
+target_version: v7
+title: Issue Contract and Planning Link Lifecycle Spec
+type: spec
+updated_at: "2026-04-19T01:16:45Z"
+---
+
+# Issue Contract and Planning Link Lifecycle Spec
+
+Created: 2026-04-19T01:16:45Z
+
+## Why
+If stories live in GitHub Issues, the issue body becomes part of the execution
+contract. It must point to real planning docs even when those docs still live
+on an unmerged planning branch.
+
+## Problem
+Branch planning happens before merge, but issue-backed execution cannot rely on
+broken or ambiguous links. Without a clear link lifecycle, users will either
+avoid creating issues until late, or they will create issues that point at docs
+which drift, disappear, or cannot be trusted after merge.
+
+## Goals
+- define a human-readable and machine-readable issue contract
+- link each issue-backed story to canonical epic/spec markdown files
+- include the planning PR link in the issue when work is created before merge
+- use pushed commit-SHA permalinks before merge
+- reconcile links to canonical `main` doc links after merge
+- make planning-merge state visible from the issue itself
+
+## Non-Goals
+- exporting brainstorms, epics, or specs as GitHub issues
+- relying on branch-name links as canonical references
+- full remote-to-local field sync from arbitrary issue edits
+- milestone and project-board automation
+
+## Constraints
+- issue links must resolve to real files before merge and after merge
+- commit-SHA links should be the default pre-merge doc reference
+- issue body contract must remain readable to humans, not hidden in local state
+- remote issue edits must not silently rewrite canonical local planning docs
+- reconcile logic should preserve issue edits outside the `plan`-owned sections
+
+## Solution Shape
+- add an issue body template with:
+  - summary/description
+  - acceptance criteria
+  - verification
+  - epic link
+  - spec link
+  - planning PR link when relevant
+  - blocker / dependency section
+  - optional async notes
+- include a machine-readable `plan` metadata block in the issue body
+- before merge, publish epic/spec links as GitHub commit-SHA permalinks
+- after merge, run reconcile to rewrite doc links to canonical `main` links and
+  clear planning-blocked markers when appropriate
+
+## Flows
+1. User shapes work on a planning branch and pushes it.
+2. User opens or references a planning PR.
+3. `plan` creates or updates an issue-backed story.
+4. The issue body contains epic/spec SHA permalinks plus the planning PR link.
+5. Planning PR merges.
+6. `plan github reconcile` rewrites epic/spec links to canonical `main` links
+   and updates planning-blocked markers.
+
+## Data / Interfaces
+- issue body schema for issue-backed stories
+- machine-readable metadata block embedded in the issue body
+- planning PR reference
+- doc reference mode: commit SHA before merge, `main` after reconcile
+- `plan github reconcile`
+
+## Risks / Open Questions
+- whether reconcile should require an explicit PR number or infer it from branch
+  and repo context
+- how aggressively `plan` should rewrite existing issue bodies after merge
+- how much issue body structure should be configurable without breaking agent
+  readability
+
+## Rollout
+- ship the issue contract alongside the GitHub story backend
+- support planning-branch publish before merge
+- add reconcile to normalize links after merge
+- keep workflow automation optional and secondary to the CLI path
+
+## Verification
+- issue-backed stories created from a planning branch include real SHA permalink
+  doc links and planning PR references
+- after reconcile, issue links point to canonical `main` docs
+- issue bodies preserve non-`plan` user edits outside `plan`-owned sections
+- no branch-name link is required as the canonical reference path
+
+## Story Breakdown
+- [ ] Define the issue body contract and metadata block
+- [ ] Publish planning-branch doc links and planning PR references
+- [ ] Reconcile issue links to canonical `main` docs after merge
+
+## Analysis
+
+### Missing Constraints
+
+### Success Criteria Gaps
+
+### Hidden Dependencies
+
+### Risk Gaps
+
+### What/Why vs How Leakage
+
+### Recommended Revisions
+
+## Checklist
+
+## Resources
+- [Epic](../epics/issue-contract-and-planning-link-lifecycle.md)
+- [Product Direction](../PRODUCT.md)
+- [Source Brainstorm](../brainstorms/github-issues-integration.md)
+
+## Notes

--- a/.plan/stories/add-github-backend-configuration-and-preflight-checks.md
+++ b/.plan/stories/add-github-backend-configuration-and-preflight-checks.md
@@ -4,10 +4,10 @@ epic: github-story-backend-and-preflight
 project: plan
 slug: add-github-backend-configuration-and-preflight-checks
 spec: github-story-backend-and-preflight
-status: todo
+status: done
 title: Add GitHub backend configuration and preflight checks
 type: story
-updated_at: "2026-04-19T01:53:14Z"
+updated_at: "2026-04-19T02:46:37Z"
 ---
 
 # Add GitHub backend configuration and preflight checks

--- a/.plan/stories/add-github-backend-configuration-and-preflight-checks.md
+++ b/.plan/stories/add-github-backend-configuration-and-preflight-checks.md
@@ -1,0 +1,35 @@
+---
+created_at: "2026-04-19T01:53:14Z"
+epic: github-story-backend-and-preflight
+project: plan
+slug: add-github-backend-configuration-and-preflight-checks
+spec: github-story-backend-and-preflight
+status: todo
+title: Add GitHub backend configuration and preflight checks
+type: story
+updated_at: "2026-04-19T01:53:14Z"
+---
+
+# Add GitHub backend configuration and preflight checks
+
+Created: 2026-04-19T01:53:14Z
+
+## Description
+
+Add the repo-level GitHub story backend setting plus the preflight path that validates `gh`, auth, repo mapping, and GitHub Issues support before GitHub mode can be enabled.
+
+## Acceptance Criteria
+
+- [ ] `plan github enable` stores backend configuration only after `gh`, auth, repo mapping, and Issues checks pass.
+
+- [ ] Failure cases return clear guidance when `gh` is missing, not logged in, or the target repo cannot support issue-backed stories.
+
+## Verification
+
+- Run GitHub backend preflight tests.
+
+## Resources
+
+- [Canonical Spec](../specs/github-story-backend-and-preflight.md)
+
+## Notes

--- a/.plan/stories/add-tests-for-local-and-github-story-backend-behavior.md
+++ b/.plan/stories/add-tests-for-local-and-github-story-backend-behavior.md
@@ -1,0 +1,35 @@
+---
+created_at: "2026-04-19T01:53:14Z"
+epic: github-story-backend-and-preflight
+project: plan
+slug: add-tests-for-local-and-github-story-backend-behavior
+spec: github-story-backend-and-preflight
+status: todo
+title: Add tests for local and GitHub story backend behavior
+type: story
+updated_at: "2026-04-19T01:53:14Z"
+---
+
+# Add tests for local and GitHub story backend behavior
+
+Created: 2026-04-19T01:53:14Z
+
+## Description
+
+Expand tests so backend selection, preflight, and story storage behavior stay correct across local-only repos and GitHub-enabled repos.
+
+## Acceptance Criteria
+
+- [ ] Tests cover successful GitHub enablement plus failure paths for missing `gh`, failed auth, and unsupported repo state.
+
+- [ ] Tests catch regressions where GitHub mode accidentally creates duplicate local story notes or breaks local story mode.
+
+## Verification
+
+- Run local and GitHub story backend test suites.
+
+## Resources
+
+- [Canonical Spec](../specs/github-story-backend-and-preflight.md)
+
+## Notes

--- a/.plan/stories/add-tests-for-local-and-github-story-backend-behavior.md
+++ b/.plan/stories/add-tests-for-local-and-github-story-backend-behavior.md
@@ -4,10 +4,10 @@ epic: github-story-backend-and-preflight
 project: plan
 slug: add-tests-for-local-and-github-story-backend-behavior
 spec: github-story-backend-and-preflight
-status: todo
+status: done
 title: Add tests for local and GitHub story backend behavior
 type: story
-updated_at: "2026-04-19T01:53:14Z"
+updated_at: "2026-04-19T02:52:42Z"
 ---
 
 # Add tests for local and GitHub story backend behavior

--- a/.plan/stories/compute-derived-ready-and-blocked-state-from-merge-plus-dependency-closure.md
+++ b/.plan/stories/compute-derived-ready-and-blocked-state-from-merge-plus-dependency-closure.md
@@ -1,0 +1,35 @@
+---
+created_at: "2026-04-19T01:53:14Z"
+epic: dependency-aware-issue-readiness
+project: plan
+slug: compute-derived-ready-and-blocked-state-from-merge-plus-dependency-closure
+spec: dependency-aware-issue-readiness
+status: todo
+title: Compute derived ready and blocked state from merge plus dependency closure
+type: story
+updated_at: "2026-04-19T01:53:14Z"
+---
+
+# Compute derived ready and blocked state from merge plus dependency closure
+
+Created: 2026-04-19T01:53:14Z
+
+## Description
+
+Implement readiness derivation so issue-backed stories stay blocked until the planning PR is merged and all dependency issues are closed, then become ready without manual toggles.
+
+## Acceptance Criteria
+
+- [ ] Issues remain blocked when planning merge state or open dependencies prevent execution.
+
+- [ ] Issues become ready when planning merge state is satisfied and dependency issues are closed.
+
+## Verification
+
+- Run readiness derivation tests.
+
+## Resources
+
+- [Canonical Spec](../specs/dependency-aware-issue-readiness.md)
+
+## Notes

--- a/.plan/stories/compute-derived-ready-and-blocked-state-from-merge-plus-dependency-closure.md
+++ b/.plan/stories/compute-derived-ready-and-blocked-state-from-merge-plus-dependency-closure.md
@@ -4,10 +4,10 @@ epic: dependency-aware-issue-readiness
 project: plan
 slug: compute-derived-ready-and-blocked-state-from-merge-plus-dependency-closure
 spec: dependency-aware-issue-readiness
-status: todo
+status: done
 title: Compute derived ready and blocked state from merge plus dependency closure
 type: story
-updated_at: "2026-04-19T01:53:14Z"
+updated_at: "2026-04-19T03:01:08Z"
 ---
 
 # Compute derived ready and blocked state from merge plus dependency closure

--- a/.plan/stories/define-the-dependency-contract-for-issue-backed-stories.md
+++ b/.plan/stories/define-the-dependency-contract-for-issue-backed-stories.md
@@ -1,0 +1,35 @@
+---
+created_at: "2026-04-19T01:53:14Z"
+epic: dependency-aware-issue-readiness
+project: plan
+slug: define-the-dependency-contract-for-issue-backed-stories
+spec: dependency-aware-issue-readiness
+status: todo
+title: Define the dependency contract for issue-backed stories
+type: story
+updated_at: "2026-04-19T01:53:14Z"
+---
+
+# Define the dependency contract for issue-backed stories
+
+Created: 2026-04-19T01:53:14Z
+
+## Description
+
+Define how blockers and dependencies are represented in issue-backed stories so they stay visible from the issue itself and remain stable enough for `plan` to compute readiness.
+
+## Acceptance Criteria
+
+- [ ] The dependency contract is visible in the issue body or another GitHub-visible surface, not hidden only in local metadata.
+
+- [ ] Dependency references are structured enough for `plan` to parse and use for readiness derivation.
+
+## Verification
+
+- Run dependency contract parsing tests.
+
+## Resources
+
+- [Canonical Spec](../specs/dependency-aware-issue-readiness.md)
+
+## Notes

--- a/.plan/stories/define-the-dependency-contract-for-issue-backed-stories.md
+++ b/.plan/stories/define-the-dependency-contract-for-issue-backed-stories.md
@@ -4,10 +4,10 @@ epic: dependency-aware-issue-readiness
 project: plan
 slug: define-the-dependency-contract-for-issue-backed-stories
 spec: dependency-aware-issue-readiness
-status: todo
+status: done
 title: Define the dependency contract for issue-backed stories
 type: story
-updated_at: "2026-04-19T01:53:14Z"
+updated_at: "2026-04-19T03:01:08Z"
 ---
 
 # Define the dependency contract for issue-backed stories

--- a/.plan/stories/define-the-issue-body-contract-and-metadata-block.md
+++ b/.plan/stories/define-the-issue-body-contract-and-metadata-block.md
@@ -1,0 +1,35 @@
+---
+created_at: "2026-04-19T01:53:14Z"
+epic: issue-contract-and-planning-link-lifecycle
+project: plan
+slug: define-the-issue-body-contract-and-metadata-block
+spec: issue-contract-and-planning-link-lifecycle
+status: todo
+title: Define the issue body contract and metadata block
+type: story
+updated_at: "2026-04-19T01:53:14Z"
+---
+
+# Define the issue body contract and metadata block
+
+Created: 2026-04-19T01:53:14Z
+
+## Description
+
+Define the `plan`-owned issue body sections and machine-readable metadata block so issue-backed stories stay readable to humans while still giving `plan` stable structure to parse and update.
+
+## Acceptance Criteria
+
+- [ ] The issue contract includes summary, acceptance criteria, verification, epic/spec links, blockers, and a stable metadata block.
+
+- [ ] The contract stays readable to humans and parseable enough for later reconcile and readiness logic.
+
+## Verification
+
+- Run issue contract rendering and parsing tests.
+
+## Resources
+
+- [Canonical Spec](../specs/issue-contract-and-planning-link-lifecycle.md)
+
+## Notes

--- a/.plan/stories/define-the-issue-body-contract-and-metadata-block.md
+++ b/.plan/stories/define-the-issue-body-contract-and-metadata-block.md
@@ -4,10 +4,10 @@ epic: issue-contract-and-planning-link-lifecycle
 project: plan
 slug: define-the-issue-body-contract-and-metadata-block
 spec: issue-contract-and-planning-link-lifecycle
-status: todo
+status: done
 title: Define the issue body contract and metadata block
 type: story
-updated_at: "2026-04-19T01:53:14Z"
+updated_at: "2026-04-19T02:55:44Z"
 ---
 
 # Define the issue body contract and metadata block

--- a/.plan/stories/enforce-issue-backed-story-storage-in-github-mode.md
+++ b/.plan/stories/enforce-issue-backed-story-storage-in-github-mode.md
@@ -4,10 +4,10 @@ epic: github-story-backend-and-preflight
 project: plan
 slug: enforce-issue-backed-story-storage-in-github-mode
 spec: github-story-backend-and-preflight
-status: todo
+status: done
 title: Enforce issue-backed story storage in GitHub mode
 type: story
-updated_at: "2026-04-19T01:53:14Z"
+updated_at: "2026-04-19T02:52:42Z"
 ---
 
 # Enforce issue-backed story storage in GitHub mode

--- a/.plan/stories/enforce-issue-backed-story-storage-in-github-mode.md
+++ b/.plan/stories/enforce-issue-backed-story-storage-in-github-mode.md
@@ -1,0 +1,35 @@
+---
+created_at: "2026-04-19T01:53:14Z"
+epic: github-story-backend-and-preflight
+project: plan
+slug: enforce-issue-backed-story-storage-in-github-mode
+spec: github-story-backend-and-preflight
+status: todo
+title: Enforce issue-backed story storage in GitHub mode
+type: story
+updated_at: "2026-04-19T01:53:14Z"
+---
+
+# Enforce issue-backed story storage in GitHub mode
+
+Created: 2026-04-19T01:53:14Z
+
+## Description
+
+Make GitHub mode treat GitHub Issues as story storage so story create, update, list, and show no longer create duplicate local markdown stories when the backend is set to `github`.
+
+## Acceptance Criteria
+
+- [ ] Story operations in GitHub mode avoid writing first-class `.plan/stories/` markdown notes and rely on issue-backed records plus minimal local metadata.
+
+- [ ] Local story mode remains unchanged for repos that do not enable GitHub execution.
+
+## Verification
+
+- Run story backend behavior tests for local and GitHub modes.
+
+## Resources
+
+- [Canonical Spec](../specs/github-story-backend-and-preflight.md)
+
+## Notes

--- a/.plan/stories/publish-planning-branch-doc-links-and-planning-pr-references.md
+++ b/.plan/stories/publish-planning-branch-doc-links-and-planning-pr-references.md
@@ -4,10 +4,10 @@ epic: issue-contract-and-planning-link-lifecycle
 project: plan
 slug: publish-planning-branch-doc-links-and-planning-pr-references
 spec: issue-contract-and-planning-link-lifecycle
-status: todo
+status: done
 title: Publish planning-branch doc links and planning PR references
 type: story
-updated_at: "2026-04-19T01:53:14Z"
+updated_at: "2026-04-19T02:55:44Z"
 ---
 
 # Publish planning-branch doc links and planning PR references

--- a/.plan/stories/publish-planning-branch-doc-links-and-planning-pr-references.md
+++ b/.plan/stories/publish-planning-branch-doc-links-and-planning-pr-references.md
@@ -1,0 +1,35 @@
+---
+created_at: "2026-04-19T01:53:14Z"
+epic: issue-contract-and-planning-link-lifecycle
+project: plan
+slug: publish-planning-branch-doc-links-and-planning-pr-references
+spec: issue-contract-and-planning-link-lifecycle
+status: todo
+title: Publish planning-branch doc links and planning PR references
+type: story
+updated_at: "2026-04-19T01:53:14Z"
+---
+
+# Publish planning-branch doc links and planning PR references
+
+Created: 2026-04-19T01:53:14Z
+
+## Description
+
+Teach issue publishing to include real commit-SHA permalinks to epic/spec docs plus the planning PR reference whenever issue-backed stories are created before the planning branch is merged.
+
+## Acceptance Criteria
+
+- [ ] Pre-merge issue publishing uses commit-SHA doc links instead of branch-name links.
+
+- [ ] The planning PR reference is visible in the issue contract when work is created from an unmerged planning branch.
+
+## Verification
+
+- Run planning-branch link publishing tests.
+
+## Resources
+
+- [Canonical Spec](../specs/issue-contract-and-planning-link-lifecycle.md)
+
+## Notes

--- a/.plan/stories/reconcile-issue-links-to-canonical-main-docs-after-merge.md
+++ b/.plan/stories/reconcile-issue-links-to-canonical-main-docs-after-merge.md
@@ -4,10 +4,10 @@ epic: issue-contract-and-planning-link-lifecycle
 project: plan
 slug: reconcile-issue-links-to-canonical-main-docs-after-merge
 spec: issue-contract-and-planning-link-lifecycle
-status: todo
+status: done
 title: Reconcile issue links to canonical main docs after merge
 type: story
-updated_at: "2026-04-19T01:53:14Z"
+updated_at: "2026-04-19T02:55:44Z"
 ---
 
 # Reconcile issue links to canonical main docs after merge

--- a/.plan/stories/reconcile-issue-links-to-canonical-main-docs-after-merge.md
+++ b/.plan/stories/reconcile-issue-links-to-canonical-main-docs-after-merge.md
@@ -1,0 +1,35 @@
+---
+created_at: "2026-04-19T01:53:14Z"
+epic: issue-contract-and-planning-link-lifecycle
+project: plan
+slug: reconcile-issue-links-to-canonical-main-docs-after-merge
+spec: issue-contract-and-planning-link-lifecycle
+status: todo
+title: Reconcile issue links to canonical main docs after merge
+type: story
+updated_at: "2026-04-19T01:53:14Z"
+---
+
+# Reconcile issue links to canonical main docs after merge
+
+Created: 2026-04-19T01:53:14Z
+
+## Description
+
+Add reconcile behavior that rewrites `plan`-owned issue sections from pre-merge SHA links to canonical `main` doc links once the planning PR lands.
+
+## Acceptance Criteria
+
+- [ ] Reconcile updates epic/spec links and planning-blocked markers inside `plan`-owned issue sections after merge.
+
+- [ ] Reconcile preserves user edits outside the `plan`-owned issue contract.
+
+## Verification
+
+- Run issue reconcile tests.
+
+## Resources
+
+- [Canonical Spec](../specs/issue-contract-and-planning-link-lifecycle.md)
+
+## Notes

--- a/.plan/stories/surface-async-safe-ready-work-in-cli-and-optional-github-visible-updates.md
+++ b/.plan/stories/surface-async-safe-ready-work-in-cli-and-optional-github-visible-updates.md
@@ -4,10 +4,10 @@ epic: dependency-aware-issue-readiness
 project: plan
 slug: surface-async-safe-ready-work-in-cli-and-optional-github-visible-updates
 spec: dependency-aware-issue-readiness
-status: todo
+status: done
 title: Surface async-safe ready work in CLI and optional GitHub-visible updates
 type: story
-updated_at: "2026-04-19T01:53:14Z"
+updated_at: "2026-04-19T03:01:09Z"
 ---
 
 # Surface async-safe ready work in CLI and optional GitHub-visible updates

--- a/.plan/stories/surface-async-safe-ready-work-in-cli-and-optional-github-visible-updates.md
+++ b/.plan/stories/surface-async-safe-ready-work-in-cli-and-optional-github-visible-updates.md
@@ -1,0 +1,35 @@
+---
+created_at: "2026-04-19T01:53:14Z"
+epic: dependency-aware-issue-readiness
+project: plan
+slug: surface-async-safe-ready-work-in-cli-and-optional-github-visible-updates
+spec: dependency-aware-issue-readiness
+status: todo
+title: Surface async-safe ready work in CLI and optional GitHub-visible updates
+type: story
+updated_at: "2026-04-19T01:53:14Z"
+---
+
+# Surface async-safe ready work in CLI and optional GitHub-visible updates
+
+Created: 2026-04-19T01:53:14Z
+
+## Description
+
+Surface multiple ready issues at once for async work and optionally reflect the same derived readiness into GitHub-visible markers without requiring a GitHub workflow.
+
+## Acceptance Criteria
+
+- [ ] CLI output can show more than one ready issue at a time when blockers do not overlap.
+
+- [ ] Optional GitHub-visible markers use the same derived readiness logic as the CLI instead of a separate automation path.
+
+## Verification
+
+- Run ready-work visibility tests.
+
+## Resources
+
+- [Canonical Spec](../specs/dependency-aware-issue-readiness.md)
+
+## Notes

--- a/cmd/github.go
+++ b/cmd/github.go
@@ -2,6 +2,9 @@ package cmd
 
 import (
 	"fmt"
+	"strings"
+
+	"plan/internal/planning"
 
 	"github.com/spf13/cobra"
 )
@@ -29,6 +32,33 @@ func newGitHubCommand() *cobra.Command {
 		},
 	}
 
-	cmd.AddCommand(enable)
+	var updateVisible bool
+	reconcile := &cobra.Command{
+		Use:   "reconcile",
+		Short: "Reconcile GitHub-backed stories after planning changes merge",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			result, err := planningManager().ReconcileGitHubStories(planning.GitHubReconcileOptions{
+				UpdateVisible: updateVisible,
+			})
+			if err != nil {
+				return err
+			}
+			out := cmd.OutOrStdout()
+			fmt.Fprintf(out, "repo: %s\n", result.Repo)
+			fmt.Fprintf(out, "branch: %s\n", result.CurrentBranch)
+			fmt.Fprintf(out, "default_branch: %s\n", result.DefaultBranch)
+			fmt.Fprintf(out, "updated_issues: %d\n", len(result.UpdatedIssues))
+			if len(result.ReadyStories) > 0 {
+				fmt.Fprintf(out, "ready_stories: %s\n", strings.Join(result.ReadyStories, ", "))
+			}
+			if len(result.BlockedStories) > 0 {
+				fmt.Fprintf(out, "blocked_stories: %s\n", strings.Join(result.BlockedStories, ", "))
+			}
+			return nil
+		},
+	}
+	reconcile.Flags().BoolVar(&updateVisible, "update-visible", false, "update optional GitHub-visible readiness markers while reconciling")
+
+	cmd.AddCommand(enable, reconcile)
 	return cmd
 }

--- a/cmd/github.go
+++ b/cmd/github.go
@@ -1,0 +1,34 @@
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+)
+
+func newGitHubCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "github",
+		Short: "Manage the GitHub story backend",
+	}
+
+	enable := &cobra.Command{
+		Use:   "enable",
+		Short: "Enable GitHub-backed stories for this repo",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			result, err := planningManager().EnableGitHubBackend()
+			if err != nil {
+				return err
+			}
+			out := cmd.OutOrStdout()
+			fmt.Fprintf(out, "github_backend: %s\n", result.Backend)
+			fmt.Fprintf(out, "repo: %s\n", result.Repo)
+			fmt.Fprintf(out, "default_branch: %s\n", result.DefaultBranch)
+			fmt.Fprintf(out, "state: %s\n", result.StatePath)
+			return nil
+		},
+	}
+
+	cmd.AddCommand(enable)
+	return cmd
+}

--- a/cmd/github_test.go
+++ b/cmd/github_test.go
@@ -1,0 +1,79 @@
+package cmd
+
+import (
+	"bytes"
+	"testing"
+
+	"plan/internal/planning"
+	"plan/internal/workspace"
+)
+
+type stubGitHubEnableClient struct {
+	preflight *planning.GitHubRepoInfo
+	err       error
+}
+
+func (s *stubGitHubEnableClient) Preflight(projectDir string) (*planning.GitHubRepoInfo, error) {
+	if s.err != nil {
+		return nil, s.err
+	}
+	return s.preflight, nil
+}
+
+func (s *stubGitHubEnableClient) CurrentContext(projectDir string) (*planning.GitHubContext, error) {
+	panic("unexpected CurrentContext call")
+}
+
+func (s *stubGitHubEnableClient) CreateIssue(projectDir, repo string, input planning.GitHubIssueInput) (*planning.GitHubIssue, error) {
+	panic("unexpected CreateIssue call")
+}
+
+func (s *stubGitHubEnableClient) UpdateIssue(projectDir, repo string, issueNumber int, input planning.GitHubIssueInput) (*planning.GitHubIssue, error) {
+	panic("unexpected UpdateIssue call")
+}
+
+func (s *stubGitHubEnableClient) GetIssue(projectDir, repo string, issueNumber int) (*planning.GitHubIssue, error) {
+	panic("unexpected GetIssue call")
+}
+
+func TestGitHubEnableCommandPrintsBackendSummary(t *testing.T) {
+	reset := planning.SetGitHubClientFactoryForTesting(func() planning.GitHubClient {
+		return &stubGitHubEnableClient{
+			preflight: &planning.GitHubRepoInfo{
+				Repo:          "JimmyMcBride/plan",
+				RepoURL:       "https://github.com/JimmyMcBride/plan",
+				DefaultBranch: "main",
+			},
+		}
+	})
+	t.Cleanup(reset)
+
+	root := t.TempDir()
+	ws := workspace.New(root)
+	if _, err := ws.Init(); err != nil {
+		t.Fatal(err)
+	}
+
+	var buf bytes.Buffer
+	command := newRootCmd()
+	command.SetOut(&buf)
+	command.SetErr(&buf)
+	command.SetArgs([]string{"--project", root, "github", "enable"})
+	if err := command.Execute(); err != nil {
+		t.Fatalf("expected github enable to succeed: %v\n%s", err, buf.String())
+	}
+
+	output := buf.String()
+	if !containsLine(output, "github_backend: github") || !containsLine(output, "repo: JimmyMcBride/plan") || !containsLine(output, "default_branch: main") {
+		t.Fatalf("unexpected github enable output:\n%s", output)
+	}
+}
+
+func containsLine(output, expected string) bool {
+	for _, line := range bytes.Split([]byte(output), []byte("\n")) {
+		if string(line) == expected {
+			return true
+		}
+	}
+	return false
+}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -27,6 +27,7 @@ func newRootCmd() *cobra.Command {
 		newStoryCommand(),
 		newRoadmapCommand(),
 		newStatusCommand(),
+		newGitHubCommand(),
 		newSkillsCommand(),
 	)
 	return root

--- a/cmd/status.go
+++ b/cmd/status.go
@@ -33,6 +33,16 @@ func printStatus(out io.Writer, status *planning.ProjectStatus) {
 		status.InProgressStories,
 		status.BlockedStories,
 	)
+	if status.ReadyStories > 0 {
+		fmt.Fprintf(out, "ready_work: %d\n", status.ReadyStories)
+		for _, story := range status.ReadyWork {
+			issueRef := ""
+			if story.IssueNumber > 0 {
+				issueRef = fmt.Sprintf(" issue=#%d", story.IssueNumber)
+			}
+			fmt.Fprintf(out, "  - %s%s epic=%s spec=%s\n", story.Title, issueRef, story.Epic, story.Spec)
+		}
+	}
 	if len(status.Epics) == 0 {
 		fmt.Fprintln(out, "epics: none")
 		return

--- a/cmd/status_test.go
+++ b/cmd/status_test.go
@@ -57,3 +57,63 @@ func TestStatusCommandPrintsSimpleEpicProgressCounts(t *testing.T) {
 		t.Fatalf("expected epic progress counts in output:\n%s", output)
 	}
 }
+
+func TestStatusCommandShowsMultipleReadyGitHubStories(t *testing.T) {
+	client := &stubGitHubStoryClient{
+		preflight: &planning.GitHubRepoInfo{
+			Repo:          "JimmyMcBride/plan",
+			RepoURL:       "https://github.com/JimmyMcBride/plan",
+			DefaultBranch: "main",
+		},
+		context: &planning.GitHubContext{
+			Repo: planning.GitHubRepoInfo{
+				Repo:          "JimmyMcBride/plan",
+				RepoURL:       "https://github.com/JimmyMcBride/plan",
+				DefaultBranch: "main",
+			},
+			CurrentBranch: "main",
+			CurrentSHA:    "abc123def456",
+		},
+	}
+	reset := planning.SetGitHubClientFactoryForTesting(func() planning.GitHubClient { return client })
+	t.Cleanup(reset)
+
+	root := t.TempDir()
+	ws := workspace.New(root)
+	if _, err := ws.Init(); err != nil {
+		t.Fatal(err)
+	}
+	manager := planning.New(ws)
+	if _, err := manager.CreateEpic("Billing", ""); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := manager.SetSpecStatus("billing", "approved"); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := manager.EnableGitHubBackend(); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := manager.CreateStory("billing", "Seed billing data", "Seed data first", []string{"Seed data"}, []string{"Run seed checks"}, nil); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := manager.CreateStory("billing", "Ship exports", "Parallel story", []string{"Ship exports"}, []string{"Run export tests"}, nil); err != nil {
+		t.Fatal(err)
+	}
+
+	var buf bytes.Buffer
+	command := newRootCmd()
+	command.SetOut(&buf)
+	command.SetErr(&buf)
+	command.SetArgs([]string{"--project", root, "status"})
+	if err := command.Execute(); err != nil {
+		t.Fatal(err)
+	}
+
+	output := buf.String()
+	if !strings.Contains(output, "ready_work: 2") {
+		t.Fatalf("expected ready-work summary in output:\n%s", output)
+	}
+	if !strings.Contains(output, "Seed billing data issue=#101 epic=billing spec=billing") || !strings.Contains(output, "Ship exports issue=#102 epic=billing spec=billing") {
+		t.Fatalf("expected multiple ready GitHub stories in output:\n%s", output)
+	}
+}

--- a/cmd/story.go
+++ b/cmd/story.go
@@ -21,6 +21,7 @@ func newStoryCommand() *cobra.Command {
 	var criteria []string
 	var verification []string
 	var resources []string
+	var blockers []string
 	create := &cobra.Command{
 		Use:   "create <epic-slug> <title>",
 		Short: "Create a story from an approved spec",
@@ -30,6 +31,18 @@ func newStoryCommand() *cobra.Command {
 			if err != nil {
 				return err
 			}
+			if len(blockers) > 0 {
+				slug, _ := note.Metadata["slug"].(string)
+				if slug == "" {
+					return fmt.Errorf("created story is missing slug metadata")
+				}
+				note, err = planningManager().UpdateStory(slug, planning.StoryChanges{
+					SetBlockers: blockers,
+				})
+				if err != nil {
+					return err
+				}
+			}
 			fmt.Fprintf(cmd.OutOrStdout(), "Created story %s\n", note.Path)
 			return nil
 		},
@@ -38,11 +51,13 @@ func newStoryCommand() *cobra.Command {
 	create.Flags().StringArrayVar(&criteria, "criteria", nil, "acceptance criterion; repeatable")
 	create.Flags().StringArrayVar(&verification, "verify", nil, "verification step; repeatable")
 	create.Flags().StringArrayVar(&resources, "resource", nil, "resource entry; repeatable")
+	create.Flags().StringArrayVar(&blockers, "blocker", nil, "story slug this story depends on; repeatable")
 
 	var status string
 	var addCriteria []string
 	var addVerification []string
 	var addResources []string
+	var setBlockers []string
 	update := &cobra.Command{
 		Use:   "update <story-slug>",
 		Short: "Update a story",
@@ -53,6 +68,7 @@ func newStoryCommand() *cobra.Command {
 				AddCriteria:     addCriteria,
 				AddVerification: addVerification,
 				AddResources:    addResources,
+				SetBlockers:     setBlockers,
 			})
 			if err != nil {
 				return err
@@ -65,6 +81,7 @@ func newStoryCommand() *cobra.Command {
 	update.Flags().StringArrayVar(&addCriteria, "criteria", nil, "acceptance criterion to append; repeatable")
 	update.Flags().StringArrayVar(&addVerification, "verify", nil, "verification step to append; repeatable")
 	update.Flags().StringArrayVar(&addResources, "resource", nil, "resource entry to append; repeatable")
+	update.Flags().StringArrayVar(&setBlockers, "blocker", nil, "story slug this story depends on; repeatable")
 
 	var epicFilter string
 	var statusFilter string

--- a/cmd/story_github_test.go
+++ b/cmd/story_github_test.go
@@ -1,0 +1,196 @@
+package cmd
+
+import (
+	"bytes"
+	"fmt"
+	"strings"
+	"testing"
+
+	"plan/internal/notes"
+	"plan/internal/planning"
+	"plan/internal/workspace"
+)
+
+type stubGitHubStoryClient struct {
+	preflight  *planning.GitHubRepoInfo
+	context    *planning.GitHubContext
+	issues     map[int]*planning.GitHubIssue
+	nextIssue  int
+}
+
+func (s *stubGitHubStoryClient) Preflight(projectDir string) (*planning.GitHubRepoInfo, error) {
+	return s.preflight, nil
+}
+
+func (s *stubGitHubStoryClient) CurrentContext(projectDir string) (*planning.GitHubContext, error) {
+	return s.context, nil
+}
+
+func (s *stubGitHubStoryClient) CreateIssue(projectDir, repo string, input planning.GitHubIssueInput) (*planning.GitHubIssue, error) {
+	if s.issues == nil {
+		s.issues = map[int]*planning.GitHubIssue{}
+	}
+	if s.nextIssue == 0 {
+		s.nextIssue = 101
+	}
+	issue := &planning.GitHubIssue{
+		Number: s.nextIssue,
+		URL:    fmt.Sprintf("https://github.com/%s/issues/%d", repo, s.nextIssue),
+		Title:  input.Title,
+		Body:   input.Body,
+		State:  "open",
+	}
+	s.issues[issue.Number] = issue
+	s.nextIssue++
+	return issue, nil
+}
+
+func (s *stubGitHubStoryClient) UpdateIssue(projectDir, repo string, issueNumber int, input planning.GitHubIssueInput) (*planning.GitHubIssue, error) {
+	issue := s.issues[issueNumber]
+	issue.Title = input.Title
+	issue.Body = input.Body
+	if strings.TrimSpace(input.State) != "" {
+		issue.State = input.State
+	}
+	return issue, nil
+}
+
+func (s *stubGitHubStoryClient) GetIssue(projectDir, repo string, issueNumber int) (*planning.GitHubIssue, error) {
+	copy := *s.issues[issueNumber]
+	return &copy, nil
+}
+
+func TestStoryCommandsSupportGitHubBackedStories(t *testing.T) {
+	client := &stubGitHubStoryClient{
+		preflight: &planning.GitHubRepoInfo{
+			Repo:          "JimmyMcBride/plan",
+			RepoURL:       "https://github.com/JimmyMcBride/plan",
+			DefaultBranch: "main",
+		},
+		context: &planning.GitHubContext{
+			Repo: planning.GitHubRepoInfo{
+				Repo:          "JimmyMcBride/plan",
+				RepoURL:       "https://github.com/JimmyMcBride/plan",
+				DefaultBranch: "main",
+			},
+			CurrentBranch: "main",
+			CurrentSHA:    "abc123def456",
+		},
+	}
+	reset := planning.SetGitHubClientFactoryForTesting(func() planning.GitHubClient { return client })
+	t.Cleanup(reset)
+
+	root := t.TempDir()
+	ws := workspace.New(root)
+	if _, err := ws.Init(); err != nil {
+		t.Fatal(err)
+	}
+	manager := planning.New(ws)
+	if _, err := manager.CreateEpic("Billing", ""); err != nil {
+		t.Fatal(err)
+	}
+	specBody := strings.Join([]string{
+		"# Billing Spec",
+		"",
+		"Created: now",
+		"",
+		"## Why",
+		"",
+		"Billing work needs GitHub-backed execution.",
+		"",
+		"## Problem",
+		"",
+		"Stories should live in GitHub issues.",
+		"",
+		"## Goals",
+		"",
+		"- create issue-backed stories",
+		"",
+		"## Non-Goals",
+		"",
+		"- tracker parity",
+		"",
+		"## Constraints",
+		"",
+		"- keep epics and specs local",
+		"",
+		"## Solution Shape",
+		"",
+		"Store execution work in GitHub issues.",
+		"",
+		"## Flows",
+		"",
+		"1. Enable GitHub mode.",
+		"2. Create issue-backed stories.",
+		"",
+		"## Data / Interfaces",
+		"",
+		"- GitHub issue body contract",
+		"",
+		"## Risks / Open Questions",
+		"",
+		"- none",
+		"",
+		"## Rollout",
+		"",
+		"- dogfood locally",
+		"",
+		"## Verification",
+		"",
+		"- run GitHub story command tests",
+		"",
+	}, "\n")
+	if _, err := manager.UpdateSpec("billing", notes.UpdateInput{
+		Body: &specBody,
+		Metadata: map[string]any{"status": "approved"},
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	command := newRootCmd()
+	command.SetArgs([]string{"--project", root, "github", "enable"})
+	if err := command.Execute(); err != nil {
+		t.Fatal(err)
+	}
+
+	var createOut bytes.Buffer
+	command = newRootCmd()
+	command.SetOut(&createOut)
+	command.SetErr(&createOut)
+	command.SetArgs([]string{
+		"--project", root, "story", "create", "billing", "Implement invoices",
+		"--body", "Create invoice generation flow",
+		"--criteria", "Generate invoices from line items",
+		"--verify", "Run focused billing tests",
+	})
+	if err := command.Execute(); err != nil {
+		t.Fatalf("expected GitHub story create to succeed: %v\n%s", err, createOut.String())
+	}
+	if !strings.Contains(createOut.String(), "Created story https://github.com/JimmyMcBride/plan/issues/101") {
+		t.Fatalf("unexpected GitHub story create output:\n%s", createOut.String())
+	}
+
+	var listOut bytes.Buffer
+	command = newRootCmd()
+	command.SetOut(&listOut)
+	command.SetErr(&listOut)
+	command.SetArgs([]string{"--project", root, "story", "list"})
+	if err := command.Execute(); err != nil {
+		t.Fatalf("expected GitHub story list to succeed: %v\n%s", err, listOut.String())
+	}
+	if !strings.Contains(listOut.String(), "Implement invoices [todo] epic=billing spec=billing") {
+		t.Fatalf("unexpected GitHub story list output:\n%s", listOut.String())
+	}
+
+	var showOut bytes.Buffer
+	command = newRootCmd()
+	command.SetOut(&showOut)
+	command.SetErr(&showOut)
+	command.SetArgs([]string{"--project", root, "story", "show", "implement-invoices"})
+	if err := command.Execute(); err != nil {
+		t.Fatalf("expected GitHub story show to succeed: %v\n%s", err, showOut.String())
+	}
+	if !strings.Contains(showOut.String(), "https://github.com/JimmyMcBride/plan/issues/101") || !strings.Contains(showOut.String(), "## Dependencies") {
+		t.Fatalf("unexpected GitHub story show output:\n%s", showOut.String())
+	}
+}

--- a/internal/planning/check.go
+++ b/internal/planning/check.go
@@ -110,7 +110,7 @@ func (m *Manager) specNotesForCheck(info *workspace.Info, input CheckInput) ([]*
 func (m *Manager) storyNotesForCheck(info *workspace.Info, input CheckInput) ([]*notes.Note, error) {
 	switch {
 	case strings.TrimSpace(input.StorySlug) != "":
-		story, err := notes.Read(filepath.Join(info.StoriesDir, slugify(input.StorySlug)+".md"))
+		story, err := m.ReadStory(input.StorySlug)
 		if err != nil {
 			return nil, err
 		}
@@ -136,7 +136,7 @@ func (m *Manager) readStoriesByFilter(info *workspace.Info, keep func(StoryInfo)
 		if !keep(story) {
 			continue
 		}
-		note, err := notes.Read(filepath.Join(info.ProjectDir, filepath.FromSlash(story.Path)))
+		note, err := m.ReadStory(story.Slug)
 		if err != nil {
 			return nil, err
 		}
@@ -364,10 +364,8 @@ func checkSpecStoryReadiness(info *workspace.Info, spec *notes.Note, stories []S
 		})
 	}
 
-	knownStorySlugs := map[string]struct{}{}
 	anyStarted := false
 	for _, story := range childStories {
-		knownStorySlugs[slugFromPath(story.Path)] = struct{}{}
 		if story.Status == "in_progress" || story.Status == "blocked" || story.Status == "done" {
 			anyStarted = true
 		}
@@ -392,6 +390,9 @@ func checkSpecStoryReadiness(info *workspace.Info, spec *notes.Note, stories []S
 		if candidate.LinkTarget == "" {
 			continue
 		}
+		if strings.HasPrefix(candidate.LinkTarget, "http://") || strings.HasPrefix(candidate.LinkTarget, "https://") {
+			continue
+		}
 		linkedPath := filepath.Clean(filepath.Join(filepath.Dir(spec.Path), filepath.FromSlash(candidate.LinkTarget)))
 		if _, err := os.Stat(linkedPath); err != nil {
 			findings = append(findings, CheckFinding{
@@ -407,7 +408,7 @@ func checkSpecStoryReadiness(info *workspace.Info, spec *notes.Note, stories []S
 		}
 	}
 	for _, story := range childStories {
-		if _, ok := expectedSlugs[slugFromPath(story.Path)]; ok {
+		if _, ok := expectedSlugs[story.Slug]; ok {
 			continue
 		}
 		findings = append(findings, CheckFinding{

--- a/internal/planning/check_test.go
+++ b/internal/planning/check_test.go
@@ -240,3 +240,51 @@ func assertHasFinding(t *testing.T, findings []CheckFinding, rule, section strin
 	}
 	t.Fatalf("expected finding %s for %s: %+v", rule, section, findings)
 }
+
+func TestCheckStorySupportsGitHubBackedStories(t *testing.T) {
+	client := &stubGitHubClient{
+		preflight: &GitHubRepoInfo{
+			Repo:          "JimmyMcBride/plan",
+			RepoURL:       "https://github.com/JimmyMcBride/plan",
+			DefaultBranch: "main",
+		},
+		context: &GitHubContext{
+			Repo: GitHubRepoInfo{
+				Repo:          "JimmyMcBride/plan",
+				RepoURL:       "https://github.com/JimmyMcBride/plan",
+				DefaultBranch: "main",
+			},
+			CurrentBranch: "main",
+			CurrentSHA:    "abc123def456",
+		},
+	}
+	reset := SetGitHubClientFactoryForTesting(func() GitHubClient { return client })
+	t.Cleanup(reset)
+
+	root := t.TempDir()
+	ws := workspace.New(root)
+	if _, err := ws.Init(); err != nil {
+		t.Fatal(err)
+	}
+	manager := New(ws)
+	if _, err := manager.EnableGitHubBackend(); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := manager.CreateEpic("Billing", ""); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := manager.SetSpecStatus("billing", "approved"); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := manager.CreateStory("billing", "Implement invoices", "Create invoice generation flow", []string{"Generate invoices from line items"}, []string{"Run focused billing tests"}, nil); err != nil {
+		t.Fatal(err)
+	}
+
+	report, err := manager.Check(CheckInput{StorySlug: "implement-invoices"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if report.HasErrors() {
+		t.Fatalf("expected GitHub-backed story check to pass: %+v", report.Findings)
+	}
+}

--- a/internal/planning/github_backend.go
+++ b/internal/planning/github_backend.go
@@ -1,0 +1,95 @@
+package planning
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"plan/internal/workspace"
+)
+
+type GitHubEnableResult struct {
+	Backend       string
+	Repo          string
+	RepoURL       string
+	DefaultBranch string
+	StatePath     string
+}
+
+func (m *Manager) StoryBackend() (workspace.StoryBackend, error) {
+	meta, err := m.workspace.ReadWorkspaceMeta()
+	if err != nil {
+		return "", err
+	}
+	if meta.StoryBackend == "" {
+		return workspace.StoryBackendLocal, nil
+	}
+	return meta.StoryBackend, nil
+}
+
+func (m *Manager) EnableGitHubBackend() (*GitHubEnableResult, error) {
+	info, err := m.workspace.EnsureInitialized()
+	if err != nil {
+		return nil, err
+	}
+	if hasLocalStoryNotes(info.StoriesDir) {
+		return nil, fmt.Errorf("cannot enable GitHub story mode while local story notes still exist under %s; keep local mode or migrate those stories first", rel(info.ProjectDir, info.StoriesDir))
+	}
+
+	repo, err := m.github.Preflight(info.ProjectDir)
+	if err != nil {
+		return nil, err
+	}
+	meta, err := m.workspace.ReadWorkspaceMeta()
+	if err != nil {
+		return nil, err
+	}
+	meta.StoryBackend = workspace.StoryBackendGitHub
+	meta.UpdatedAt = time.Now().UTC().Format(time.RFC3339)
+	if err := m.workspace.WriteWorkspaceMeta(*meta); err != nil {
+		return nil, err
+	}
+
+	state, err := m.workspace.ReadGitHubState()
+	if err != nil {
+		return nil, err
+	}
+	now := time.Now().UTC().Format(time.RFC3339)
+	state.Repo = repo.Repo
+	state.RepoURL = repo.RepoURL
+	state.DefaultBranch = repo.DefaultBranch
+	state.LastEnabledAt = now
+	state.LastUpdatedAt = now
+	if state.Stories == nil {
+		state.Stories = map[string]workspace.GitHubStoryRecord{}
+	}
+	if err := m.workspace.WriteGitHubState(*state); err != nil {
+		return nil, err
+	}
+
+	return &GitHubEnableResult{
+		Backend:       string(workspace.StoryBackendGitHub),
+		Repo:          repo.Repo,
+		RepoURL:       repo.RepoURL,
+		DefaultBranch: repo.DefaultBranch,
+		StatePath:     rel(info.ProjectDir, info.GitHubFile),
+	}, nil
+}
+
+func hasLocalStoryNotes(storiesDir string) bool {
+	entries, err := os.ReadDir(storiesDir)
+	if err != nil {
+		return false
+	}
+	for _, entry := range entries {
+		if entry.IsDir() {
+			continue
+		}
+		if strings.EqualFold(filepath.Ext(entry.Name()), ".md") {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/planning/github_backend_test.go
+++ b/internal/planning/github_backend_test.go
@@ -335,3 +335,243 @@ func TestUpdateStoryMutatesIssueBackedRecordWithoutLocalMarkdown(t *testing.T) {
 		t.Fatalf("expected dependency contract in updated issue body:\n%s", client.lastUpdate.Body)
 	}
 }
+
+func TestGitHubIssueContractIncludesMetadataAndPlanningSections(t *testing.T) {
+	client := &stubGitHubClient{
+		preflight: &GitHubRepoInfo{
+			Repo:          "JimmyMcBride/plan",
+			RepoURL:       "https://github.com/JimmyMcBride/plan",
+			DefaultBranch: "main",
+		},
+		context: &GitHubContext{
+			Repo: GitHubRepoInfo{
+				Repo:          "JimmyMcBride/plan",
+				RepoURL:       "https://github.com/JimmyMcBride/plan",
+				DefaultBranch: "main",
+			},
+			CurrentBranch: "main",
+			CurrentSHA:    "abc123def456",
+		},
+	}
+	reset := SetGitHubClientFactoryForTesting(func() GitHubClient { return client })
+	t.Cleanup(reset)
+
+	root := t.TempDir()
+	manager := newGitHubStoryManager(t, root)
+	if _, err := manager.EnableGitHubBackend(); err != nil {
+		t.Fatal(err)
+	}
+	seedApprovedGitHubEpic(t, manager)
+	if _, err := manager.CreateStory(
+		"billing",
+		"Implement invoices",
+		"Create invoice generation flow",
+		[]string{"Generate invoices from line items"},
+		[]string{"Run focused billing tests"},
+		nil,
+	); err != nil {
+		t.Fatal(err)
+	}
+
+	body := client.lastCreate.Body
+	if !strings.Contains(body, planIssueBlockStart) || !strings.Contains(body, "## Planning Links") || !strings.Contains(body, "## Dependencies") {
+		t.Fatalf("expected plan-managed issue sections:\n%s", body)
+	}
+	meta := parseGitHubStoryMetadata(body)
+	if meta["slug"] != "implement-invoices" || meta["epic"] != "billing" || meta["spec"] != "billing" {
+		t.Fatalf("unexpected issue metadata block: %+v\n%s", meta, body)
+	}
+}
+
+func TestCreateGitHubStoryUsesShaLinksAndPlanningPRBeforeMerge(t *testing.T) {
+	client := &stubGitHubClient{
+		preflight: &GitHubRepoInfo{
+			Repo:          "JimmyMcBride/plan",
+			RepoURL:       "https://github.com/JimmyMcBride/plan",
+			DefaultBranch: "main",
+		},
+		context: &GitHubContext{
+			Repo: GitHubRepoInfo{
+				Repo:          "JimmyMcBride/plan",
+				RepoURL:       "https://github.com/JimmyMcBride/plan",
+				DefaultBranch: "main",
+			},
+			CurrentBranch: "feat/planning-branch",
+			CurrentSHA:    "abc123def456",
+			PlanningPR: &GitHubPullRequest{
+				Number:   42,
+				URL:      "https://github.com/JimmyMcBride/plan/pull/42",
+				State:    "OPEN",
+				HeadRef:  "feat/planning-branch",
+				BaseRef:  "main",
+				IsMerged: false,
+			},
+		},
+	}
+	reset := SetGitHubClientFactoryForTesting(func() GitHubClient { return client })
+	t.Cleanup(reset)
+
+	root := t.TempDir()
+	manager := newGitHubStoryManager(t, root)
+	if _, err := manager.EnableGitHubBackend(); err != nil {
+		t.Fatal(err)
+	}
+	seedApprovedGitHubEpic(t, manager)
+	if _, err := manager.CreateStory(
+		"billing",
+		"Implement invoices",
+		"Create invoice generation flow",
+		[]string{"Generate invoices from line items"},
+		[]string{"Run focused billing tests"},
+		nil,
+	); err != nil {
+		t.Fatal(err)
+	}
+
+	body := client.lastCreate.Body
+	if !strings.Contains(body, "/blob/abc123def456/.plan/specs/billing.md") {
+		t.Fatalf("expected SHA permalink in pre-merge issue body:\n%s", body)
+	}
+	if strings.Contains(body, "/blob/feat/planning-branch/") {
+		t.Fatalf("expected branch-name links to stay out of issue body:\n%s", body)
+	}
+	if !strings.Contains(body, "Planning PR: [#42](https://github.com/JimmyMcBride/plan/pull/42)") {
+		t.Fatalf("expected planning PR link in issue body:\n%s", body)
+	}
+}
+
+func TestCreateGitHubStoryRequiresPlanningPROffDefaultBranch(t *testing.T) {
+	client := &stubGitHubClient{
+		preflight: &GitHubRepoInfo{
+			Repo:          "JimmyMcBride/plan",
+			RepoURL:       "https://github.com/JimmyMcBride/plan",
+			DefaultBranch: "main",
+		},
+		context: &GitHubContext{
+			Repo: GitHubRepoInfo{
+				Repo:          "JimmyMcBride/plan",
+				RepoURL:       "https://github.com/JimmyMcBride/plan",
+				DefaultBranch: "main",
+			},
+			CurrentBranch: "feat/planning-branch",
+			CurrentSHA:    "abc123def456",
+		},
+	}
+	reset := SetGitHubClientFactoryForTesting(func() GitHubClient { return client })
+	t.Cleanup(reset)
+
+	root := t.TempDir()
+	manager := newGitHubStoryManager(t, root)
+	if _, err := manager.EnableGitHubBackend(); err != nil {
+		t.Fatal(err)
+	}
+	seedApprovedGitHubEpic(t, manager)
+	if _, err := manager.CreateStory(
+		"billing",
+		"Implement invoices",
+		"Create invoice generation flow",
+		[]string{"Generate invoices from line items"},
+		[]string{"Run focused billing tests"},
+		nil,
+	); err == nil {
+		t.Fatal("expected planning branch without PR to be rejected")
+	} else if !strings.Contains(err.Error(), "has no planning PR") {
+		t.Fatalf("unexpected planning-branch error: %v", err)
+	}
+}
+
+func TestReconcileGitHubStoriesPromotesMainLinksAndPreservesUserText(t *testing.T) {
+	client := &stubGitHubClient{
+		preflight: &GitHubRepoInfo{
+			Repo:          "JimmyMcBride/plan",
+			RepoURL:       "https://github.com/JimmyMcBride/plan",
+			DefaultBranch: "main",
+		},
+		context: &GitHubContext{
+			Repo: GitHubRepoInfo{
+				Repo:          "JimmyMcBride/plan",
+				RepoURL:       "https://github.com/JimmyMcBride/plan",
+				DefaultBranch: "main",
+			},
+			CurrentBranch: "feat/planning-branch",
+			CurrentSHA:    "abc123def456",
+			PlanningPR: &GitHubPullRequest{
+				Number:   42,
+				URL:      "https://github.com/JimmyMcBride/plan/pull/42",
+				State:    "OPEN",
+				HeadRef:  "feat/planning-branch",
+				BaseRef:  "main",
+				IsMerged: false,
+			},
+		},
+	}
+	reset := SetGitHubClientFactoryForTesting(func() GitHubClient { return client })
+	t.Cleanup(reset)
+
+	root := t.TempDir()
+	manager := newGitHubStoryManager(t, root)
+	if _, err := manager.EnableGitHubBackend(); err != nil {
+		t.Fatal(err)
+	}
+	seedApprovedGitHubEpic(t, manager)
+	if _, err := manager.CreateStory(
+		"billing",
+		"Implement invoices",
+		"Create invoice generation flow",
+		[]string{"Generate invoices from line items"},
+		[]string{"Run focused billing tests"},
+		nil,
+	); err != nil {
+		t.Fatal(err)
+	}
+
+	client.issues[101].Body += "\n\nUser note outside managed block.\n"
+	client.context.CurrentBranch = "main"
+	client.context.PlanningPR = nil
+
+	result, err := manager.ReconcileGitHubStories(GitHubReconcileOptions{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(result.UpdatedIssues) != 1 {
+		t.Fatalf("expected one reconciled issue: %+v", result)
+	}
+	issue := client.issues[101]
+	if !strings.Contains(issue.Body, "/blob/main/.plan/specs/billing.md") {
+		t.Fatalf("expected canonical main link after reconcile:\n%s", issue.Body)
+	}
+	if strings.Contains(issue.Body, "/blob/abc123def456/") {
+		t.Fatalf("expected SHA links to be removed after reconcile:\n%s", issue.Body)
+	}
+	if !strings.Contains(issue.Body, "User note outside managed block.") {
+		t.Fatalf("expected user text outside managed block to survive reconcile:\n%s", issue.Body)
+	}
+
+	state, err := manager.workspace.ReadGitHubState()
+	if err != nil {
+		t.Fatal(err)
+	}
+	record := state.Stories["implement-invoices"]
+	if !record.PlanningPRMerged || record.DocRefMode != "main" || record.DocRef != "main" {
+		t.Fatalf("expected record to reconcile to default branch links: %+v", record)
+	}
+}
+
+func newGitHubStoryManager(t *testing.T, root string) *Manager {
+	t.Helper()
+	ws := workspace.New(root)
+	if _, err := ws.Init(); err != nil {
+		t.Fatal(err)
+	}
+	return New(ws)
+}
+
+func seedApprovedGitHubEpic(t *testing.T, manager *Manager) {
+	t.Helper()
+	if _, err := manager.CreateEpic("Billing", ""); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := manager.SetSpecStatus("billing", "approved"); err != nil {
+		t.Fatal(err)
+	}
+}

--- a/internal/planning/github_backend_test.go
+++ b/internal/planning/github_backend_test.go
@@ -1,0 +1,135 @@
+package planning
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"plan/internal/workspace"
+)
+
+type stubGitHubClient struct {
+	preflight    *GitHubRepoInfo
+	preflightErr error
+}
+
+func (s *stubGitHubClient) Preflight(projectDir string) (*GitHubRepoInfo, error) {
+	if s.preflightErr != nil {
+		return nil, s.preflightErr
+	}
+	return s.preflight, nil
+}
+
+func (s *stubGitHubClient) CurrentContext(projectDir string) (*GitHubContext, error) {
+	panic("unexpected CurrentContext call")
+}
+
+func (s *stubGitHubClient) CreateIssue(projectDir, repo string, input GitHubIssueInput) (*GitHubIssue, error) {
+	panic("unexpected CreateIssue call")
+}
+
+func (s *stubGitHubClient) UpdateIssue(projectDir, repo string, issueNumber int, input GitHubIssueInput) (*GitHubIssue, error) {
+	panic("unexpected UpdateIssue call")
+}
+
+func (s *stubGitHubClient) GetIssue(projectDir, repo string, issueNumber int) (*GitHubIssue, error) {
+	panic("unexpected GetIssue call")
+}
+
+func TestEnableGitHubBackendPersistsRepoConfigAfterPreflight(t *testing.T) {
+	reset := SetGitHubClientFactoryForTesting(func() GitHubClient {
+		return &stubGitHubClient{
+			preflight: &GitHubRepoInfo{
+				Repo:          "JimmyMcBride/plan",
+				RepoURL:       "https://github.com/JimmyMcBride/plan",
+				DefaultBranch: "main",
+			},
+		}
+	})
+	t.Cleanup(reset)
+
+	root := t.TempDir()
+	ws := workspace.New(root)
+	if _, err := ws.Init(); err != nil {
+		t.Fatal(err)
+	}
+	manager := New(ws)
+
+	result, err := manager.EnableGitHubBackend()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.Backend != "github" || result.Repo != "JimmyMcBride/plan" || result.DefaultBranch != "main" {
+		t.Fatalf("unexpected enable result: %+v", result)
+	}
+
+	meta, err := ws.ReadWorkspaceMeta()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if meta.StoryBackend != workspace.StoryBackendGitHub {
+		t.Fatalf("expected GitHub story backend: %+v", meta)
+	}
+
+	state, err := ws.ReadGitHubState()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if state.Repo != "JimmyMcBride/plan" || state.DefaultBranch != "main" {
+		t.Fatalf("unexpected github state: %+v", state)
+	}
+	if state.LastEnabledAt == "" || state.LastUpdatedAt == "" {
+		t.Fatalf("expected github state timestamps: %+v", state)
+	}
+}
+
+func TestEnableGitHubBackendFailsWhenLocalStoriesAlreadyExist(t *testing.T) {
+	reset := SetGitHubClientFactoryForTesting(func() GitHubClient {
+		return &stubGitHubClient{
+			preflight: &GitHubRepoInfo{
+				Repo:          "JimmyMcBride/plan",
+				RepoURL:       "https://github.com/JimmyMcBride/plan",
+				DefaultBranch: "main",
+			},
+		}
+	})
+	t.Cleanup(reset)
+
+	root := t.TempDir()
+	ws := workspace.New(root)
+	if _, err := ws.Init(); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(root, ".plan", "stories", "existing.md"), []byte("# Existing\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	manager := New(ws)
+	if _, err := manager.EnableGitHubBackend(); err == nil {
+		t.Fatal("expected local stories to block GitHub enablement")
+	} else if !strings.Contains(err.Error(), "local story notes still exist") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestEnableGitHubBackendPropagatesPreflightFailures(t *testing.T) {
+	reset := SetGitHubClientFactoryForTesting(func() GitHubClient {
+		return &stubGitHubClient{preflightErr: errors.New("gh auth status failed; run `gh auth login` before enabling GitHub mode")}
+	})
+	t.Cleanup(reset)
+
+	root := t.TempDir()
+	ws := workspace.New(root)
+	if _, err := ws.Init(); err != nil {
+		t.Fatal(err)
+	}
+
+	manager := New(ws)
+	if _, err := manager.EnableGitHubBackend(); err == nil {
+		t.Fatal("expected preflight error")
+	} else if !strings.Contains(err.Error(), "gh auth status failed") {
+		t.Fatalf("unexpected preflight error: %v", err)
+	}
+}

--- a/internal/planning/github_backend_test.go
+++ b/internal/planning/github_backend_test.go
@@ -557,6 +557,122 @@ func TestReconcileGitHubStoriesPromotesMainLinksAndPreservesUserText(t *testing.
 	}
 }
 
+func TestGitHubStoryReadinessDerivesFromDependencies(t *testing.T) {
+	client := &stubGitHubClient{
+		preflight: &GitHubRepoInfo{
+			Repo:          "JimmyMcBride/plan",
+			RepoURL:       "https://github.com/JimmyMcBride/plan",
+			DefaultBranch: "main",
+		},
+		context: &GitHubContext{
+			Repo: GitHubRepoInfo{
+				Repo:          "JimmyMcBride/plan",
+				RepoURL:       "https://github.com/JimmyMcBride/plan",
+				DefaultBranch: "main",
+			},
+			CurrentBranch: "main",
+			CurrentSHA:    "abc123def456",
+		},
+	}
+	reset := SetGitHubClientFactoryForTesting(func() GitHubClient { return client })
+	t.Cleanup(reset)
+
+	root := t.TempDir()
+	manager := newGitHubStoryManager(t, root)
+	if _, err := manager.EnableGitHubBackend(); err != nil {
+		t.Fatal(err)
+	}
+	seedApprovedGitHubEpic(t, manager)
+	if _, err := manager.CreateStory("billing", "Seed billing data", "Seed data first", []string{"Seed data"}, []string{"Run seed checks"}, nil); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := manager.CreateStory("billing", "Implement invoices", "Create invoice generation flow", []string{"Generate invoices"}, []string{"Run billing tests"}, nil); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := manager.UpdateStory("implement-invoices", StoryChanges{SetBlockers: []string{"seed-billing-data"}}); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := manager.CreateStory("billing", "Ship exports", "Parallel story", []string{"Ship exports"}, []string{"Run export tests"}, nil); err != nil {
+		t.Fatal(err)
+	}
+
+	stories, err := manager.ListStories("", "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	bySlug := map[string]StoryInfo{}
+	for _, story := range stories {
+		bySlug[story.Slug] = story
+	}
+	if !bySlug["seed-billing-data"].Ready || !bySlug["ship-exports"].Ready {
+		t.Fatalf("expected independent stories to be ready: %+v", stories)
+	}
+	if bySlug["implement-invoices"].Status != "blocked" || !bySlug["implement-invoices"].BlockedByDeps {
+		t.Fatalf("expected dependent story to stay blocked: %+v", bySlug["implement-invoices"])
+	}
+
+	if _, err := manager.UpdateStory("seed-billing-data", StoryChanges{Status: "done"}); err != nil {
+		t.Fatal(err)
+	}
+	stories, err = manager.ListStories("", "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, story := range stories {
+		bySlug[story.Slug] = story
+	}
+	if bySlug["implement-invoices"].Status != "todo" || !bySlug["implement-invoices"].Ready {
+		t.Fatalf("expected dependent story to become ready once dependency closes: %+v", bySlug["implement-invoices"])
+	}
+}
+
+func TestReconcileUpdateVisibleAppliesDerivedLabels(t *testing.T) {
+	client := &stubGitHubClient{
+		preflight: &GitHubRepoInfo{
+			Repo:          "JimmyMcBride/plan",
+			RepoURL:       "https://github.com/JimmyMcBride/plan",
+			DefaultBranch: "main",
+		},
+		context: &GitHubContext{
+			Repo: GitHubRepoInfo{
+				Repo:          "JimmyMcBride/plan",
+				RepoURL:       "https://github.com/JimmyMcBride/plan",
+				DefaultBranch: "main",
+			},
+			CurrentBranch: "main",
+			CurrentSHA:    "abc123def456",
+		},
+	}
+	reset := SetGitHubClientFactoryForTesting(func() GitHubClient { return client })
+	t.Cleanup(reset)
+
+	root := t.TempDir()
+	manager := newGitHubStoryManager(t, root)
+	if _, err := manager.EnableGitHubBackend(); err != nil {
+		t.Fatal(err)
+	}
+	seedApprovedGitHubEpic(t, manager)
+	if _, err := manager.CreateStory("billing", "Seed billing data", "Seed data first", []string{"Seed data"}, []string{"Run seed checks"}, nil); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := manager.CreateStory("billing", "Implement invoices", "Create invoice generation flow", []string{"Generate invoices"}, []string{"Run billing tests"}, nil); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := manager.UpdateStory("implement-invoices", StoryChanges{SetBlockers: []string{"seed-billing-data"}}); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := manager.ReconcileGitHubStories(GitHubReconcileOptions{UpdateVisible: true}); err != nil {
+		t.Fatal(err)
+	}
+	if !containsString(client.issues[101].Labels, planIssueReadyLabel) {
+		t.Fatalf("expected ready label on independent issue: %+v", client.issues[101].Labels)
+	}
+	if !containsString(client.issues[102].Labels, planIssueBlockedLabel) {
+		t.Fatalf("expected blocked label on dependent issue: %+v", client.issues[102].Labels)
+	}
+}
+
 func newGitHubStoryManager(t *testing.T, root string) *Manager {
 	t.Helper()
 	ws := workspace.New(root)

--- a/internal/planning/github_backend_test.go
+++ b/internal/planning/github_backend_test.go
@@ -2,6 +2,7 @@ package planning
 
 import (
 	"errors"
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -13,6 +14,11 @@ import (
 type stubGitHubClient struct {
 	preflight    *GitHubRepoInfo
 	preflightErr error
+	context      *GitHubContext
+	issues       map[int]*GitHubIssue
+	nextIssue    int
+	lastCreate   GitHubIssueInput
+	lastUpdate   GitHubIssueInput
 }
 
 func (s *stubGitHubClient) Preflight(projectDir string) (*GitHubRepoInfo, error) {
@@ -23,19 +29,59 @@ func (s *stubGitHubClient) Preflight(projectDir string) (*GitHubRepoInfo, error)
 }
 
 func (s *stubGitHubClient) CurrentContext(projectDir string) (*GitHubContext, error) {
-	panic("unexpected CurrentContext call")
+	if s.context == nil {
+		panic("unexpected CurrentContext call")
+	}
+	return s.context, nil
 }
 
 func (s *stubGitHubClient) CreateIssue(projectDir, repo string, input GitHubIssueInput) (*GitHubIssue, error) {
-	panic("unexpected CreateIssue call")
+	s.lastCreate = input
+	if s.issues == nil {
+		s.issues = map[int]*GitHubIssue{}
+	}
+	if s.nextIssue == 0 {
+		s.nextIssue = 101
+	}
+	issue := &GitHubIssue{
+		Number: s.nextIssue,
+		URL:    fmt.Sprintf("https://github.com/%s/issues/%d", repo, s.nextIssue),
+		Title:  input.Title,
+		Body:   input.Body,
+		State:  "open",
+		Labels: append([]string(nil), input.Labels...),
+	}
+	if strings.TrimSpace(input.State) != "" {
+		issue.State = input.State
+	}
+	s.issues[issue.Number] = issue
+	s.nextIssue++
+	return issue, nil
 }
 
 func (s *stubGitHubClient) UpdateIssue(projectDir, repo string, issueNumber int, input GitHubIssueInput) (*GitHubIssue, error) {
-	panic("unexpected UpdateIssue call")
+	s.lastUpdate = input
+	issue, ok := s.issues[issueNumber]
+	if !ok {
+		panic("unexpected UpdateIssue call")
+	}
+	issue.Title = input.Title
+	issue.Body = input.Body
+	if strings.TrimSpace(input.State) != "" {
+		issue.State = input.State
+	}
+	issue.Labels = append([]string(nil), input.Labels...)
+	return issue, nil
 }
 
 func (s *stubGitHubClient) GetIssue(projectDir, repo string, issueNumber int) (*GitHubIssue, error) {
-	panic("unexpected GetIssue call")
+	issue, ok := s.issues[issueNumber]
+	if !ok {
+		panic("unexpected GetIssue call")
+	}
+	copy := *issue
+	copy.Labels = append([]string(nil), issue.Labels...)
+	return &copy, nil
 }
 
 func TestEnableGitHubBackendPersistsRepoConfigAfterPreflight(t *testing.T) {
@@ -131,5 +177,161 @@ func TestEnableGitHubBackendPropagatesPreflightFailures(t *testing.T) {
 		t.Fatal("expected preflight error")
 	} else if !strings.Contains(err.Error(), "gh auth status failed") {
 		t.Fatalf("unexpected preflight error: %v", err)
+	}
+}
+
+func TestCreateStoryUsesGitHubIssueStorageWhenBackendEnabled(t *testing.T) {
+	client := &stubGitHubClient{
+		preflight: &GitHubRepoInfo{
+			Repo:          "JimmyMcBride/plan",
+			RepoURL:       "https://github.com/JimmyMcBride/plan",
+			DefaultBranch: "main",
+		},
+		context: &GitHubContext{
+			Repo: GitHubRepoInfo{
+				Repo:          "JimmyMcBride/plan",
+				RepoURL:       "https://github.com/JimmyMcBride/plan",
+				DefaultBranch: "main",
+			},
+			CurrentBranch: "main",
+			CurrentSHA:    "abc123def456",
+		},
+	}
+	reset := SetGitHubClientFactoryForTesting(func() GitHubClient { return client })
+	t.Cleanup(reset)
+
+	root := t.TempDir()
+	ws := workspace.New(root)
+	if _, err := ws.Init(); err != nil {
+		t.Fatal(err)
+	}
+	manager := New(ws)
+	if _, err := manager.EnableGitHubBackend(); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := manager.CreateEpic("Billing", ""); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := manager.SetSpecStatus("billing", "approved"); err != nil {
+		t.Fatal(err)
+	}
+
+	story, err := manager.CreateStory(
+		"billing",
+		"Implement invoices",
+		"Create invoice generation flow",
+		[]string{"Generate invoices from line items"},
+		[]string{"Run focused billing tests"},
+		nil,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if story.Path != "https://github.com/JimmyMcBride/plan/issues/101" {
+		t.Fatalf("unexpected GitHub story path: %s", story.Path)
+	}
+	if _, err := os.Stat(filepath.Join(root, ".plan", "stories", "implement-invoices.md")); !os.IsNotExist(err) {
+		t.Fatalf("expected no local story note in GitHub mode, got err=%v", err)
+	}
+
+	state, err := ws.ReadGitHubState()
+	if err != nil {
+		t.Fatal(err)
+	}
+	record, ok := state.Stories["implement-invoices"]
+	if !ok {
+		t.Fatalf("expected GitHub story record to be stored: %+v", state.Stories)
+	}
+	if record.IssueNumber != 101 || record.Status != "todo" {
+		t.Fatalf("unexpected issue-backed story record: %+v", record)
+	}
+	if !strings.Contains(client.lastCreate.Body, "## Planning Links") || !strings.Contains(client.lastCreate.Body, "## Dependencies") {
+		t.Fatalf("expected issue contract in created body:\n%s", client.lastCreate.Body)
+	}
+
+	items, err := manager.ListStories("", "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(items) != 1 || items[0].Backend != "github" || items[0].IssueNumber != 101 {
+		t.Fatalf("unexpected GitHub story list: %+v", items)
+	}
+}
+
+func TestUpdateStoryMutatesIssueBackedRecordWithoutLocalMarkdown(t *testing.T) {
+	client := &stubGitHubClient{
+		preflight: &GitHubRepoInfo{
+			Repo:          "JimmyMcBride/plan",
+			RepoURL:       "https://github.com/JimmyMcBride/plan",
+			DefaultBranch: "main",
+		},
+		context: &GitHubContext{
+			Repo: GitHubRepoInfo{
+				Repo:          "JimmyMcBride/plan",
+				RepoURL:       "https://github.com/JimmyMcBride/plan",
+				DefaultBranch: "main",
+			},
+			CurrentBranch: "main",
+			CurrentSHA:    "abc123def456",
+		},
+	}
+	reset := SetGitHubClientFactoryForTesting(func() GitHubClient { return client })
+	t.Cleanup(reset)
+
+	root := t.TempDir()
+	ws := workspace.New(root)
+	if _, err := ws.Init(); err != nil {
+		t.Fatal(err)
+	}
+	manager := New(ws)
+	if _, err := manager.EnableGitHubBackend(); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := manager.CreateEpic("Billing", ""); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := manager.SetSpecStatus("billing", "approved"); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := manager.CreateStory(
+		"billing",
+		"Implement invoices",
+		"Create invoice generation flow",
+		[]string{"Generate invoices from line items"},
+		[]string{"Run focused billing tests"},
+		nil,
+	); err != nil {
+		t.Fatal(err)
+	}
+
+	updated, err := manager.UpdateStory("implement-invoices", StoryChanges{
+		Status:          "in_progress",
+		AddResources:    []string{"Issue owner: billing"},
+		SetBlockers:     []string{"seed-billing-data"},
+		AddVerification: []string{"Check GitHub issue body"},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if updated.Metadata["status"] != "blocked" && updated.Metadata["status"] != "in_progress" {
+		t.Fatalf("expected GitHub story note metadata to reflect updated status: %+v", updated.Metadata)
+	}
+	if _, err := os.Stat(filepath.Join(root, ".plan", "stories", "implement-invoices.md")); !os.IsNotExist(err) {
+		t.Fatalf("expected no local story note in GitHub mode, got err=%v", err)
+	}
+
+	state, err := ws.ReadGitHubState()
+	if err != nil {
+		t.Fatal(err)
+	}
+	record := state.Stories["implement-invoices"]
+	if record.Status != "in_progress" {
+		t.Fatalf("expected stored GitHub story status to update: %+v", record)
+	}
+	if len(record.Dependencies) != 1 || record.Dependencies[0] != "seed-billing-data" {
+		t.Fatalf("expected dependencies to persist in record: %+v", record)
+	}
+	if !strings.Contains(client.lastUpdate.Body, "seed-billing-data") {
+		t.Fatalf("expected dependency contract in updated issue body:\n%s", client.lastUpdate.Body)
 	}
 }

--- a/internal/planning/github_client.go
+++ b/internal/planning/github_client.go
@@ -1,0 +1,277 @@
+package planning
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"os/exec"
+	"path/filepath"
+	"strings"
+)
+
+type GitHubClient interface {
+	Preflight(projectDir string) (*GitHubRepoInfo, error)
+	CurrentContext(projectDir string) (*GitHubContext, error)
+	CreateIssue(projectDir, repo string, input GitHubIssueInput) (*GitHubIssue, error)
+	UpdateIssue(projectDir, repo string, issueNumber int, input GitHubIssueInput) (*GitHubIssue, error)
+	GetIssue(projectDir, repo string, issueNumber int) (*GitHubIssue, error)
+}
+
+type GitHubRepoInfo struct {
+	Repo          string
+	RepoURL       string
+	DefaultBranch string
+}
+
+type GitHubPullRequest struct {
+	Number     int
+	URL        string
+	State      string
+	HeadRef    string
+	BaseRef    string
+	IsDraft    bool
+	IsMerged   bool
+	MergedAt   string
+	HeadSHA    string
+	DefaultRef string
+}
+
+type GitHubContext struct {
+	Repo          GitHubRepoInfo
+	CurrentBranch string
+	CurrentSHA    string
+	PlanningPR    *GitHubPullRequest
+}
+
+type GitHubIssueInput struct {
+	Title  string
+	Body   string
+	State  string
+	Labels []string
+}
+
+type GitHubIssue struct {
+	Number int
+	URL    string
+	Title  string
+	Body   string
+	State  string
+	Labels []string
+}
+
+var newGitHubClient = func() GitHubClient {
+	return &cliGitHubClient{}
+}
+
+func SetGitHubClientFactoryForTesting(factory func() GitHubClient) func() {
+	previous := newGitHubClient
+	newGitHubClient = factory
+	return func() {
+		newGitHubClient = previous
+	}
+}
+
+type cliGitHubClient struct{}
+
+func (c *cliGitHubClient) Preflight(projectDir string) (*GitHubRepoInfo, error) {
+	if _, err := exec.LookPath("gh"); err != nil {
+		return nil, fmt.Errorf("gh is required for GitHub mode; install GitHub CLI from https://cli.github.com/ and retry")
+	}
+	if _, err := c.run(projectDir, nil, "gh", "auth", "status"); err != nil {
+		return nil, fmt.Errorf("gh auth status failed; run `gh auth login` before enabling GitHub mode")
+	}
+
+	type repoView struct {
+		NameWithOwner   string `json:"nameWithOwner"`
+		URL             string `json:"url"`
+		HasIssues       bool   `json:"hasIssuesEnabled"`
+		DefaultBranchRef struct {
+			Name string `json:"name"`
+		} `json:"defaultBranchRef"`
+	}
+
+	out, err := c.run(projectDir, nil, "gh", "repo", "view", "--json", "nameWithOwner,url,hasIssuesEnabled,defaultBranchRef")
+	if err != nil {
+		return nil, fmt.Errorf("gh repo view failed; make sure this project is a GitHub checkout with an accessible origin")
+	}
+	var payload repoView
+	if err := json.Unmarshal(out, &payload); err != nil {
+		return nil, fmt.Errorf("parse GitHub repo metadata: %w", err)
+	}
+	if strings.TrimSpace(payload.NameWithOwner) == "" || strings.TrimSpace(payload.URL) == "" {
+		return nil, fmt.Errorf("current repo did not resolve to a GitHub repository")
+	}
+	if !payload.HasIssues {
+		return nil, fmt.Errorf("GitHub Issues are disabled for %s; enable Issues before turning on GitHub story mode", payload.NameWithOwner)
+	}
+	if strings.TrimSpace(payload.DefaultBranchRef.Name) == "" {
+		return nil, fmt.Errorf("could not determine the default branch for %s", payload.NameWithOwner)
+	}
+	return &GitHubRepoInfo{
+		Repo:          payload.NameWithOwner,
+		RepoURL:       payload.URL,
+		DefaultBranch: payload.DefaultBranchRef.Name,
+	}, nil
+}
+
+func (c *cliGitHubClient) CurrentContext(projectDir string) (*GitHubContext, error) {
+	repo, err := c.Preflight(projectDir)
+	if err != nil {
+		return nil, err
+	}
+	branchRaw, err := c.run(projectDir, nil, "git", "rev-parse", "--abbrev-ref", "HEAD")
+	if err != nil {
+		return nil, fmt.Errorf("resolve current git branch: %w", err)
+	}
+	shaRaw, err := c.run(projectDir, nil, "git", "rev-parse", "HEAD")
+	if err != nil {
+		return nil, fmt.Errorf("resolve current git commit: %w", err)
+	}
+	context := &GitHubContext{
+		Repo:          *repo,
+		CurrentBranch: strings.TrimSpace(string(branchRaw)),
+		CurrentSHA:    strings.TrimSpace(string(shaRaw)),
+	}
+	if context.CurrentBranch == "" {
+		return nil, fmt.Errorf("could not determine current git branch")
+	}
+
+	type prPayload struct {
+		Number      int    `json:"number"`
+		URL         string `json:"url"`
+		State       string `json:"state"`
+		IsDraft     bool   `json:"isDraft"`
+		MergedAt    string `json:"mergedAt"`
+		HeadRefName string `json:"headRefName"`
+		BaseRefName string `json:"baseRefName"`
+	}
+
+	out, err := c.run(projectDir, nil, "gh", "pr", "list", "--head", context.CurrentBranch, "--json", "number,url,state,isDraft,mergedAt,headRefName,baseRefName", "--limit", "1")
+	if err != nil {
+		return nil, fmt.Errorf("inspect pull request context: %w", err)
+	}
+	var prs []prPayload
+	if err := json.Unmarshal(out, &prs); err != nil {
+		return nil, fmt.Errorf("parse pull request context: %w", err)
+	}
+	if len(prs) > 0 {
+		context.PlanningPR = &GitHubPullRequest{
+			Number:     prs[0].Number,
+			URL:        prs[0].URL,
+			State:      prs[0].State,
+			HeadRef:    prs[0].HeadRefName,
+			BaseRef:    prs[0].BaseRefName,
+			IsDraft:    prs[0].IsDraft,
+			IsMerged:   strings.TrimSpace(prs[0].MergedAt) != "",
+			MergedAt:   prs[0].MergedAt,
+			HeadSHA:    context.CurrentSHA,
+			DefaultRef: repo.DefaultBranch,
+		}
+	}
+	return context, nil
+}
+
+func (c *cliGitHubClient) CreateIssue(projectDir, repo string, input GitHubIssueInput) (*GitHubIssue, error) {
+	return c.upsertIssue(projectDir, fmt.Sprintf("repos/%s/issues", repo), input)
+}
+
+func (c *cliGitHubClient) UpdateIssue(projectDir, repo string, issueNumber int, input GitHubIssueInput) (*GitHubIssue, error) {
+	return c.upsertIssue(projectDir, fmt.Sprintf("repos/%s/issues/%d", repo, issueNumber), input)
+}
+
+func (c *cliGitHubClient) upsertIssue(projectDir, apiPath string, input GitHubIssueInput) (*GitHubIssue, error) {
+	payload := map[string]any{
+		"title": input.Title,
+		"body":  input.Body,
+	}
+	if strings.TrimSpace(input.State) != "" {
+		payload["state"] = input.State
+	}
+	if input.Labels != nil {
+		payload["labels"] = input.Labels
+	}
+	method := "POST"
+	if strings.Contains(apiPath, "/issues/") {
+		method = "PATCH"
+	}
+	out, err := c.api(projectDir, method, apiPath, payload)
+	if err != nil {
+		return nil, err
+	}
+	return parseGitHubIssue(out)
+}
+
+func (c *cliGitHubClient) GetIssue(projectDir, repo string, issueNumber int) (*GitHubIssue, error) {
+	out, err := c.api(projectDir, "GET", fmt.Sprintf("repos/%s/issues/%d", repo, issueNumber), nil)
+	if err != nil {
+		return nil, err
+	}
+	return parseGitHubIssue(out)
+}
+
+func (c *cliGitHubClient) api(projectDir, method, apiPath string, payload any) ([]byte, error) {
+	args := []string{"api", "--method", method, apiPath}
+	var stdin []byte
+	if payload != nil {
+		args = append(args, "--input", "-")
+		raw, err := json.Marshal(payload)
+		if err != nil {
+			return nil, err
+		}
+		stdin = raw
+	}
+	out, err := c.run(projectDir, stdin, "gh", args...)
+	if err != nil {
+		return nil, fmt.Errorf("gh api %s %s: %w", method, apiPath, err)
+	}
+	return out, nil
+}
+
+func (c *cliGitHubClient) run(projectDir string, stdin []byte, name string, args ...string) ([]byte, error) {
+	cmd := exec.Command(name, args...)
+	cmd.Dir = filepath.Clean(projectDir)
+	if stdin != nil {
+		cmd.Stdin = bytes.NewReader(stdin)
+	}
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		message := strings.TrimSpace(string(out))
+		if message == "" {
+			message = err.Error()
+		}
+		return nil, fmt.Errorf("%s", message)
+	}
+	return out, nil
+}
+
+func parseGitHubIssue(raw []byte) (*GitHubIssue, error) {
+	type label struct {
+		Name string `json:"name"`
+	}
+	type payload struct {
+		Number int     `json:"number"`
+		URL    string  `json:"html_url"`
+		Title  string  `json:"title"`
+		Body   string  `json:"body"`
+		State  string  `json:"state"`
+		Labels []label `json:"labels"`
+	}
+	var item payload
+	if err := json.Unmarshal(raw, &item); err != nil {
+		return nil, fmt.Errorf("parse issue payload: %w", err)
+	}
+	issue := &GitHubIssue{
+		Number: item.Number,
+		URL:    item.URL,
+		Title:  item.Title,
+		Body:   item.Body,
+		State:  item.State,
+	}
+	for _, current := range item.Labels {
+		if strings.TrimSpace(current.Name) == "" {
+			continue
+		}
+		issue.Labels = append(issue.Labels, current.Name)
+	}
+	return issue, nil
+}

--- a/internal/planning/github_reconcile.go
+++ b/internal/planning/github_reconcile.go
@@ -91,18 +91,23 @@ func (m *Manager) ReconcileGitHubStories(options GitHubReconcileOptions) (*GitHu
 		}
 
 		body := mergeManagedIssueBody(issue.Body, renderGitHubStoryIssueBody(state, &context.Repo, epic, spec, record))
-		if body != issue.Body {
+		labels := issue.Labels
+		if options.UpdateVisible {
+			labels = applyDerivedReadyLabels(labels, status, ready)
+		}
+		if body != issue.Body || !sameStringSlice(labels, issue.Labels) {
 			updatedIssue, err := m.github.UpdateIssue(info.ProjectDir, state.Repo, record.IssueNumber, GitHubIssueInput{
 				Title:  record.Title,
 				Body:   body,
 				State:  issue.State,
-				Labels: issue.Labels,
+				Labels: labels,
 			})
 			if err != nil {
 				return nil, err
 			}
 			record.IssueURL = updatedIssue.URL
 			record.RemoteState = updatedIssue.State
+			record.VisibleReadyMarkerSet = containsString(labels, planIssueReadyLabel) || containsString(labels, planIssueBlockedLabel)
 			result.UpdatedIssues = append(result.UpdatedIssues, fmt.Sprintf("#%d", record.IssueNumber))
 		}
 		record.UpdatedAt = time.Now().UTC().Format(time.RFC3339)
@@ -115,4 +120,25 @@ func (m *Manager) ReconcileGitHubStories(options GitHubReconcileOptions) (*GitHu
 		return nil, err
 	}
 	return result, nil
+}
+
+func sameStringSlice(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}
+
+func containsString(items []string, target string) bool {
+	for _, item := range items {
+		if item == target {
+			return true
+		}
+	}
+	return false
 }

--- a/internal/planning/github_reconcile.go
+++ b/internal/planning/github_reconcile.go
@@ -1,0 +1,118 @@
+package planning
+
+import (
+	"fmt"
+	"path/filepath"
+	"sort"
+	"time"
+
+	"plan/internal/notes"
+	"plan/internal/workspace"
+)
+
+type GitHubReconcileOptions struct {
+	UpdateVisible bool
+}
+
+type GitHubReconcileResult struct {
+	Repo            string
+	CurrentBranch   string
+	DefaultBranch   string
+	UpdatedIssues   []string
+	ReadyStories    []string
+	BlockedStories  []string
+	PlanningPromote bool
+}
+
+func (m *Manager) ReconcileGitHubStories(options GitHubReconcileOptions) (*GitHubReconcileResult, error) {
+	info, err := m.workspace.EnsureInitialized()
+	if err != nil {
+		return nil, err
+	}
+	backend, err := m.storyBackendForInfo()
+	if err != nil {
+		return nil, err
+	}
+	if backend != workspace.StoryBackendGitHub {
+		return nil, fmt.Errorf("GitHub reconcile is only available when the story backend is set to github")
+	}
+
+	state, err := m.readGitHubStateForStories()
+	if err != nil {
+		return nil, err
+	}
+	context, err := m.github.CurrentContext(info.ProjectDir)
+	if err != nil {
+		return nil, err
+	}
+	result := &GitHubReconcileResult{
+		Repo:          state.Repo,
+		CurrentBranch: context.CurrentBranch,
+		DefaultBranch: context.Repo.DefaultBranch,
+	}
+	if context.CurrentBranch == context.Repo.DefaultBranch {
+		result.PlanningPromote = true
+	}
+
+	slugs := make([]string, 0, len(state.Stories))
+	for slug := range state.Stories {
+		slugs = append(slugs, slug)
+	}
+	sort.Strings(slugs)
+
+	for _, slug := range slugs {
+		record := state.Stories[slug]
+		epic, err := notes.Read(filepath.Join(info.EpicsDir, record.Epic+".md"))
+		if err != nil {
+			return nil, err
+		}
+		spec, err := notes.Read(filepath.Join(info.SpecsDir, record.Spec+".md"))
+		if err != nil {
+			return nil, err
+		}
+		issue, err := m.github.GetIssue(info.ProjectDir, state.Repo, record.IssueNumber)
+		if err != nil {
+			return nil, err
+		}
+		record.IssueURL = issue.URL
+		record.RemoteState = issue.State
+		if result.PlanningPromote {
+			record.PlanningPRMerged = true
+			record.DocRefMode = "main"
+			record.DocRef = context.Repo.DefaultBranch
+		}
+
+		status, ready, _, _, _ := deriveGitHubStoryState(record, state)
+		if ready {
+			result.ReadyStories = append(result.ReadyStories, slug)
+		}
+		if status == "blocked" {
+			result.BlockedStories = append(result.BlockedStories, slug)
+		}
+
+		body := mergeManagedIssueBody(issue.Body, renderGitHubStoryIssueBody(state, &context.Repo, epic, spec, record))
+		if body != issue.Body {
+			updatedIssue, err := m.github.UpdateIssue(info.ProjectDir, state.Repo, record.IssueNumber, GitHubIssueInput{
+				Title:  record.Title,
+				Body:   body,
+				State:  issue.State,
+				Labels: issue.Labels,
+			})
+			if err != nil {
+				return nil, err
+			}
+			record.IssueURL = updatedIssue.URL
+			record.RemoteState = updatedIssue.State
+			result.UpdatedIssues = append(result.UpdatedIssues, fmt.Sprintf("#%d", record.IssueNumber))
+		}
+		record.UpdatedAt = time.Now().UTC().Format(time.RFC3339)
+		state.Stories[slug] = record
+	}
+
+	state.LastReconciled = time.Now().UTC().Format(time.RFC3339)
+	state.LastUpdatedAt = state.LastReconciled
+	if err := m.workspace.WriteGitHubState(*state); err != nil {
+		return nil, err
+	}
+	return result, nil
+}

--- a/internal/planning/github_story_backend.go
+++ b/internal/planning/github_story_backend.go
@@ -235,6 +235,7 @@ func (m *Manager) listGitHubStories(info *workspace.Info, filterEpic, filterStat
 			Ready:         ready,
 			BlockedByPlan: blockedByPlan,
 			BlockedByDeps: blockedByDeps,
+			Started:       record.Status == "in_progress" || record.Status == "blocked" || record.Status == "done" || strings.EqualFold(record.RemoteState, "closed"),
 		}
 		if len(blockedReasons) > 0 && status == "blocked" && len(item.Blockers) == 0 {
 			item.Blockers = append(item.Blockers, blockedReasons...)
@@ -337,6 +338,7 @@ func deriveGitHubStoryState(record workspace.GitHubStoryRecord, state *workspace
 
 func renderGitHubStoryIssueBody(state *workspace.GitHubState, repo *GitHubRepoInfo, epic, spec *notes.Note, record workspace.GitHubStoryRecord) string {
 	content := renderGitHubStoryNoteContent(state, record)
+	status, ready, blockedReasons, _, _ := deriveGitHubStoryState(record, state)
 
 	epicLink, specLink := gitHubPlanningLinks(repo, record)
 	planningLines := []string{
@@ -350,6 +352,14 @@ func renderGitHubStoryIssueBody(state *workspace.GitHubState, repo *GitHubRepoIn
 		planningLines = append(planningLines, "- Planning Merge: merged")
 	} else {
 		planningLines = append(planningLines, "- Planning Merge: blocked until planning PR merges")
+	}
+	derivedState := status
+	if ready {
+		derivedState = "ready"
+	}
+	planningLines = append(planningLines, fmt.Sprintf("- Derived State: %s", derivedState))
+	for _, reason := range blockedReasons {
+		planningLines = append(planningLines, fmt.Sprintf("  - %s", reason))
 	}
 
 	dependencies := renderGitHubDependenciesSection(state, record)
@@ -501,6 +511,24 @@ func mergeManagedIssueBody(existingBody, managedBody string) string {
 		return managedBody
 	}
 	return strings.TrimRight(existing, "\n") + "\n\n" + strings.TrimRight(managedBody, "\n") + "\n"
+}
+
+func applyDerivedReadyLabels(labels []string, status string, ready bool) []string {
+	var out []string
+	for _, label := range labels {
+		if label == planIssueReadyLabel || label == planIssueBlockedLabel {
+			continue
+		}
+		out = append(out, label)
+	}
+	switch {
+	case ready:
+		out = append(out, planIssueReadyLabel)
+	case status == "blocked":
+		out = append(out, planIssueBlockedLabel)
+	}
+	sort.Strings(out)
+	return out
 }
 
 func extractManagedIssueBody(body string) string {

--- a/internal/planning/github_story_backend.go
+++ b/internal/planning/github_story_backend.go
@@ -1,0 +1,504 @@
+package planning
+
+import (
+	"fmt"
+	"path/filepath"
+	"sort"
+	"strings"
+	"time"
+
+	"plan/internal/notes"
+	"plan/internal/workspace"
+)
+
+const (
+	planIssueBlockStart  = "<!-- plan:start -->"
+	planIssueBlockEnd    = "<!-- plan:end -->"
+	planIssueMetaPrefix  = "<!-- plan:meta"
+	planIssueReadyLabel  = "plan:ready"
+	planIssueBlockedLabel = "plan:blocked"
+)
+
+func (m *Manager) storyBackendForInfo() (workspace.StoryBackend, error) {
+	return m.StoryBackend()
+}
+
+func (m *Manager) readGitHubStateForStories() (*workspace.GitHubState, error) {
+	state, err := m.workspace.ReadGitHubState()
+	if err != nil {
+		return nil, err
+	}
+	if state.Stories == nil {
+		state.Stories = map[string]workspace.GitHubStoryRecord{}
+	}
+	return state, nil
+}
+
+func (m *Manager) createGitHubStory(info *workspace.Info, epicSlug, title, description string, criteria, verification, resources []string) (*notes.Note, error) {
+	if len(trimmedItems(criteria)) == 0 {
+		return nil, fmt.Errorf("at least one acceptance criterion is required")
+	}
+	if len(trimmedItems(verification)) == 0 {
+		return nil, fmt.Errorf("at least one verification step is required")
+	}
+	epic, err := notes.Read(filepath.Join(info.EpicsDir, slugify(epicSlug)+".md"))
+	if err != nil {
+		return nil, err
+	}
+	specSlug := m.specSlugFromEpic(epic)
+	spec, err := notes.Read(filepath.Join(info.SpecsDir, specSlug+".md"))
+	if err != nil {
+		return nil, err
+	}
+	if status := stringValue(spec.Metadata["status"]); status != "approved" {
+		if status == "" {
+			status = "draft"
+		}
+		return nil, fmt.Errorf("spec %s is %q; approve the spec before creating stories", rel(info.ProjectDir, spec.Path), status)
+	}
+
+	state, err := m.readGitHubStateForStories()
+	if err != nil {
+		return nil, err
+	}
+	if strings.TrimSpace(state.Repo) == "" || strings.TrimSpace(state.RepoURL) == "" {
+		return nil, fmt.Errorf("GitHub story mode is enabled but repo metadata is missing; rerun `plan github enable --project .`")
+	}
+
+	storySlug := slugify(title)
+	if _, exists := state.Stories[storySlug]; exists {
+		return nil, fmt.Errorf("GitHub-backed story already exists for slug %s", storySlug)
+	}
+
+	context, err := m.github.CurrentContext(info.ProjectDir)
+	if err != nil {
+		return nil, err
+	}
+	if context.Repo.Repo != state.Repo {
+		return nil, fmt.Errorf("current repo resolved to %s, but plan workspace is configured for %s; rerun `plan github enable --project .` if the remote changed", context.Repo.Repo, state.Repo)
+	}
+
+	record := workspace.GitHubStoryRecord{
+		Slug:               storySlug,
+		Title:              title,
+		Epic:               slugFromPath(epic.Path),
+		Spec:               specSlug,
+		Status:             "todo",
+		Description:        strings.TrimSpace(description),
+		AcceptanceCriteria: trimmedItems(criteria),
+		Verification:       trimmedItems(verification),
+		Resources:          trimmedItems(resources),
+		RemoteState:        "open",
+		UpdatedAt:          time.Now().UTC().Format(time.RFC3339),
+	}
+	if strings.TrimSpace(record.Description) == "" {
+		record.Description = fmt.Sprintf("Deliver the %q execution slice from the canonical spec.", title)
+	}
+	if context.CurrentBranch != context.Repo.DefaultBranch {
+		if context.PlanningPR == nil {
+			return nil, fmt.Errorf("current branch %s has no planning PR; open a planning PR before creating GitHub-backed stories", context.CurrentBranch)
+		}
+		record.PlanningPRNumber = context.PlanningPR.Number
+		record.PlanningPRURL = context.PlanningPR.URL
+		record.PlanningPRMerged = context.PlanningPR.IsMerged
+		record.DocRefMode = "sha"
+		record.DocRef = context.CurrentSHA
+	} else {
+		record.PlanningPRMerged = true
+		record.DocRefMode = "main"
+		record.DocRef = context.Repo.DefaultBranch
+	}
+
+	body := mergeManagedIssueBody("", renderGitHubStoryIssueBody(state, &context.Repo, epic, spec, record))
+	issue, err := m.github.CreateIssue(info.ProjectDir, state.Repo, GitHubIssueInput{
+		Title: title,
+		Body:  body,
+		State: "open",
+	})
+	if err != nil {
+		return nil, err
+	}
+	record.IssueNumber = issue.Number
+	record.IssueURL = issue.URL
+	record.RemoteState = issue.State
+	record.UpdatedAt = time.Now().UTC().Format(time.RFC3339)
+	state.Stories[storySlug] = record
+	if err := m.workspace.WriteGitHubState(*state); err != nil {
+		return nil, err
+	}
+	return m.readGitHubStoryFromState(info, state, storySlug)
+}
+
+func (m *Manager) updateGitHubStory(info *workspace.Info, storySlug string, changes StoryChanges) (*notes.Note, error) {
+	state, err := m.readGitHubStateForStories()
+	if err != nil {
+		return nil, err
+	}
+	record, ok := state.Stories[slugify(storySlug)]
+	if !ok {
+		return nil, fmt.Errorf("GitHub-backed story %s does not exist", slugify(storySlug))
+	}
+	if changes.Status != "" && !isValidStoryStatus(changes.Status) {
+		return nil, fmt.Errorf("invalid story status %q", changes.Status)
+	}
+
+	if changes.Status != "" {
+		record.Status = changes.Status
+	}
+	record.AcceptanceCriteria = append(record.AcceptanceCriteria, trimmedItems(changes.AddCriteria)...)
+	record.Verification = append(record.Verification, trimmedItems(changes.AddVerification)...)
+	record.Resources = append(record.Resources, trimmedItems(changes.AddResources)...)
+	if changes.SetBlockers != nil {
+		record.Dependencies = normalizeStoryRefs(changes.SetBlockers)
+	}
+
+	if requiresExecutionExpectations(record.Status) && !gitHubStoryRecordHasExecutionExpectations(record) {
+		return nil, fmt.Errorf("story %s needs acceptance criteria and verification steps before it can be marked %q", record.Slug, record.Status)
+	}
+
+	context, err := m.github.CurrentContext(info.ProjectDir)
+	if err != nil {
+		return nil, err
+	}
+	epic, err := notes.Read(filepath.Join(info.EpicsDir, record.Epic+".md"))
+	if err != nil {
+		return nil, err
+	}
+	spec, err := notes.Read(filepath.Join(info.SpecsDir, record.Spec+".md"))
+	if err != nil {
+		return nil, err
+	}
+	existingIssue, err := m.github.GetIssue(info.ProjectDir, state.Repo, record.IssueNumber)
+	if err != nil {
+		return nil, err
+	}
+	record.RemoteState = existingIssue.State
+	managedBody := renderGitHubStoryIssueBody(state, &context.Repo, epic, spec, record)
+	body := mergeManagedIssueBody(existingIssue.Body, managedBody)
+
+	issueState := "open"
+	if record.Status == "done" {
+		issueState = "closed"
+	}
+	updatedIssue, err := m.github.UpdateIssue(info.ProjectDir, state.Repo, record.IssueNumber, GitHubIssueInput{
+		Title:  record.Title,
+		Body:   body,
+		State:  issueState,
+		Labels: existingIssue.Labels,
+	})
+	if err != nil {
+		return nil, err
+	}
+	record.IssueURL = updatedIssue.URL
+	record.RemoteState = updatedIssue.State
+	record.UpdatedAt = time.Now().UTC().Format(time.RFC3339)
+	state.Stories[record.Slug] = record
+	if err := m.workspace.WriteGitHubState(*state); err != nil {
+		return nil, err
+	}
+	note, err := m.readGitHubStoryFromState(info, state, record.Slug)
+	if err != nil {
+		return nil, err
+	}
+	if err := m.syncSpecStatusForStory(info, note); err != nil {
+		return nil, err
+	}
+	return note, nil
+}
+
+func (m *Manager) listGitHubStories(info *workspace.Info, filterEpic, filterStatus string) ([]StoryInfo, error) {
+	state, err := m.readGitHubStateForStories()
+	if err != nil {
+		return nil, err
+	}
+	specVersions, err := loadSpecTargetVersions(info)
+	if err != nil {
+		return nil, err
+	}
+
+	filterEpic = slugify(filterEpic)
+	out := make([]StoryInfo, 0, len(state.Stories))
+	for _, record := range state.Stories {
+		status, ready, blockedReasons, blockedByPlan, blockedByDeps := deriveGitHubStoryState(record, state)
+		item := StoryInfo{
+			Slug:          record.Slug,
+			Path:          record.IssueURL,
+			Title:         record.Title,
+			Status:        status,
+			Epic:          record.Epic,
+			Spec:          record.Spec,
+			TargetVersion: specVersions[record.Spec],
+			Blockers:      append([]string(nil), record.Dependencies...),
+			Backend:       string(workspace.StoryBackendGitHub),
+			IssueNumber:   record.IssueNumber,
+			IssueURL:      record.IssueURL,
+			Ready:         ready,
+			BlockedByPlan: blockedByPlan,
+			BlockedByDeps: blockedByDeps,
+		}
+		if len(blockedReasons) > 0 && status == "blocked" && len(item.Blockers) == 0 {
+			item.Blockers = append(item.Blockers, blockedReasons...)
+		}
+		if filterEpic != "" && item.Epic != filterEpic {
+			continue
+		}
+		if filterStatus != "" && item.Status != filterStatus {
+			continue
+		}
+		out = append(out, item)
+	}
+	sort.Slice(out, func(i, j int) bool {
+		if out[i].Ready != out[j].Ready {
+			return out[i].Ready
+		}
+		return out[i].Title < out[j].Title
+	})
+	return out, nil
+}
+
+func (m *Manager) readGitHubStory(info *workspace.Info, storySlug string) (*notes.Note, error) {
+	state, err := m.readGitHubStateForStories()
+	if err != nil {
+		return nil, err
+	}
+	return m.readGitHubStoryFromState(info, state, storySlug)
+}
+
+func (m *Manager) readGitHubStoryFromState(info *workspace.Info, state *workspace.GitHubState, storySlug string) (*notes.Note, error) {
+	record, ok := state.Stories[slugify(storySlug)]
+	if !ok {
+		return nil, fmt.Errorf("GitHub-backed story %s does not exist", slugify(storySlug))
+	}
+	status, _, _, _, _ := deriveGitHubStoryState(record, state)
+	content := renderGitHubStoryNoteContent(state, record)
+	return &notes.Note{
+		Path:  record.IssueURL,
+		Title: record.Title,
+		Type:  "story",
+		Metadata: map[string]any{
+			"slug":     record.Slug,
+			"status":   status,
+			"epic":     record.Epic,
+			"spec":     record.Spec,
+			"backend":  string(workspace.StoryBackendGitHub),
+			"issue":    record.IssueNumber,
+			"issue_url": record.IssueURL,
+			"blockers": append([]string(nil), record.Dependencies...),
+		},
+		Content: content,
+	}, nil
+}
+
+func gitHubStoryRecordHasExecutionExpectations(record workspace.GitHubStoryRecord) bool {
+	return len(trimmedItems(record.AcceptanceCriteria)) > 0 && len(trimmedItems(record.Verification)) > 0
+}
+
+func deriveGitHubStoryState(record workspace.GitHubStoryRecord, state *workspace.GitHubState) (status string, ready bool, blockedReasons []string, blockedByPlan bool, blockedByDeps bool) {
+	status = record.Status
+	if status == "" {
+		status = "todo"
+	}
+	if strings.EqualFold(record.RemoteState, "closed") {
+		status = "done"
+	}
+	if status == "done" {
+		return status, false, nil, false, false
+	}
+
+	if !record.PlanningPRMerged {
+		blockedByPlan = true
+		blockedReasons = append(blockedReasons, "planning PR not merged")
+	}
+	for _, dep := range normalizeStoryRefs(record.Dependencies) {
+		dependency, ok := state.Stories[dep]
+		if !ok {
+			blockedByDeps = true
+			blockedReasons = append(blockedReasons, fmt.Sprintf("dependency %s is missing", dep))
+			continue
+		}
+		if dependency.Status != "done" && !strings.EqualFold(dependency.RemoteState, "closed") {
+			blockedByDeps = true
+			name := dependency.Title
+			if strings.TrimSpace(name) == "" {
+				name = dep
+			}
+			blockedReasons = append(blockedReasons, fmt.Sprintf("dependency %s is still open", name))
+		}
+	}
+	if len(blockedReasons) > 0 && status != "in_progress" {
+		return "blocked", false, blockedReasons, blockedByPlan, blockedByDeps
+	}
+	if status == "blocked" && len(blockedReasons) == 0 {
+		status = "todo"
+	}
+	ready = status == "todo" && len(blockedReasons) == 0
+	return status, ready, blockedReasons, blockedByPlan, blockedByDeps
+}
+
+func renderGitHubStoryIssueBody(state *workspace.GitHubState, repo *GitHubRepoInfo, epic, spec *notes.Note, record workspace.GitHubStoryRecord) string {
+	content := renderGitHubStoryNoteContent(state, record)
+
+	epicLink, specLink := gitHubPlanningLinks(repo, record)
+	planningLines := []string{
+		fmt.Sprintf("- Epic: [%s](%s)", epic.Title, epicLink),
+		fmt.Sprintf("- Spec: [%s](%s)", spec.Title, specLink),
+	}
+	if record.PlanningPRURL != "" {
+		planningLines = append(planningLines, fmt.Sprintf("- Planning PR: [#%d](%s)", record.PlanningPRNumber, record.PlanningPRURL))
+	}
+	if record.PlanningPRMerged {
+		planningLines = append(planningLines, "- Planning Merge: merged")
+	} else {
+		planningLines = append(planningLines, "- Planning Merge: blocked until planning PR merges")
+	}
+
+	dependencies := renderGitHubDependenciesSection(state, record)
+	asyncNotes := renderListOrPlaceholder(record.AsyncNotes, "- none")
+	meta := renderGitHubStoryMetadataBlock(record)
+
+	body := content
+	body = notes.SetSection(body, "Planning Links", strings.Join(planningLines, "\n"))
+	body = notes.SetSection(body, "Dependencies", dependencies)
+	body = notes.SetSection(body, "Async Notes", asyncNotes)
+
+	return strings.Join([]string{
+		planIssueBlockStart,
+		strings.TrimRight(body, "\n"),
+		"",
+		meta,
+		planIssueBlockEnd,
+		"",
+	}, "\n")
+}
+
+func renderGitHubStoryNoteContent(state *workspace.GitHubState, record workspace.GitHubStoryRecord) string {
+	var body strings.Builder
+	body.WriteString("## Description\n\n")
+	body.WriteString(strings.TrimSpace(record.Description))
+	body.WriteString("\n\n## Acceptance Criteria\n\n")
+	body.WriteString(renderChecklistOrPlaceholder(record.AcceptanceCriteria))
+	body.WriteString("\n\n## Verification\n\n")
+	body.WriteString(renderListOrPlaceholder(record.Verification, "- Validate the story against the canonical spec."))
+	body.WriteString("\n\n## Critique\n\n")
+	body.WriteString(renderStoryCritique(StoryCritique{
+		ScopeFit:              record.ScopeFit,
+		VerticalSliceCheck:    record.VerticalSliceCheck,
+		HiddenPrerequisites:   record.HiddenPrerequisites,
+		VerificationGaps:      record.VerificationGaps,
+		RewriteRecommendation: record.RewriteRecommendation,
+	}))
+	body.WriteString("\n\n## Resources\n\n")
+	resources := append([]string(nil), record.Resources...)
+	if record.IssueURL != "" {
+		resources = append([]string{fmt.Sprintf("- [GitHub Issue](%s)", record.IssueURL)}, resources...)
+	}
+	body.WriteString(renderListOrPlaceholder(resources, "- none"))
+	body.WriteString("\n\n## Dependencies\n\n")
+	body.WriteString(renderGitHubDependenciesSection(state, record))
+	body.WriteString("\n\n## Async Notes\n\n")
+	body.WriteString(renderListOrPlaceholder(record.AsyncNotes, "- none"))
+	body.WriteString("\n")
+	return body.String()
+}
+
+func gitHubPlanningLinks(repo *GitHubRepoInfo, record workspace.GitHubStoryRecord) (string, string) {
+	ref := repo.DefaultBranch
+	if record.DocRefMode == "sha" && strings.TrimSpace(record.DocRef) != "" {
+		ref = record.DocRef
+	}
+	if record.DocRefMode == "main" && strings.TrimSpace(record.DocRef) != "" {
+		ref = record.DocRef
+	}
+	base := strings.TrimSuffix(repo.RepoURL, "/")
+	return fmt.Sprintf("%s/blob/%s/.plan/epics/%s.md", base, ref, record.Epic),
+		fmt.Sprintf("%s/blob/%s/.plan/specs/%s.md", base, ref, record.Spec)
+}
+
+func renderGitHubDependenciesSection(state *workspace.GitHubState, record workspace.GitHubStoryRecord) string {
+	if len(record.Dependencies) == 0 {
+		return "- none"
+	}
+	var lines []string
+	for _, dep := range normalizeStoryRefs(record.Dependencies) {
+		dependency, ok := state.Stories[dep]
+		if !ok {
+			lines = append(lines, fmt.Sprintf("- [ ] blocked by %s", dep))
+			continue
+		}
+		check := "[ ]"
+		label := dependency.Title
+		if strings.EqualFold(dependency.RemoteState, "closed") || dependency.Status == "done" {
+			check = "[x]"
+		}
+		if label == "" {
+			label = dep
+		}
+		if dependency.IssueURL != "" {
+			lines = append(lines, fmt.Sprintf("- %s [%s](%s)", check, label, dependency.IssueURL))
+			continue
+		}
+		lines = append(lines, fmt.Sprintf("- %s %s", check, label))
+	}
+	return strings.Join(lines, "\n")
+}
+
+func renderChecklistOrPlaceholder(items []string) string {
+	items = trimmedItems(items)
+	if len(items) == 0 {
+		return "- [ ] Add acceptance criteria"
+	}
+	var lines []string
+	for _, item := range items {
+		lines = append(lines, checklist(item))
+	}
+	return strings.Join(lines, "\n")
+}
+
+func renderListOrPlaceholder(items []string, placeholder string) string {
+	items = trimmedItems(items)
+	if len(items) == 0 {
+		return placeholder
+	}
+	var lines []string
+	for _, item := range items {
+		trimmed := strings.TrimSpace(item)
+		if strings.HasPrefix(trimmed, "- ") || strings.HasPrefix(trimmed, "* ") {
+			lines = append(lines, trimmed)
+			continue
+		}
+		lines = append(lines, "- "+trimmed)
+	}
+	return strings.Join(lines, "\n")
+}
+
+func renderGitHubStoryMetadataBlock(record workspace.GitHubStoryRecord) string {
+	lines := []string{
+		planIssueMetaPrefix,
+		fmt.Sprintf("slug: %s", record.Slug),
+		fmt.Sprintf("epic: %s", record.Epic),
+		fmt.Sprintf("spec: %s", record.Spec),
+		fmt.Sprintf("status: %s", record.Status),
+		fmt.Sprintf("issue_number: %d", record.IssueNumber),
+		fmt.Sprintf("doc_ref_mode: %s", record.DocRefMode),
+		fmt.Sprintf("doc_ref: %s", record.DocRef),
+		fmt.Sprintf("planning_pr_number: %d", record.PlanningPRNumber),
+		fmt.Sprintf("planning_pr_merged: %t", record.PlanningPRMerged),
+		fmt.Sprintf("depends_on: %s", strings.Join(normalizeStoryRefs(record.Dependencies), ",")),
+		"-->",
+	}
+	return strings.Join(lines, "\n")
+}
+
+func mergeManagedIssueBody(existingBody, managedBody string) string {
+	existing := strings.ReplaceAll(existingBody, "\r\n", "\n")
+	start := strings.Index(existing, planIssueBlockStart)
+	end := strings.Index(existing, planIssueBlockEnd)
+	if start >= 0 && end > start {
+		end += len(planIssueBlockEnd)
+		return strings.TrimRight(existing[:start], "\n") + "\n\n" + strings.TrimRight(managedBody, "\n") + existing[end:]
+	}
+	if strings.TrimSpace(existing) == "" {
+		return managedBody
+	}
+	return strings.TrimRight(existing, "\n") + "\n\n" + strings.TrimRight(managedBody, "\n") + "\n"
+}

--- a/internal/planning/github_story_backend.go
+++ b/internal/planning/github_story_backend.go
@@ -502,3 +502,42 @@ func mergeManagedIssueBody(existingBody, managedBody string) string {
 	}
 	return strings.TrimRight(existing, "\n") + "\n\n" + strings.TrimRight(managedBody, "\n") + "\n"
 }
+
+func extractManagedIssueBody(body string) string {
+	body = strings.ReplaceAll(body, "\r\n", "\n")
+	start := strings.Index(body, planIssueBlockStart)
+	end := strings.Index(body, planIssueBlockEnd)
+	if start < 0 || end <= start {
+		return ""
+	}
+	start += len(planIssueBlockStart)
+	return strings.TrimSpace(body[start:end])
+}
+
+func parseGitHubStoryMetadata(body string) map[string]string {
+	body = strings.ReplaceAll(body, "\r\n", "\n")
+	start := strings.Index(body, planIssueMetaPrefix)
+	if start < 0 {
+		return nil
+	}
+	body = body[start+len(planIssueMetaPrefix):]
+	end := strings.Index(body, "\n-->")
+	if end < 0 {
+		return nil
+	}
+	block := strings.TrimSpace(body[:end])
+	out := map[string]string{}
+	for _, line := range strings.Split(block, "\n") {
+		parts := strings.SplitN(line, ":", 2)
+		if len(parts) != 2 {
+			continue
+		}
+		key := strings.TrimSpace(parts[0])
+		value := strings.TrimSpace(parts[1])
+		if key == "" {
+			continue
+		}
+		out[key] = value
+	}
+	return out
+}

--- a/internal/planning/manager.go
+++ b/internal/planning/manager.go
@@ -381,6 +381,13 @@ func (m *Manager) ReadStory(storySlug string) (*notes.Note, error) {
 	if err != nil {
 		return nil, err
 	}
+	backend, err := m.storyBackendForInfo()
+	if err != nil {
+		return nil, err
+	}
+	if backend == workspace.StoryBackendGitHub {
+		return m.readGitHubStory(info, storySlug)
+	}
 	note, err := notes.Read(filepath.Join(info.StoriesDir, slugify(storySlug)+".md"))
 	if err != nil {
 		return nil, err
@@ -416,6 +423,13 @@ func (m *Manager) CreateStory(epicSlug, title, description string, criteria, ver
 	info, err := m.workspace.EnsureInitialized()
 	if err != nil {
 		return nil, err
+	}
+	backend, err := m.storyBackendForInfo()
+	if err != nil {
+		return nil, err
+	}
+	if backend == workspace.StoryBackendGitHub {
+		return m.createGitHubStory(info, epicSlug, title, description, criteria, verification, resources)
 	}
 	if len(trimmedItems(criteria)) == 0 {
 		return nil, fmt.Errorf("at least one acceptance criterion is required")
@@ -478,6 +492,13 @@ func (m *Manager) UpdateStory(storySlug string, changes StoryChanges) (*notes.No
 	if err != nil {
 		return nil, err
 	}
+	backend, err := m.storyBackendForInfo()
+	if err != nil {
+		return nil, err
+	}
+	if backend == workspace.StoryBackendGitHub {
+		return m.updateGitHubStory(info, storySlug, changes)
+	}
 	if changes.Status != "" && !isValidStoryStatus(changes.Status) {
 		return nil, fmt.Errorf("invalid story status %q", changes.Status)
 	}
@@ -520,6 +541,13 @@ func (m *Manager) ListStories(filterEpic, filterStatus string) ([]StoryInfo, err
 	if err != nil {
 		return nil, err
 	}
+	backend, err := m.storyBackendForInfo()
+	if err != nil {
+		return nil, err
+	}
+	if backend == workspace.StoryBackendGitHub {
+		return m.listGitHubStories(info, filterEpic, filterStatus)
+	}
 	items, err := readNotesInDir(info.StoriesDir)
 	if err != nil {
 		return nil, err
@@ -533,6 +561,7 @@ func (m *Manager) ListStories(filterEpic, filterStatus string) ([]StoryInfo, err
 	for _, story := range items {
 		specSlug := stringValue(story.Metadata["spec"])
 		item := StoryInfo{
+			Slug:          slugFromPath(story.Path),
 			Path:          rel(info.ProjectDir, story.Path),
 			Title:         story.Title,
 			Status:        stringValue(story.Metadata["status"]),
@@ -540,6 +569,7 @@ func (m *Manager) ListStories(filterEpic, filterStatus string) ([]StoryInfo, err
 			Spec:          specSlug,
 			TargetVersion: specVersions[specSlug],
 			Blockers:      stringSliceValue(story.Metadata["blockers"]),
+			Backend:       string(workspace.StoryBackendLocal),
 		}
 		if filterEpic != "" && item.Epic != filterEpic {
 			continue
@@ -582,6 +612,12 @@ func (m *Manager) Status() (*ProjectStatus, error) {
 			status.BlockedStories++
 		case "in_progress":
 			status.InProgressStories++
+		}
+		if story.Ready {
+			status.ReadyStories++
+		}
+		if story.BlockedByDeps {
+			status.DependencyBlocked++
 		}
 	}
 	return status, nil

--- a/internal/planning/manager.go
+++ b/internal/planning/manager.go
@@ -57,6 +57,7 @@ type EpicInfo struct {
 }
 
 type StoryInfo struct {
+	Slug          string
 	Path          string
 	Title         string
 	Status        string
@@ -64,6 +65,12 @@ type StoryInfo struct {
 	Spec          string
 	TargetVersion string
 	Blockers      []string
+	Backend       string
+	IssueNumber   int
+	IssueURL      string
+	Ready         bool
+	BlockedByPlan bool
+	BlockedByDeps bool
 }
 
 type VersionStatus struct {
@@ -108,10 +115,11 @@ type EpicBundle struct {
 
 type Manager struct {
 	workspace *workspace.Manager
+	github    GitHubClient
 }
 
 func New(workspaceManager *workspace.Manager) *Manager {
-	return &Manager{workspace: workspaceManager}
+	return &Manager{workspace: workspaceManager, github: newGitHubClient()}
 }
 
 func (m *Manager) CreateBrainstorm(topic string) (*notes.Note, error) {

--- a/internal/planning/manager.go
+++ b/internal/planning/manager.go
@@ -71,6 +71,7 @@ type StoryInfo struct {
 	Ready         bool
 	BlockedByPlan bool
 	BlockedByDeps bool
+	Started       bool
 }
 
 type VersionStatus struct {
@@ -98,6 +99,7 @@ type ProjectStatus struct {
 	InProgressStories int
 	ReadyStories      int
 	DependencyBlocked int
+	ReadyWork         []StoryInfo
 }
 
 type StoryChanges struct {
@@ -570,6 +572,7 @@ func (m *Manager) ListStories(filterEpic, filterStatus string) ([]StoryInfo, err
 			TargetVersion: specVersions[specSlug],
 			Blockers:      stringSliceValue(story.Metadata["blockers"]),
 			Backend:       string(workspace.StoryBackendLocal),
+			Started:       stringValue(story.Metadata["status"]) == "in_progress" || stringValue(story.Metadata["status"]) == "blocked" || stringValue(story.Metadata["status"]) == "done",
 		}
 		if filterEpic != "" && item.Epic != filterEpic {
 			continue
@@ -615,6 +618,7 @@ func (m *Manager) Status() (*ProjectStatus, error) {
 		}
 		if story.Ready {
 			status.ReadyStories++
+			status.ReadyWork = append(status.ReadyWork, story)
 		}
 		if story.BlockedByDeps {
 			status.DependencyBlocked++
@@ -964,14 +968,15 @@ func deriveSpecStatus(current string, stories []StoryInfo) string {
 	allDone := true
 	anyStarted := false
 	for _, item := range stories {
-		switch item.Status {
-		case "done":
+		if item.Status == "done" {
+			if item.Started {
+				anyStarted = true
+			}
+			continue
+		}
+		allDone = false
+		if item.Started {
 			anyStarted = true
-		case "in_progress", "blocked":
-			anyStarted = true
-			allDone = false
-		default:
-			allDone = false
 		}
 	}
 	if allDone {

--- a/internal/workspace/workspace.go
+++ b/internal/workspace/workspace.go
@@ -11,15 +11,59 @@ import (
 )
 
 const (
-	CurrentSchemaVersion = 1
+	CurrentSchemaVersion = 2
 	PlanningModel        = "epic_spec_story_v1"
 )
 
+type StoryBackend string
+
+const (
+	StoryBackendLocal  StoryBackend = "local"
+	StoryBackendGitHub StoryBackend = "github"
+)
+
 type WorkspaceMeta struct {
-	SchemaVersion int    `json:"schema_version"`
-	PlanningModel string `json:"planning_model"`
-	CreatedAt     string `json:"created_at"`
-	UpdatedAt     string `json:"updated_at"`
+	SchemaVersion int          `json:"schema_version"`
+	PlanningModel string       `json:"planning_model"`
+	StoryBackend  StoryBackend `json:"story_backend"`
+	CreatedAt     string       `json:"created_at"`
+	UpdatedAt     string       `json:"updated_at"`
+}
+
+type GitHubState struct {
+	Repo           string                       `json:"repo,omitempty"`
+	RepoURL        string                       `json:"repo_url,omitempty"`
+	DefaultBranch  string                       `json:"default_branch,omitempty"`
+	LastEnabledAt  string                       `json:"last_enabled_at,omitempty"`
+	LastUpdatedAt  string                       `json:"last_updated_at,omitempty"`
+	LastReconciled string                       `json:"last_reconciled_at,omitempty"`
+	Stories        map[string]GitHubStoryRecord `json:"stories"`
+}
+
+type GitHubStoryRecord struct {
+	Slug                  string   `json:"slug"`
+	Title                 string   `json:"title"`
+	Epic                  string   `json:"epic"`
+	Spec                  string   `json:"spec"`
+	Status                string   `json:"status,omitempty"`
+	Description           string   `json:"description,omitempty"`
+	AcceptanceCriteria    []string `json:"acceptance_criteria,omitempty"`
+	Verification          []string `json:"verification,omitempty"`
+	Resources             []string `json:"resources,omitempty"`
+	Dependencies          []string `json:"dependencies,omitempty"`
+	AsyncNotes            []string `json:"async_notes,omitempty"`
+	IssueNumber           int      `json:"issue_number,omitempty"`
+	IssueURL              string   `json:"issue_url,omitempty"`
+	RemoteState           string   `json:"remote_state,omitempty"`
+	PlanningPRNumber      int      `json:"planning_pr_number,omitempty"`
+	PlanningPRURL         string   `json:"planning_pr_url,omitempty"`
+	PlanningPRMerged      bool     `json:"planning_pr_merged,omitempty"`
+	DocRefMode            string   `json:"doc_ref_mode,omitempty"`
+	DocRef                string   `json:"doc_ref,omitempty"`
+	Ready                 bool     `json:"ready,omitempty"`
+	BlockedReasons        []string `json:"blocked_reasons,omitempty"`
+	VisibleReadyMarkerSet bool     `json:"visible_ready_marker_set,omitempty"`
+	UpdatedAt             string   `json:"updated_at,omitempty"`
 }
 
 type MigrationState struct {
@@ -68,6 +112,7 @@ type Info struct {
 	MetaDir        string
 	WorkspaceFile  string
 	MigrationsFile string
+	GitHubFile     string
 }
 
 type InitResult struct {
@@ -127,6 +172,7 @@ func (m *Manager) Resolve() (*Info, error) {
 		MetaDir:        metaDir,
 		WorkspaceFile:  filepath.Join(metaDir, "workspace.json"),
 		MigrationsFile: filepath.Join(metaDir, "migrations.json"),
+		GitHubFile:     filepath.Join(metaDir, "github.json"),
 	}, nil
 }
 
@@ -153,6 +199,7 @@ func (i *Info) ToolManagedSurfaces() []Surface {
 		i.newSurface(".meta/", i.MetaDir, "tool_managed", "dir"),
 		i.newSurface("workspace.json", i.WorkspaceFile, "tool_managed", "file"),
 		i.newSurface("migrations.json", i.MigrationsFile, "tool_managed", "file"),
+		i.newSurface("github.json", i.GitHubFile, "tool_managed", "file"),
 	}
 }
 
@@ -216,6 +263,11 @@ func (m *Manager) Init() (*InitResult, error) {
 		return nil, err
 	} else if created {
 		result.Created = append(result.Created, rel(info.ProjectDir, info.MigrationsFile))
+	}
+	if created, err := ensureGitHubState(info.GitHubFile, now); err != nil {
+		return nil, err
+	} else if created {
+		result.Created = append(result.Created, rel(info.ProjectDir, info.GitHubFile))
 	}
 	if err := recordMigrationRun(info, "init", result.Created, nil, now); err != nil {
 		return nil, err
@@ -283,6 +335,14 @@ func (m *Manager) ReadMigrationState() (*MigrationState, error) {
 	return readMigrationStateFile(info.MigrationsFile)
 }
 
+func (m *Manager) ReadGitHubState() (*GitHubState, error) {
+	info, err := m.Resolve()
+	if err != nil {
+		return nil, err
+	}
+	return readGitHubStateFile(info.GitHubFile)
+}
+
 func readMigrationStateFile(path string) (*MigrationState, error) {
 	raw, err := os.ReadFile(path)
 	if err != nil {
@@ -291,6 +351,18 @@ func readMigrationStateFile(path string) (*MigrationState, error) {
 	var state MigrationState
 	if err := json.Unmarshal(raw, &state); err != nil {
 		return nil, fmt.Errorf("parse migration state: %w", err)
+	}
+	return &state, nil
+}
+
+func readGitHubStateFile(path string) (*GitHubState, error) {
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("read github state: %w", err)
+	}
+	var state GitHubState
+	if err := json.Unmarshal(raw, &state); err != nil {
+		return nil, fmt.Errorf("parse github state: %w", err)
 	}
 	return &state, nil
 }
@@ -349,6 +421,17 @@ func (m *Manager) Doctor() (*DoctorReport, error) {
 			if !contains(report.Broken, "migrations.json") {
 				report.Broken = append(report.Broken, "migrations.json")
 			}
+		}
+	}
+
+	githubState, err := readGitHubStateFile(info.GitHubFile)
+	if err != nil {
+		if !contains(report.Missing, "github.json") {
+			report.Broken = append(report.Broken, "github.json")
+		}
+	} else if err := validateGitHubState(githubState); err != nil {
+		if !contains(report.Broken, "github.json") {
+			report.Broken = append(report.Broken, "github.json")
 		}
 	}
 
@@ -449,6 +532,19 @@ func (m *Manager) repairWorkspace(info *Info, operation string) (*UpdateResult, 
 			result.Updated = append(result.Updated, rel(info.ProjectDir, info.MigrationsFile))
 		}
 	}
+	if created, err := ensureGitHubState(info.GitHubFile, now); err != nil {
+		return nil, err
+	} else if created {
+		result.Created = append(result.Created, rel(info.ProjectDir, info.GitHubFile))
+	} else {
+		updated, err := reconcileGitHubState(info.GitHubFile, now)
+		if err != nil {
+			return nil, err
+		}
+		if updated {
+			result.Updated = append(result.Updated, rel(info.ProjectDir, info.GitHubFile))
+		}
+	}
 	if err := recordMigrationRun(info, operation, result.Created, result.Updated, now); err != nil {
 		return nil, err
 	}
@@ -513,6 +609,18 @@ func reconcileWorkspaceMeta(path, now string) (bool, error) {
 	return true, writeJSON(path, normalized)
 }
 
+func (m *Manager) WriteWorkspaceMeta(meta WorkspaceMeta) error {
+	info, err := m.Resolve()
+	if err != nil {
+		return err
+	}
+	normalized, _, err := normalizeWorkspaceMeta(meta, time.Now().UTC().Format(time.RFC3339))
+	if err != nil {
+		return err
+	}
+	return writeJSON(info.WorkspaceFile, normalized)
+}
+
 func ensureMigrationState(path, now string) (bool, error) {
 	if _, err := os.Stat(path); err == nil {
 		return false, nil
@@ -520,6 +628,16 @@ func ensureMigrationState(path, now string) (bool, error) {
 		return false, err
 	}
 	state := defaultMigrationState(now)
+	return true, writeJSON(path, state)
+}
+
+func ensureGitHubState(path, now string) (bool, error) {
+	if _, err := os.Stat(path); err == nil {
+		return false, nil
+	} else if !os.IsNotExist(err) {
+		return false, err
+	}
+	state := defaultGitHubState(now)
 	return true, writeJSON(path, state)
 }
 
@@ -542,10 +660,30 @@ func reconcileMigrationState(path, now string) (bool, error) {
 	return true, writeJSON(path, normalized)
 }
 
+func reconcileGitHubState(path, now string) (bool, error) {
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		return false, err
+	}
+	var state GitHubState
+	if err := json.Unmarshal(raw, &state); err != nil {
+		return true, writeJSON(path, defaultGitHubState(now))
+	}
+	normalized, changed, err := normalizeGitHubState(state, now)
+	if err != nil {
+		return false, err
+	}
+	if !changed {
+		return false, nil
+	}
+	return true, writeJSON(path, normalized)
+}
+
 func defaultWorkspaceMeta(now string) WorkspaceMeta {
 	return WorkspaceMeta{
 		SchemaVersion: CurrentSchemaVersion,
 		PlanningModel: PlanningModel,
+		StoryBackend:  StoryBackendLocal,
 		CreatedAt:     now,
 		UpdatedAt:     now,
 	}
@@ -557,6 +695,13 @@ func defaultMigrationState(now string) MigrationState {
 		Known:         []string{},
 		LastRunAt:     now,
 		Status:        "current",
+	}
+}
+
+func defaultGitHubState(now string) GitHubState {
+	return GitHubState{
+		LastUpdatedAt: now,
+		Stories:       map[string]GitHubStoryRecord{},
 	}
 }
 
@@ -576,6 +721,10 @@ func normalizeWorkspaceMeta(meta WorkspaceMeta, now string) (WorkspaceMeta, bool
 	}
 	if normalized.PlanningModel == "" {
 		normalized.PlanningModel = PlanningModel
+		changed = true
+	}
+	if normalized.StoryBackend == "" {
+		normalized.StoryBackend = StoryBackendLocal
 		changed = true
 	}
 	if normalized.CreatedAt == "" {
@@ -621,6 +770,23 @@ func normalizeMigrationState(state MigrationState, now string) (MigrationState, 
 	return normalized, changed, nil
 }
 
+func normalizeGitHubState(state GitHubState, now string) (GitHubState, bool, error) {
+	normalized := state
+	changed := false
+	if normalized.Stories == nil {
+		normalized.Stories = map[string]GitHubStoryRecord{}
+		changed = true
+	}
+	if normalized.LastUpdatedAt == "" {
+		normalized.LastUpdatedAt = now
+		changed = true
+	}
+	if changed {
+		normalized.LastUpdatedAt = now
+	}
+	return normalized, changed, nil
+}
+
 func validateWorkspaceMeta(meta *WorkspaceMeta) error {
 	switch {
 	case meta.SchemaVersion == 0:
@@ -631,6 +797,8 @@ func validateWorkspaceMeta(meta *WorkspaceMeta) error {
 		return fmt.Errorf("planning_model is required")
 	case meta.PlanningModel != PlanningModel:
 		return fmt.Errorf("planning_model %q is not supported", meta.PlanningModel)
+	case meta.StoryBackend != "" && meta.StoryBackend != StoryBackendLocal && meta.StoryBackend != StoryBackendGitHub:
+		return fmt.Errorf("story_backend %q is not supported", meta.StoryBackend)
 	case meta.CreatedAt == "":
 		return fmt.Errorf("created_at is required")
 	case meta.UpdatedAt == "":
@@ -638,6 +806,13 @@ func validateWorkspaceMeta(meta *WorkspaceMeta) error {
 	default:
 		return nil
 	}
+}
+
+func validateGitHubState(state *GitHubState) error {
+	if state == nil {
+		return fmt.Errorf("github state is required")
+	}
+	return nil
 }
 
 func validateMigrationState(state *MigrationState) error {
@@ -685,6 +860,18 @@ func recordMigrationRun(info *Info, operation string, created, updated []string,
 	return writeJSON(info.MigrationsFile, state)
 }
 
+func (m *Manager) WriteGitHubState(state GitHubState) error {
+	info, err := m.Resolve()
+	if err != nil {
+		return err
+	}
+	normalized, _, err := normalizeGitHubState(state, time.Now().UTC().Format(time.RFC3339))
+	if err != nil {
+		return err
+	}
+	return writeJSON(info.GitHubFile, normalized)
+}
+
 func writeJSON(path string, v any) error {
 	raw, err := json.MarshalIndent(v, "", "  ")
 	if err != nil {
@@ -718,11 +905,11 @@ func classifyDoctorWorkspace(missing, broken []string) string {
 }
 
 func isPartialWorkspace(missing []string) bool {
-	return contains(missing, ".meta/") || contains(missing, "workspace.json") || contains(missing, "migrations.json")
+	return contains(missing, ".meta/") || contains(missing, "workspace.json") || contains(missing, "migrations.json") || contains(missing, "github.json")
 }
 
 func isBrokenWorkspace(broken []string) bool {
-	return contains(broken, "workspace.json") || contains(broken, "migrations.json")
+	return contains(broken, "workspace.json") || contains(broken, "migrations.json") || contains(broken, "github.json")
 }
 
 func guidanceForWorkspaceStatus(status string) []string {

--- a/internal/workspace/workspace.go
+++ b/internal/workspace/workspace.go
@@ -52,6 +52,11 @@ type GitHubStoryRecord struct {
 	Resources             []string `json:"resources,omitempty"`
 	Dependencies          []string `json:"dependencies,omitempty"`
 	AsyncNotes            []string `json:"async_notes,omitempty"`
+	ScopeFit              string   `json:"scope_fit,omitempty"`
+	VerticalSliceCheck    string   `json:"vertical_slice_check,omitempty"`
+	HiddenPrerequisites   string   `json:"hidden_prerequisites,omitempty"`
+	VerificationGaps      string   `json:"verification_gaps,omitempty"`
+	RewriteRecommendation string   `json:"rewrite_recommendation,omitempty"`
 	IssueNumber           int      `json:"issue_number,omitempty"`
 	IssueURL              string   `json:"issue_url,omitempty"`
 	RemoteState           string   `json:"remote_state,omitempty"`

--- a/internal/workspace/workspace_test.go
+++ b/internal/workspace/workspace_test.go
@@ -29,6 +29,7 @@ func TestInitCreatesPlanWorkspace(t *testing.T) {
 		filepath.Join(root, ".plan", "ROADMAP.md"),
 		filepath.Join(root, ".plan", ".meta", "workspace.json"),
 		filepath.Join(root, ".plan", ".meta", "migrations.json"),
+		filepath.Join(root, ".plan", ".meta", "github.json"),
 	} {
 		if _, err := os.Stat(path); err != nil {
 			t.Fatalf("expected %s: %v", path, err)
@@ -49,7 +50,7 @@ func TestWorkspaceContractSeparatesUserAuthoredAndToolManagedSurfaces(t *testing
 	if len(contract.UserAuthored) != 6 {
 		t.Fatalf("unexpected user-authored surface count: %d", len(contract.UserAuthored))
 	}
-	if len(contract.ToolManaged) != 3 {
+	if len(contract.ToolManaged) != 4 {
 		t.Fatalf("unexpected tool-managed surface count: %d", len(contract.ToolManaged))
 	}
 
@@ -113,6 +114,9 @@ func TestDoctorReportsCurrentAfterInit(t *testing.T) {
 	}
 	if report.PlanningModel != PlanningModel {
 		t.Fatalf("unexpected planning model: %+v", report)
+	}
+	if report.SchemaVersion != CurrentSchemaVersion {
+		t.Fatalf("unexpected schema version: %+v", report)
 	}
 }
 
@@ -215,6 +219,9 @@ func TestUpdateRepairsToolManagedStateWithoutTouchingUserNotes(t *testing.T) {
 	if err := os.Remove(filepath.Join(root, ".plan", ".meta", "migrations.json")); err != nil {
 		t.Fatal(err)
 	}
+	if err := os.Remove(filepath.Join(root, ".plan", ".meta", "github.json")); err != nil {
+		t.Fatal(err)
+	}
 
 	result, err := manager.Update()
 	if err != nil {
@@ -225,6 +232,9 @@ func TestUpdateRepairsToolManagedStateWithoutTouchingUserNotes(t *testing.T) {
 	}
 	if !contains(result.Created, ".plan/.meta/migrations.json") {
 		t.Fatalf("expected migration state recreation: %+v", result)
+	}
+	if !contains(result.Created, ".plan/.meta/github.json") {
+		t.Fatalf("expected GitHub state recreation: %+v", result)
 	}
 
 	raw, err := os.ReadFile(projectPath)


### PR DESCRIPTION
## Summary

- add GitHub-backed story execution mode with `plan github enable` and `plan github reconcile`
- keep brainstorms, epics, and specs local while storing stories in GitHub Issues with a managed issue contract
- derive blocked/ready work from planning merge state plus issue dependencies, and surface async-safe ready work in the CLI

## Testing

- [x] `go test ./...`
- [x] `go build ./...`
- [x] Other: `go run . status --project .`
- [x] Other: `go run . check --project .`
- [x] Other: `git diff --check`

## Release Notes

<!-- This section is promoted into the published GitHub release body when this PR ships. -->
- User-facing change: `plan` can now use GitHub Issues as the execution backend for stories while keeping shaping docs local in `.plan`.
- Planning or workflow impact: planning branches can publish issue-backed stories with SHA doc permalinks and later reconcile them to canonical `main` links after merge.
- Follow-up work: dogfood the GitHub execution flow on a real feature branch and tighten docs around migration/enablement.

## Planning

- Related epic/spec/story: `.plan/epics/github-story-backend-and-preflight.md`
- Related epic/spec/story: `.plan/epics/issue-contract-and-planning-link-lifecycle.md`
- Related epic/spec/story: `.plan/epics/dependency-aware-issue-readiness.md`
