### PR TITLE
docs: define github issue workflow

### DIFF
--- a/.plan/PROJECT.md
+++ b/.plan/PROJECT.md
@@ -32,6 +32,11 @@ memory/context-management bloat.
 - Stories are created only after spec approval.
 - Stories should be execution-ready and verification-aware.
 - New passes should improve clarity, boundedness, and agent executability.
+- If GitHub story mode is enabled, stories live in GitHub Issues rather than
+  local markdown notes.
+- GitHub execution follows a queue loop: establish ready work, grab the next
+  issue or issues, ship a PR, review until ready, squash-merge, return to
+  `main`, run `plan update`, reconcile, then grab the next ready work.
 
 ## Notes
 
@@ -39,3 +44,4 @@ memory/context-management bloat.
 - v5 focuses on skill quality, shaping, and evals.
 - v6 focuses on story slicing and critique.
 - v7 is GitHub sync only if local planning quality clearly earns the added complexity.
+- v8 focuses on guided co-planning and stage-by-stage execution handoffs.

--- a/README.md
+++ b/README.md
@@ -5,6 +5,9 @@
 It keeps planning material in `.plan/` and focuses on one job: turning rough
 ideas into shaped, execution-ready plans that agents can follow cleanly.
 
+If GitHub story mode is enabled, brainstorms, epics, and specs stay local in
+`.plan/`, while stories execute as GitHub Issues.
+
 ## Philosophy
 
 - local-first
@@ -37,6 +40,16 @@ Workflow entry:
 8. Slice into stories
 9. Critique story readiness
 
+Execution loop in GitHub mode:
+
+1. Establish queue
+2. Grab next ready issue or issues
+3. Implement on a branch and open PR
+4. Review and iterate until ready
+5. Squash-merge
+6. Return to `main`, pull latest, update and reconcile
+7. Grab next ready issue and repeat
+
 The default path stays small. New shaping passes should improve the same
 artifacts rather than add new top-level planning objects.
 
@@ -54,6 +67,7 @@ my-project/
     .meta/
       workspace.json
       migrations.json
+      github.json
 ```
 
 User-authored planning material lives in:
@@ -63,12 +77,13 @@ User-authored planning material lives in:
 - `.plan/brainstorms/`
 - `.plan/epics/`
 - `.plan/specs/`
-- `.plan/stories/`
+- `.plan/stories/` in local story mode
 
 Tool-owned state lives only in:
 
 - `.plan/.meta/workspace.json`
 - `.plan/.meta/migrations.json`
+- `.plan/.meta/github.json` when GitHub story mode is enabled
 
 `plan update` may repair or normalize tool-owned state. It must not rewrite
 user-authored planning notes just to migrate product direction.
@@ -108,10 +123,36 @@ Full guide:
 - `plan epic create|promote|list|show|shape`
 - `plan spec show|edit|status|analyze|checklist`
 - `plan story create|update|list|show|slice|critique`
+- `plan github enable|reconcile`
 - `plan roadmap show|edit`
 - `plan check`
 - `plan status`
 - `plan skills install|targets`
+
+## GitHub Queue Workflow
+
+For GitHub-backed stories, use this loop:
+
+```bash
+plan status --project .
+
+# do issue work on a branch and merge the PR
+
+git switch main
+git pull --ff-only origin main
+plan update --project .
+plan github reconcile --project . --update-visible
+plan status --project .
+```
+
+Rules:
+
+- use `plan status --project .` as the queue view
+- take only issues shown in `ready_work`
+- work on a feature branch, not on `main`
+- squash-merge the PR when work is accepted
+- after merge, always return to `main`, pull, update, and reconcile before
+  grabbing the next issue
 
 ## Roadmap Direction
 
@@ -121,6 +162,7 @@ Product phases, not release-tag numbers:
 - `v5`: Planning Skills, Shaping, and Evals
 - `v6`: Story Slicing and Execution Readiness
 - `v7`: External Sync, only if the local loop clearly wins
+- `v8`: Guided Co-Planning System
 
 Release tags can stay in `v0.x.y` semver until a separate `1.0` decision.
 

--- a/docs/using-plan.md
+++ b/docs/using-plan.md
@@ -13,6 +13,7 @@ Right now:
 - `story slice` and `story critique` are part of the current workflow
 - `plan check` validates the spec-to-story handoff more aggressively than it
   did in earlier versions
+- GitHub-backed story execution is available when you enable GitHub story mode
 
 So this guide covers the current command surface as it exists today.
 
@@ -64,6 +65,7 @@ Workflow entry:
   .meta/
     workspace.json
     migrations.json
+    github.json
 ```
 
 Meaning:
@@ -73,8 +75,8 @@ Meaning:
 - `brainstorms/`: discovery notes
 - `epics/`: outcome boundaries
 - `specs/`: canonical execution contracts
-- `stories/`: execution-ready slices
-- `.meta/`: tool-owned state only
+- `stories/`: execution-ready slices in local story mode
+- `.meta/`: tool-owned state only, including GitHub story metadata when enabled
 
 ## New Repo Setup
 
@@ -104,6 +106,29 @@ If the repo already exists and you want `plan` to manage it:
 plan adopt --project .
 plan doctor --project .
 ```
+
+## Optional: Enable GitHub Story Mode
+
+If you want brainstorms, epics, and specs local but stories stored as GitHub
+Issues:
+
+```bash
+plan update --project .
+plan github enable --project .
+```
+
+Preconditions:
+
+- `gh` is installed
+- `gh auth status` passes
+- the repo has GitHub Issues enabled
+- local story notes are not still active in `.plan/stories/`
+
+When GitHub story mode is enabled:
+
+- stories are created as GitHub Issues
+- `.plan/.meta/github.json` becomes the local issue-state index
+- `plan status --project .` shows `ready_work` after reconcile
 
 ## Step-By-Step Workflow
 
@@ -362,11 +387,52 @@ plan story create --project . newsletter-system "Build template editor" \
   --verify "Manually verify the editor flow"
 ```
 
+If GitHub story mode is enabled, the same command creates a GitHub Issue-backed
+story instead of a local markdown story note.
+
 Important rules:
 
 - a story requires at least one acceptance criterion
 - a story requires at least one verification step
 - story creation is blocked until the spec is `approved`
+
+### 11A. GitHub Queue Workflow
+
+If stories are GitHub-backed, use this execution loop:
+
+1. Establish queue with `plan status --project .`
+2. Grab issue or issues from `ready_work`
+3. Do the work on a feature branch and open a PR
+4. Review and iterate until the PR is ready
+5. Squash-merge the PR
+6. Return to `main`
+7. Pull latest changes
+8. Run `plan update --project .`
+9. Run `plan github reconcile --project . --update-visible`
+10. Re-check `plan status --project .`
+11. Grab the next ready issue or issues and repeat
+
+Recommended commands:
+
+```bash
+plan status --project .
+
+# do issue work on a branch and merge the PR
+
+git switch main
+git pull --ff-only origin main
+plan update --project .
+plan github reconcile --project . --update-visible
+plan status --project .
+```
+
+Use this model:
+
+- `plan status` = queue view
+- GitHub Issue = execution unit
+- PR = implementation review loop
+- squash-merge = queue advancement
+- `update` + `reconcile` = refresh local truth before taking the next issue
 
 Show a story:
 
@@ -571,6 +637,7 @@ Top-level commands available today:
 - `plan epic`
 - `plan spec`
 - `plan story`
+- `plan github`
 - `plan roadmap`
 - `plan check`
 - `plan status`
@@ -584,4 +651,5 @@ plan brainstorm --help
 plan epic --help
 plan spec --help
 plan story --help
+plan github --help
 ```


### PR DESCRIPTION
## Summary
- document the GitHub issue execution loop for plan
- add GitHub story mode guidance to README and usage docs
- align project rules with queue-first GitHub execution

## Verification
- git diff --check