### PR TITLE
feat: add guided brainstorm session foundation

### DIFF
--- a/.plan/.meta/github.json
+++ b/.plan/.meta/github.json
@@ -3,7 +3,8 @@
   "repo_url": "https://github.com/JimmyMcBride/plan",
   "default_branch": "main",
   "last_enabled_at": "2026-04-20T03:04:26Z",
-  "last_updated_at": "2026-04-20T03:06:24Z",
+  "last_updated_at": "2026-04-20T03:37:40Z",
+  "last_reconciled_at": "2026-04-20T03:37:40Z",
   "stories": {
     "add-brainstorm-stage-recap-and-stop-flow": {
       "slug": "add-brainstorm-stage-recap-and-stop-flow",
@@ -30,9 +31,11 @@
       "remote_state": "open",
       "planning_pr_number": 9,
       "planning_pr_url": "https://github.com/JimmyMcBride/plan/pull/9",
-      "doc_ref_mode": "sha",
-      "doc_ref": "8ba14acadf5a04439647c6367bd5f19fa05fe071",
-      "updated_at": "2026-04-20T03:07:30Z"
+      "planning_pr_merged": true,
+      "doc_ref_mode": "main",
+      "doc_ref": "main",
+      "visible_ready_marker_set": true,
+      "updated_at": "2026-04-20T03:37:36Z"
     },
     "add-cluster-reflection-and-gap-guidance": {
       "slug": "add-cluster-reflection-and-gap-guidance",
@@ -58,9 +61,11 @@
       "remote_state": "open",
       "planning_pr_number": 9,
       "planning_pr_url": "https://github.com/JimmyMcBride/plan/pull/9",
-      "doc_ref_mode": "sha",
-      "doc_ref": "8ba14acadf5a04439647c6367bd5f19fa05fe071",
-      "updated_at": "2026-04-20T03:07:26Z"
+      "planning_pr_merged": true,
+      "doc_ref_mode": "main",
+      "doc_ref": "main",
+      "visible_ready_marker_set": true,
+      "updated_at": "2026-04-20T03:37:36Z"
     },
     "add-guided-session-state-model": {
       "slug": "add-guided-session-state-model",
@@ -83,9 +88,11 @@
       "remote_state": "open",
       "planning_pr_number": 9,
       "planning_pr_url": "https://github.com/JimmyMcBride/plan/pull/9",
-      "doc_ref_mode": "sha",
-      "doc_ref": "8ba14acadf5a04439647c6367bd5f19fa05fe071",
-      "updated_at": "2026-04-20T03:06:24Z"
+      "planning_pr_merged": true,
+      "doc_ref_mode": "main",
+      "doc_ref": "main",
+      "visible_ready_marker_set": true,
+      "updated_at": "2026-04-20T03:37:37Z"
     },
     "add-multi-session-switching-and-coverage": {
       "slug": "add-multi-session-switching-and-coverage",
@@ -111,9 +118,11 @@
       "remote_state": "open",
       "planning_pr_number": 9,
       "planning_pr_url": "https://github.com/JimmyMcBride/plan/pull/9",
-      "doc_ref_mode": "sha",
-      "doc_ref": "8ba14acadf5a04439647c6367bd5f19fa05fe071",
-      "updated_at": "2026-04-20T03:07:22Z"
+      "planning_pr_merged": true,
+      "doc_ref_mode": "main",
+      "doc_ref": "main",
+      "visible_ready_marker_set": true,
+      "updated_at": "2026-04-20T03:37:37Z"
     },
     "add-reopen-impact-summary-and-needs-review-markers": {
       "slug": "add-reopen-impact-summary-and-needs-review-markers",
@@ -139,9 +148,11 @@
       "remote_state": "open",
       "planning_pr_number": 9,
       "planning_pr_url": "https://github.com/JimmyMcBride/plan/pull/9",
-      "doc_ref_mode": "sha",
-      "doc_ref": "8ba14acadf5a04439647c6367bd5f19fa05fe071",
-      "updated_at": "2026-04-20T03:07:46Z"
+      "planning_pr_merged": true,
+      "doc_ref_mode": "main",
+      "doc_ref": "main",
+      "visible_ready_marker_set": true,
+      "updated_at": "2026-04-20T03:37:37Z"
     },
     "add-roadmap-parking-writes-and-source-links": {
       "slug": "add-roadmap-parking-writes-and-source-links",
@@ -167,9 +178,11 @@
       "remote_state": "open",
       "planning_pr_number": 9,
       "planning_pr_url": "https://github.com/JimmyMcBride/plan/pull/9",
-      "doc_ref_mode": "sha",
-      "doc_ref": "8ba14acadf5a04439647c6367bd5f19fa05fe071",
-      "updated_at": "2026-04-20T03:07:54Z"
+      "planning_pr_merged": true,
+      "doc_ref_mode": "main",
+      "doc_ref": "main",
+      "visible_ready_marker_set": true,
+      "updated_at": "2026-04-20T03:37:38Z"
     },
     "implement-brainstorm-to-epic-handoff": {
       "slug": "implement-brainstorm-to-epic-handoff",
@@ -196,9 +209,11 @@
       "remote_state": "open",
       "planning_pr_number": 9,
       "planning_pr_url": "https://github.com/JimmyMcBride/plan/pull/9",
-      "doc_ref_mode": "sha",
-      "doc_ref": "8ba14acadf5a04439647c6367bd5f19fa05fe071",
-      "updated_at": "2026-04-20T03:07:34Z"
+      "planning_pr_merged": true,
+      "doc_ref_mode": "main",
+      "doc_ref": "main",
+      "visible_ready_marker_set": true,
+      "updated_at": "2026-04-20T03:37:38Z"
     },
     "implement-downstream-review-checkpoints": {
       "slug": "implement-downstream-review-checkpoints",
@@ -224,9 +239,11 @@
       "remote_state": "open",
       "planning_pr_number": 9,
       "planning_pr_url": "https://github.com/JimmyMcBride/plan/pull/9",
-      "doc_ref_mode": "sha",
-      "doc_ref": "8ba14acadf5a04439647c6367bd5f19fa05fe071",
-      "updated_at": "2026-04-20T03:07:50Z"
+      "planning_pr_merged": true,
+      "doc_ref_mode": "main",
+      "doc_ref": "main",
+      "visible_ready_marker_set": true,
+      "updated_at": "2026-04-20T03:37:38Z"
     },
     "implement-epic-to-spec-handoff": {
       "slug": "implement-epic-to-spec-handoff",
@@ -252,9 +269,11 @@
       "remote_state": "open",
       "planning_pr_number": 9,
       "planning_pr_url": "https://github.com/JimmyMcBride/plan/pull/9",
-      "doc_ref_mode": "sha",
-      "doc_ref": "8ba14acadf5a04439647c6367bd5f19fa05fe071",
-      "updated_at": "2026-04-20T03:07:38Z"
+      "planning_pr_merged": true,
+      "doc_ref_mode": "main",
+      "doc_ref": "main",
+      "visible_ready_marker_set": true,
+      "updated_at": "2026-04-20T03:37:39Z"
     },
     "implement-guided-story-creation-handoff": {
       "slug": "implement-guided-story-creation-handoff",
@@ -280,9 +299,11 @@
       "remote_state": "open",
       "planning_pr_number": 9,
       "planning_pr_url": "https://github.com/JimmyMcBride/plan/pull/9",
-      "doc_ref_mode": "sha",
-      "doc_ref": "8ba14acadf5a04439647c6367bd5f19fa05fe071",
-      "updated_at": "2026-04-20T03:07:42Z"
+      "planning_pr_merged": true,
+      "doc_ref_mode": "main",
+      "doc_ref": "main",
+      "visible_ready_marker_set": true,
+      "updated_at": "2026-04-20T03:37:39Z"
     },
     "implement-guided-vision-intake": {
       "slug": "implement-guided-vision-intake",
@@ -305,9 +326,11 @@
       "remote_state": "open",
       "planning_pr_number": 9,
       "planning_pr_url": "https://github.com/JimmyMcBride/plan/pull/9",
-      "doc_ref_mode": "sha",
-      "doc_ref": "8ba14acadf5a04439647c6367bd5f19fa05fe071",
-      "updated_at": "2026-04-20T03:05:34Z"
+      "planning_pr_merged": true,
+      "doc_ref_mode": "main",
+      "doc_ref": "main",
+      "visible_ready_marker_set": true,
+      "updated_at": "2026-04-20T03:37:39Z"
     },
     "implement-resume-flow-and-session-menu": {
       "slug": "implement-resume-flow-and-session-menu",
@@ -333,9 +356,11 @@
       "remote_state": "open",
       "planning_pr_number": 9,
       "planning_pr_url": "https://github.com/JimmyMcBride/plan/pull/9",
-      "doc_ref_mode": "sha",
-      "doc_ref": "8ba14acadf5a04439647c6367bd5f19fa05fe071",
-      "updated_at": "2026-04-20T03:07:18Z"
+      "planning_pr_merged": true,
+      "doc_ref_mode": "main",
+      "doc_ref": "main",
+      "visible_ready_marker_set": true,
+      "updated_at": "2026-04-20T03:37:40Z"
     }
   }
 }

--- a/.plan/.meta/migrations.json
+++ b/.plan/.meta/migrations.json
@@ -1,11 +1,11 @@
 {
   "schema_version": 1,
   "known": [],
-  "last_run_at": "2026-04-20T03:04:12Z",
+  "last_run_at": "2026-04-20T03:37:35Z",
   "status": "current",
   "last_operation": "update",
   "last_created": [
-    ".plan/.meta/github.json"
+    ".plan/stories"
   ],
   "history": [
     {
@@ -14,6 +14,14 @@
       "status": "current",
       "created": [
         ".plan/.meta/github.json"
+      ]
+    },
+    {
+      "operation": "update",
+      "at": "2026-04-20T03:37:35Z",
+      "status": "current",
+      "created": [
+        ".plan/stories"
       ]
     }
   ]

--- a/cmd/brainstorm.go
+++ b/cmd/brainstorm.go
@@ -25,6 +25,9 @@ func newBrainstormCommand() *cobra.Command {
 		Short: "Start a new brainstorm",
 		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
+			reader := bufio.NewReader(cmd.InOrStdin())
+			out := cmd.OutOrStdout()
+
 			note, err := planningManager().CreateBrainstormWithInput(planning.BrainstormCreateInput{
 				Topic:         args[0],
 				FocusQuestion: focusQuestion,
@@ -33,7 +36,32 @@ func newBrainstormCommand() *cobra.Command {
 			if err != nil {
 				return err
 			}
-			fmt.Printf("Created brainstorm %s\n", note.Path)
+			if _, err := planningManager().EnsureGuidedBrainstormSession(args[0]); err != nil {
+				return err
+			}
+			fmt.Fprintf(out, "Created brainstorm %s\n", note.Path)
+
+			vision, err := promptSectionValue(reader, out, "Vision", "Describe the vision in plain language. What do you see in your head? Focus on the outcome first, not the implementation.")
+			if err != nil {
+				return err
+			}
+			if _, _, err := planningManager().UpdateGuidedBrainstormIntake(args[0], planning.GuidedBrainstormIntakeInput{
+				Vision: vision,
+			}); err != nil {
+				return err
+			}
+
+			supportingMaterial, err := promptSectionValue(reader, out, "Supporting Material", "List any relevant docs, links, or research you want to provide for this brainstorm. Enter one per line. Leave empty if none.")
+			if err != nil {
+				return err
+			}
+			note, session, err := planningManager().UpdateGuidedBrainstormIntake(args[0], planning.GuidedBrainstormIntakeInput{
+				SupportingMaterial: supportingMaterial,
+			})
+			if err != nil {
+				return err
+			}
+			fmt.Fprintf(out, "Guided brainstorm session ready for %s\nSummary: %s\nNext: %s\n", note.Path, session.Summary, session.NextAction)
 			return nil
 		},
 	}

--- a/cmd/brainstorm_test.go
+++ b/cmd/brainstorm_test.go
@@ -140,3 +140,59 @@ func TestBrainstormChallengeCommandPersistsClustersAndResumes(t *testing.T) {
 		t.Fatalf("expected simpler alternative after resume:\n%s", note.Content)
 	}
 }
+
+func TestBrainstormStartGuidesVisionIntakeAndCreatesSession(t *testing.T) {
+	root := t.TempDir()
+	ws := workspace.New(root)
+	if _, err := ws.Init(); err != nil {
+		t.Fatal(err)
+	}
+
+	input := strings.Join([]string{
+		"I want plan to guide me from a rough vision to execution-ready work without making me fill out a template first.",
+		"",
+		"docs/guided-planning-notes.md",
+		"https://example.com/research/guided-planning",
+		"",
+	}, "\n")
+
+	var output bytes.Buffer
+	command := newRootCmd()
+	command.SetOut(&output)
+	command.SetErr(&output)
+	command.SetIn(strings.NewReader(input))
+	command.SetArgs([]string{"--project", root, "brainstorm", "start", "Guided Planning"})
+	if err := command.Execute(); err != nil {
+		t.Fatalf("expected guided brainstorm start to succeed: %v\n%s", err, output.String())
+	}
+
+	note, err := notes.Read(filepath.Join(root, ".plan", "brainstorms", "guided-planning.md"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := notes.ExtractSection(note.Content, "Vision"); got != "I want plan to guide me from a rough vision to execution-ready work without making me fill out a template first." {
+		t.Fatalf("unexpected vision section:\n%s", got)
+	}
+	supporting := notes.ExtractSection(note.Content, "Supporting Material")
+	if !strings.Contains(supporting, "- docs/guided-planning-notes.md") || !strings.Contains(supporting, "- https://example.com/research/guided-planning") {
+		t.Fatalf("unexpected supporting material section:\n%s", supporting)
+	}
+
+	state, err := ws.ReadGuidedSessionState()
+	if err != nil {
+		t.Fatal(err)
+	}
+	session, ok := state.Sessions["brainstorm/guided-planning"]
+	if !ok {
+		t.Fatalf("expected guided session record: %+v", state)
+	}
+	if session.CurrentStage != "brainstorm" || session.CurrentClusterLabel != "vision-intake" {
+		t.Fatalf("unexpected guided session progress: %+v", session)
+	}
+	if session.NextAction != "Continue guided brainstorm clarification." {
+		t.Fatalf("unexpected guided session next action: %+v", session)
+	}
+	if !strings.Contains(output.String(), "Created brainstorm .plan/brainstorms/guided-planning.md") {
+		t.Fatalf("expected creation output:\n%s", output.String())
+	}
+}

--- a/internal/planning/guided_session.go
+++ b/internal/planning/guided_session.go
@@ -1,0 +1,153 @@
+package planning
+
+import (
+	"fmt"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"plan/internal/notes"
+	"plan/internal/workspace"
+)
+
+type GuidedBrainstormIntakeInput struct {
+	Vision             string
+	SupportingMaterial string
+}
+
+func (m *Manager) EnsureGuidedBrainstormSession(brainstormSlug string) (*workspace.GuidedSessionRecord, error) {
+	info, err := m.workspace.EnsureInitialized()
+	if err != nil {
+		return nil, err
+	}
+	brainstormPath := filepath.Join(info.BrainstormsDir, slugify(brainstormSlug)+".md")
+	note, err := notes.Read(brainstormPath)
+	if err != nil {
+		return nil, err
+	}
+	if note.Type != "brainstorm" {
+		return nil, fmt.Errorf("%s is not a brainstorm note", note.Path)
+	}
+	return m.upsertGuidedBrainstormSession(note)
+}
+
+func (m *Manager) UpdateGuidedBrainstormIntake(brainstormSlug string, input GuidedBrainstormIntakeInput) (*notes.Note, *workspace.GuidedSessionRecord, error) {
+	info, err := m.workspace.EnsureInitialized()
+	if err != nil {
+		return nil, nil, err
+	}
+	path := filepath.Join(info.BrainstormsDir, slugify(brainstormSlug)+".md")
+	note, err := notes.Read(path)
+	if err != nil {
+		return nil, nil, err
+	}
+	if note.Type != "brainstorm" {
+		return nil, nil, fmt.Errorf("%s is not a brainstorm note", note.Path)
+	}
+
+	body := note.Content
+	if strings.TrimSpace(input.Vision) != "" {
+		body = notes.SetSection(body, "Vision", strings.TrimSpace(input.Vision))
+	}
+	if strings.TrimSpace(input.SupportingMaterial) != "" {
+		body = notes.SetSection(body, "Supporting Material", normalizeBulletList(input.SupportingMaterial))
+	}
+
+	updated, err := notes.Update(path, notes.UpdateInput{Body: &body})
+	if err != nil {
+		return nil, nil, err
+	}
+	session, err := m.upsertGuidedBrainstormSession(updated)
+	if err != nil {
+		return nil, nil, err
+	}
+	return m.relNote(updated, info.ProjectDir), session, nil
+}
+
+func (m *Manager) ReadGuidedSession(chainID string) (*workspace.GuidedSessionRecord, error) {
+	state, err := m.workspace.ReadGuidedSessionState()
+	if err != nil {
+		return nil, err
+	}
+	record, ok := state.Sessions[strings.TrimSpace(chainID)]
+	if !ok {
+		return nil, fmt.Errorf("guided session %q not found", chainID)
+	}
+	return &record, nil
+}
+
+func (m *Manager) upsertGuidedBrainstormSession(note *notes.Note) (*workspace.GuidedSessionRecord, error) {
+	state, err := m.workspace.ReadGuidedSessionState()
+	if err != nil {
+		return nil, err
+	}
+
+	now := time.Now().UTC().Format(time.RFC3339)
+	slug := slugFromPath(note.Path)
+	chainID := guidedChainID(slug)
+	record, exists := state.Sessions[chainID]
+	if !exists {
+		record = workspace.GuidedSessionRecord{
+			ChainID:       chainID,
+			Brainstorm:    slug,
+			StageStatuses: map[string]string{},
+			CreatedAt:     now,
+		}
+	}
+	if record.Brainstorm == "" {
+		record.Brainstorm = slug
+	}
+	if record.CurrentStage == "" {
+		record.CurrentStage = "brainstorm"
+	}
+	if record.CurrentCluster == 0 {
+		record.CurrentCluster = 1
+	}
+	if record.CurrentClusterLabel == "" {
+		record.CurrentClusterLabel = "vision-intake"
+	}
+	if record.StageStatuses == nil {
+		record.StageStatuses = map[string]string{}
+	}
+	record.StageStatuses["brainstorm"] = "in_progress"
+	record.Summary = summarizeBrainstormSession(note)
+	record.NextAction = nextBrainstormSessionAction(note)
+	record.UpdatedAt = now
+
+	state.LastActiveChain = chainID
+	state.LastUpdatedAt = now
+	state.Sessions[chainID] = record
+	if err := m.workspace.WriteGuidedSessionState(*state); err != nil {
+		return nil, err
+	}
+	return &record, nil
+}
+
+func guidedChainID(brainstormSlug string) string {
+	return fmt.Sprintf("brainstorm/%s", slugify(brainstormSlug))
+}
+
+func summarizeBrainstormSession(note *notes.Note) string {
+	var parts []string
+	if strings.TrimSpace(notes.ExtractSection(note.Content, "Vision")) != "" {
+		parts = append(parts, "Vision captured.")
+	} else {
+		parts = append(parts, "Vision still missing.")
+	}
+	if strings.TrimSpace(notes.ExtractSection(note.Content, "Supporting Material")) != "" {
+		parts = append(parts, "Supporting material recorded.")
+	} else {
+		parts = append(parts, "No supporting material recorded yet.")
+	}
+	return strings.Join(parts, " ")
+}
+
+func nextBrainstormSessionAction(note *notes.Note) string {
+	if strings.TrimSpace(notes.ExtractSection(note.Content, "Vision")) == "" {
+		return "Capture the user's vision in plain language."
+	}
+	if strings.TrimSpace(notes.ExtractSection(note.Content, "Supporting Material")) == "" {
+		return "Ask the user for any relevant docs, links, or research to carry into the brainstorm."
+	}
+	return "Continue guided brainstorm clarification."
+}

--- a/internal/planning/guided_session_test.go
+++ b/internal/planning/guided_session_test.go
@@ -1,0 +1,81 @@
+package planning
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"plan/internal/notes"
+	"plan/internal/workspace"
+)
+
+func TestGuidedBrainstormSessionPersistsChainStateAndStaysStable(t *testing.T) {
+	root := t.TempDir()
+	ws := workspace.New(root)
+	if _, err := ws.Init(); err != nil {
+		t.Fatal(err)
+	}
+	manager := New(ws)
+	if _, err := manager.CreateBrainstorm("Guided Flow"); err != nil {
+		t.Fatal(err)
+	}
+
+	first, err := manager.EnsureGuidedBrainstormSession("guided-flow")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if first.ChainID != "brainstorm/guided-flow" {
+		t.Fatalf("unexpected chain id: %+v", first)
+	}
+	if first.CurrentStage != "brainstorm" || first.CurrentCluster != 1 || first.CurrentClusterLabel != "vision-intake" {
+		t.Fatalf("unexpected session progress: %+v", first)
+	}
+	if first.StageStatuses["brainstorm"] != "in_progress" {
+		t.Fatalf("expected brainstorm stage to be in progress: %+v", first)
+	}
+	createdAt := first.CreatedAt
+
+	updatedNote, second, err := manager.UpdateGuidedBrainstormIntake("guided-flow", GuidedBrainstormIntakeInput{
+		Vision:             "Guide the user from a rough idea into a real plan without dumping templates too early.",
+		SupportingMaterial: "docs/research.md\nhttps://example.com/guided-planning",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if second.CreatedAt != createdAt {
+		t.Fatalf("expected session create time to stay stable: first=%s second=%s", createdAt, second.CreatedAt)
+	}
+	if second.NextAction != "Continue guided brainstorm clarification." {
+		t.Fatalf("unexpected next action: %+v", second)
+	}
+	if !strings.Contains(second.Summary, "Vision captured.") || !strings.Contains(second.Summary, "Supporting material recorded.") {
+		t.Fatalf("unexpected session summary: %+v", second)
+	}
+
+	state, err := ws.ReadGuidedSessionState()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if state.LastActiveChain != "brainstorm/guided-flow" {
+		t.Fatalf("unexpected last active chain: %+v", state)
+	}
+	if len(state.Sessions) != 1 {
+		t.Fatalf("expected one guided session record: %+v", state)
+	}
+
+	raw, err := notes.Read(filepath.Join(root, ".plan", "brainstorms", "guided-flow.md"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := notes.ExtractSection(raw.Content, "Vision"); got != "Guide the user from a rough idea into a real plan without dumping templates too early." {
+		t.Fatalf("unexpected brainstorm vision:\n%s", got)
+	}
+	supporting := notes.ExtractSection(raw.Content, "Supporting Material")
+	if !strings.Contains(supporting, "- docs/research.md") || !strings.Contains(supporting, "- https://example.com/guided-planning") {
+		t.Fatalf("unexpected supporting material:\n%s", supporting)
+	}
+	if updatedNote.Path != ".plan/brainstorms/guided-flow.md" {
+		t.Fatalf("unexpected updated note path: %+v", updatedNote)
+	}
+}

--- a/internal/templates/brainstorm.md
+++ b/internal/templates/brainstorm.md
@@ -6,6 +6,10 @@ Started: {{ .Now }}
 
 ## Desired Outcome
 
+## Vision
+
+## Supporting Material
+
 ## Constraints
 
 ## Open Questions

--- a/internal/workspace/guided_sessions.go
+++ b/internal/workspace/guided_sessions.go
@@ -1,0 +1,175 @@
+package workspace
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"time"
+)
+
+type GuidedSessionState struct {
+	SchemaVersion   int                            `json:"schema_version"`
+	LastActiveChain string                         `json:"last_active_chain,omitempty"`
+	LastUpdatedAt   string                         `json:"last_updated_at,omitempty"`
+	Sessions        map[string]GuidedSessionRecord `json:"sessions"`
+}
+
+type GuidedSessionRecord struct {
+	ChainID             string            `json:"chain_id"`
+	Brainstorm          string            `json:"brainstorm,omitempty"`
+	Epic                string            `json:"epic,omitempty"`
+	Spec                string            `json:"spec,omitempty"`
+	CurrentStage        string            `json:"current_stage,omitempty"`
+	CurrentCluster      int               `json:"current_cluster,omitempty"`
+	CurrentClusterLabel string            `json:"current_cluster_label,omitempty"`
+	StageStatuses       map[string]string `json:"stage_statuses,omitempty"`
+	Summary             string            `json:"summary,omitempty"`
+	NextAction          string            `json:"next_action,omitempty"`
+	CreatedAt           string            `json:"created_at,omitempty"`
+	UpdatedAt           string            `json:"updated_at,omitempty"`
+}
+
+func (m *Manager) ReadGuidedSessionState() (*GuidedSessionState, error) {
+	info, err := m.Resolve()
+	if err != nil {
+		return nil, err
+	}
+	if _, err := os.Stat(info.SessionsFile); err != nil {
+		if !os.IsNotExist(err) {
+			return nil, err
+		}
+		now := time.Now().UTC().Format(time.RFC3339)
+		if _, err := ensureGuidedSessionState(info.SessionsFile, now); err != nil {
+			return nil, err
+		}
+	}
+	return readGuidedSessionStateFile(info.SessionsFile)
+}
+
+func (m *Manager) WriteGuidedSessionState(state GuidedSessionState) error {
+	info, err := m.Resolve()
+	if err != nil {
+		return err
+	}
+	normalized, _, err := normalizeGuidedSessionState(state, time.Now().UTC().Format(time.RFC3339))
+	if err != nil {
+		return err
+	}
+	return writeJSON(info.SessionsFile, normalized)
+}
+
+func readGuidedSessionStateFile(path string) (*GuidedSessionState, error) {
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("read guided session state: %w", err)
+	}
+	var state GuidedSessionState
+	if err := json.Unmarshal(raw, &state); err != nil {
+		return nil, fmt.Errorf("parse guided session state: %w", err)
+	}
+	return &state, nil
+}
+
+func ensureGuidedSessionState(path, now string) (bool, error) {
+	if _, err := os.Stat(path); err == nil {
+		return false, nil
+	} else if !os.IsNotExist(err) {
+		return false, err
+	}
+	state := defaultGuidedSessionState(now)
+	return true, writeJSON(path, state)
+}
+
+func reconcileGuidedSessionState(path, now string) (bool, error) {
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		return false, err
+	}
+	var state GuidedSessionState
+	if err := json.Unmarshal(raw, &state); err != nil {
+		return true, writeJSON(path, defaultGuidedSessionState(now))
+	}
+	normalized, changed, err := normalizeGuidedSessionState(state, now)
+	if err != nil {
+		return false, err
+	}
+	if !changed {
+		return false, nil
+	}
+	return true, writeJSON(path, normalized)
+}
+
+func defaultGuidedSessionState(now string) GuidedSessionState {
+	return GuidedSessionState{
+		SchemaVersion: CurrentSchemaVersion,
+		LastUpdatedAt: now,
+		Sessions:      map[string]GuidedSessionRecord{},
+	}
+}
+
+func normalizeGuidedSessionState(state GuidedSessionState, now string) (GuidedSessionState, bool, error) {
+	if state.SchemaVersion > CurrentSchemaVersion {
+		return GuidedSessionState{}, false, fmt.Errorf("guided session schema version %d is newer than supported version %d", state.SchemaVersion, CurrentSchemaVersion)
+	}
+
+	normalized := state
+	changed := false
+	if normalized.SchemaVersion == 0 {
+		normalized.SchemaVersion = CurrentSchemaVersion
+		changed = true
+	}
+	if normalized.Sessions == nil {
+		normalized.Sessions = map[string]GuidedSessionRecord{}
+		changed = true
+	}
+	if normalized.LastUpdatedAt == "" {
+		normalized.LastUpdatedAt = now
+		changed = true
+	}
+
+	for key, record := range normalized.Sessions {
+		recordChanged := false
+		if record.ChainID == "" {
+			record.ChainID = key
+			recordChanged = true
+		}
+		if record.StageStatuses == nil {
+			record.StageStatuses = map[string]string{}
+			recordChanged = true
+		}
+		if record.CreatedAt == "" {
+			record.CreatedAt = now
+			recordChanged = true
+		}
+		if record.UpdatedAt == "" {
+			record.UpdatedAt = now
+			recordChanged = true
+		}
+		if recordChanged {
+			normalized.Sessions[key] = record
+			changed = true
+		}
+	}
+
+	if changed {
+		normalized.LastUpdatedAt = now
+	}
+	return normalized, changed, nil
+}
+
+func validateGuidedSessionState(state *GuidedSessionState) error {
+	switch {
+	case state == nil:
+		return fmt.Errorf("guided session state is required")
+	case state.SchemaVersion == 0:
+		return fmt.Errorf("schema_version is required")
+	case state.SchemaVersion > CurrentSchemaVersion:
+		return fmt.Errorf("schema_version %d is newer than supported %d", state.SchemaVersion, CurrentSchemaVersion)
+	case state.LastUpdatedAt == "":
+		return fmt.Errorf("last_updated_at is required")
+	case state.Sessions == nil:
+		return fmt.Errorf("sessions are required")
+	default:
+		return nil
+	}
+}

--- a/internal/workspace/workspace.go
+++ b/internal/workspace/workspace.go
@@ -118,6 +118,7 @@ type Info struct {
 	WorkspaceFile  string
 	MigrationsFile string
 	GitHubFile     string
+	SessionsFile   string
 }
 
 type InitResult struct {
@@ -178,6 +179,7 @@ func (m *Manager) Resolve() (*Info, error) {
 		WorkspaceFile:  filepath.Join(metaDir, "workspace.json"),
 		MigrationsFile: filepath.Join(metaDir, "migrations.json"),
 		GitHubFile:     filepath.Join(metaDir, "github.json"),
+		SessionsFile:   filepath.Join(metaDir, "guided_sessions.json"),
 	}, nil
 }
 
@@ -205,6 +207,7 @@ func (i *Info) ToolManagedSurfaces() []Surface {
 		i.newSurface("workspace.json", i.WorkspaceFile, "tool_managed", "file"),
 		i.newSurface("migrations.json", i.MigrationsFile, "tool_managed", "file"),
 		i.newSurface("github.json", i.GitHubFile, "tool_managed", "file"),
+		i.newSurface("guided_sessions.json", i.SessionsFile, "tool_managed", "file"),
 	}
 }
 
@@ -273,6 +276,11 @@ func (m *Manager) Init() (*InitResult, error) {
 		return nil, err
 	} else if created {
 		result.Created = append(result.Created, rel(info.ProjectDir, info.GitHubFile))
+	}
+	if created, err := ensureGuidedSessionState(info.SessionsFile, now); err != nil {
+		return nil, err
+	} else if created {
+		result.Created = append(result.Created, rel(info.ProjectDir, info.SessionsFile))
 	}
 	if err := recordMigrationRun(info, "init", result.Created, nil, now); err != nil {
 		return nil, err
@@ -440,6 +448,17 @@ func (m *Manager) Doctor() (*DoctorReport, error) {
 		}
 	}
 
+	sessionsState, err := readGuidedSessionStateFile(info.SessionsFile)
+	if err != nil {
+		if !contains(report.Missing, "guided_sessions.json") {
+			report.Broken = append(report.Broken, "guided_sessions.json")
+		}
+	} else if err := validateGuidedSessionState(sessionsState); err != nil {
+		if !contains(report.Broken, "guided_sessions.json") {
+			report.Broken = append(report.Broken, "guided_sessions.json")
+		}
+	}
+
 	report.WorkspaceStatus = classifyDoctorWorkspace(report.Missing, report.Broken)
 	if report.WorkspaceStatus == "partial" && report.MigrationStatus == "current" {
 		report.MigrationStatus = "partial"
@@ -548,6 +567,19 @@ func (m *Manager) repairWorkspace(info *Info, operation string) (*UpdateResult, 
 		}
 		if updated {
 			result.Updated = append(result.Updated, rel(info.ProjectDir, info.GitHubFile))
+		}
+	}
+	if created, err := ensureGuidedSessionState(info.SessionsFile, now); err != nil {
+		return nil, err
+	} else if created {
+		result.Created = append(result.Created, rel(info.ProjectDir, info.SessionsFile))
+	} else {
+		updated, err := reconcileGuidedSessionState(info.SessionsFile, now)
+		if err != nil {
+			return nil, err
+		}
+		if updated {
+			result.Updated = append(result.Updated, rel(info.ProjectDir, info.SessionsFile))
 		}
 	}
 	if err := recordMigrationRun(info, operation, result.Created, result.Updated, now); err != nil {
@@ -910,11 +942,11 @@ func classifyDoctorWorkspace(missing, broken []string) string {
 }
 
 func isPartialWorkspace(missing []string) bool {
-	return contains(missing, ".meta/") || contains(missing, "workspace.json") || contains(missing, "migrations.json") || contains(missing, "github.json")
+	return contains(missing, ".meta/") || contains(missing, "workspace.json") || contains(missing, "migrations.json") || contains(missing, "github.json") || contains(missing, "guided_sessions.json")
 }
 
 func isBrokenWorkspace(broken []string) bool {
-	return contains(broken, "workspace.json") || contains(broken, "migrations.json") || contains(broken, "github.json")
+	return contains(broken, "workspace.json") || contains(broken, "migrations.json") || contains(broken, "github.json") || contains(broken, "guided_sessions.json")
 }
 
 func guidanceForWorkspaceStatus(status string) []string {

--- a/internal/workspace/workspace_test.go
+++ b/internal/workspace/workspace_test.go
@@ -30,6 +30,7 @@ func TestInitCreatesPlanWorkspace(t *testing.T) {
 		filepath.Join(root, ".plan", ".meta", "workspace.json"),
 		filepath.Join(root, ".plan", ".meta", "migrations.json"),
 		filepath.Join(root, ".plan", ".meta", "github.json"),
+		filepath.Join(root, ".plan", ".meta", "guided_sessions.json"),
 	} {
 		if _, err := os.Stat(path); err != nil {
 			t.Fatalf("expected %s: %v", path, err)
@@ -50,7 +51,7 @@ func TestWorkspaceContractSeparatesUserAuthoredAndToolManagedSurfaces(t *testing
 	if len(contract.UserAuthored) != 6 {
 		t.Fatalf("unexpected user-authored surface count: %d", len(contract.UserAuthored))
 	}
-	if len(contract.ToolManaged) != 4 {
+	if len(contract.ToolManaged) != 5 {
 		t.Fatalf("unexpected tool-managed surface count: %d", len(contract.ToolManaged))
 	}
 
@@ -222,6 +223,9 @@ func TestUpdateRepairsToolManagedStateWithoutTouchingUserNotes(t *testing.T) {
 	if err := os.Remove(filepath.Join(root, ".plan", ".meta", "github.json")); err != nil {
 		t.Fatal(err)
 	}
+	if err := os.Remove(filepath.Join(root, ".plan", ".meta", "guided_sessions.json")); err != nil {
+		t.Fatal(err)
+	}
 
 	result, err := manager.Update()
 	if err != nil {
@@ -235,6 +239,9 @@ func TestUpdateRepairsToolManagedStateWithoutTouchingUserNotes(t *testing.T) {
 	}
 	if !contains(result.Created, ".plan/.meta/github.json") {
 		t.Fatalf("expected GitHub state recreation: %+v", result)
+	}
+	if !contains(result.Created, ".plan/.meta/guided_sessions.json") {
+		t.Fatalf("expected guided session state recreation: %+v", result)
 	}
 
 	raw, err := os.ReadFile(projectPath)


### PR DESCRIPTION
Fixes #10
Fixes #11

## Summary
- add durable guided session metadata under `.plan/.meta/guided_sessions.json`
- turn `plan brainstorm start` into guided vision intake with explicit supporting-material prompts
- cover session persistence, upgrade compatibility, and guided brainstorm start with tests

## Verification
- go test ./...
- go build ./...
- go run . check --project .
- go run . status --project .