### PR TITLE
feat: add guided brainstorm resume and gap guidance

### DIFF
--- a/.plan/.meta/github.json
+++ b/.plan/.meta/github.json
@@ -3,8 +3,8 @@
   "repo_url": "https://github.com/JimmyMcBride/plan",
   "default_branch": "main",
   "last_enabled_at": "2026-04-20T03:04:26Z",
-  "last_updated_at": "2026-04-20T03:37:40Z",
-  "last_reconciled_at": "2026-04-20T03:37:40Z",
+  "last_updated_at": "2026-04-20T04:03:37Z",
+  "last_reconciled_at": "2026-04-20T04:03:37Z",
   "stories": {
     "add-brainstorm-stage-recap-and-stop-flow": {
       "slug": "add-brainstorm-stage-recap-and-stop-flow",
@@ -35,7 +35,7 @@
       "doc_ref_mode": "main",
       "doc_ref": "main",
       "visible_ready_marker_set": true,
-      "updated_at": "2026-04-20T03:37:36Z"
+      "updated_at": "2026-04-20T04:03:31Z"
     },
     "add-cluster-reflection-and-gap-guidance": {
       "slug": "add-cluster-reflection-and-gap-guidance",
@@ -65,7 +65,7 @@
       "doc_ref_mode": "main",
       "doc_ref": "main",
       "visible_ready_marker_set": true,
-      "updated_at": "2026-04-20T03:37:36Z"
+      "updated_at": "2026-04-20T04:03:31Z"
     },
     "add-guided-session-state-model": {
       "slug": "add-guided-session-state-model",
@@ -85,14 +85,13 @@
       ],
       "issue_number": 10,
       "issue_url": "https://github.com/JimmyMcBride/plan/issues/10",
-      "remote_state": "open",
+      "remote_state": "closed",
       "planning_pr_number": 9,
       "planning_pr_url": "https://github.com/JimmyMcBride/plan/pull/9",
       "planning_pr_merged": true,
       "doc_ref_mode": "main",
       "doc_ref": "main",
-      "visible_ready_marker_set": true,
-      "updated_at": "2026-04-20T03:37:37Z"
+      "updated_at": "2026-04-20T04:03:32Z"
     },
     "add-multi-session-switching-and-coverage": {
       "slug": "add-multi-session-switching-and-coverage",
@@ -122,7 +121,7 @@
       "doc_ref_mode": "main",
       "doc_ref": "main",
       "visible_ready_marker_set": true,
-      "updated_at": "2026-04-20T03:37:37Z"
+      "updated_at": "2026-04-20T04:03:33Z"
     },
     "add-reopen-impact-summary-and-needs-review-markers": {
       "slug": "add-reopen-impact-summary-and-needs-review-markers",
@@ -152,7 +151,7 @@
       "doc_ref_mode": "main",
       "doc_ref": "main",
       "visible_ready_marker_set": true,
-      "updated_at": "2026-04-20T03:37:37Z"
+      "updated_at": "2026-04-20T04:03:33Z"
     },
     "add-roadmap-parking-writes-and-source-links": {
       "slug": "add-roadmap-parking-writes-and-source-links",
@@ -182,7 +181,7 @@
       "doc_ref_mode": "main",
       "doc_ref": "main",
       "visible_ready_marker_set": true,
-      "updated_at": "2026-04-20T03:37:38Z"
+      "updated_at": "2026-04-20T04:03:33Z"
     },
     "implement-brainstorm-to-epic-handoff": {
       "slug": "implement-brainstorm-to-epic-handoff",
@@ -213,7 +212,7 @@
       "doc_ref_mode": "main",
       "doc_ref": "main",
       "visible_ready_marker_set": true,
-      "updated_at": "2026-04-20T03:37:38Z"
+      "updated_at": "2026-04-20T04:03:34Z"
     },
     "implement-downstream-review-checkpoints": {
       "slug": "implement-downstream-review-checkpoints",
@@ -243,7 +242,7 @@
       "doc_ref_mode": "main",
       "doc_ref": "main",
       "visible_ready_marker_set": true,
-      "updated_at": "2026-04-20T03:37:38Z"
+      "updated_at": "2026-04-20T04:03:34Z"
     },
     "implement-epic-to-spec-handoff": {
       "slug": "implement-epic-to-spec-handoff",
@@ -273,7 +272,7 @@
       "doc_ref_mode": "main",
       "doc_ref": "main",
       "visible_ready_marker_set": true,
-      "updated_at": "2026-04-20T03:37:39Z"
+      "updated_at": "2026-04-20T04:03:34Z"
     },
     "implement-guided-story-creation-handoff": {
       "slug": "implement-guided-story-creation-handoff",
@@ -303,7 +302,7 @@
       "doc_ref_mode": "main",
       "doc_ref": "main",
       "visible_ready_marker_set": true,
-      "updated_at": "2026-04-20T03:37:39Z"
+      "updated_at": "2026-04-20T04:03:35Z"
     },
     "implement-guided-vision-intake": {
       "slug": "implement-guided-vision-intake",
@@ -323,14 +322,13 @@
       ],
       "issue_number": 11,
       "issue_url": "https://github.com/JimmyMcBride/plan/issues/11",
-      "remote_state": "open",
+      "remote_state": "closed",
       "planning_pr_number": 9,
       "planning_pr_url": "https://github.com/JimmyMcBride/plan/pull/9",
       "planning_pr_merged": true,
       "doc_ref_mode": "main",
       "doc_ref": "main",
-      "visible_ready_marker_set": true,
-      "updated_at": "2026-04-20T03:37:39Z"
+      "updated_at": "2026-04-20T04:03:36Z"
     },
     "implement-resume-flow-and-session-menu": {
       "slug": "implement-resume-flow-and-session-menu",
@@ -360,7 +358,7 @@
       "doc_ref_mode": "main",
       "doc_ref": "main",
       "visible_ready_marker_set": true,
-      "updated_at": "2026-04-20T03:37:40Z"
+      "updated_at": "2026-04-20T04:03:37Z"
     }
   }
 }

--- a/.plan/.meta/guided_sessions.json
+++ b/.plan/.meta/guided_sessions.json
@@ -1,0 +1,5 @@
+{
+  "schema_version": 2,
+  "last_updated_at": "2026-04-20T04:03:30Z",
+  "sessions": {}
+}

--- a/.plan/.meta/migrations.json
+++ b/.plan/.meta/migrations.json
@@ -1,11 +1,11 @@
 {
   "schema_version": 1,
   "known": [],
-  "last_run_at": "2026-04-20T03:37:35Z",
+  "last_run_at": "2026-04-20T04:03:30Z",
   "status": "current",
   "last_operation": "update",
   "last_created": [
-    ".plan/stories"
+    ".plan/.meta/guided_sessions.json"
   ],
   "history": [
     {
@@ -22,6 +22,14 @@
       "status": "current",
       "created": [
         ".plan/stories"
+      ]
+    },
+    {
+      "operation": "update",
+      "at": "2026-04-20T04:03:30Z",
+      "status": "current",
+      "created": [
+        ".plan/.meta/guided_sessions.json"
       ]
     }
   ]

--- a/cmd/brainstorm.go
+++ b/cmd/brainstorm.go
@@ -8,9 +8,25 @@ import (
 	"strings"
 
 	"plan/internal/planning"
+	"plan/internal/workspace"
 
 	"github.com/spf13/cobra"
 )
+
+type guidedClusterPrompt struct {
+	heading string
+	help    string
+	apply   func(input *planning.BrainstormRefinementInput, value string)
+}
+
+type guidedBrainstormCluster struct {
+	index      int
+	label      string
+	prompts    []guidedClusterPrompt
+	nextIndex  int
+	nextLabel  string
+	nextAction string
+}
 
 func newBrainstormCommand() *cobra.Command {
 	cmd := &cobra.Command{
@@ -67,6 +83,54 @@ func newBrainstormCommand() *cobra.Command {
 	}
 	start.Flags().StringVar(&focusQuestion, "focus", "", "focus question to seed into the brainstorm")
 	start.Flags().StringArrayVar(&seedIdeas, "idea", nil, "initial idea to capture; repeatable")
+
+	resume := &cobra.Command{
+		Use:   "resume [brainstorm-slug]",
+		Short: "Resume the active guided brainstorm session",
+		Args:  cobra.MaximumNArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			reader := bufio.NewReader(cmd.InOrStdin())
+			out := cmd.OutOrStdout()
+
+			var session *workspace.GuidedSessionRecord
+			var err error
+			if len(args) == 1 {
+				session, err = planningManager().ReadGuidedSession("brainstorm/" + strings.TrimSpace(args[0]))
+			} else {
+				session, err = planningManager().ReadLastActiveGuidedSession()
+			}
+			if err != nil {
+				return err
+			}
+
+			if session.Brainstorm == "" {
+				return fmt.Errorf("guided session %s is not linked to a brainstorm", session.ChainID)
+			}
+			fmt.Fprintf(out, "Resuming %s\nSummary: %s\nNext: %s\n", session.ChainID, session.Summary, session.NextAction)
+
+			action, err := promptSessionAction(reader, out)
+			if err != nil {
+				return err
+			}
+			switch action {
+			case "3":
+				updated, err := planningManager().UpdateGuidedSession(session.ChainID, planning.GuidedSessionUpdateInput{
+					CurrentStage: "brainstorm",
+					StageStatus:  "in_progress",
+					NextAction:   "Resume the brainstorm when you are ready to continue shaping it.",
+				})
+				if err != nil {
+					return err
+				}
+				fmt.Fprintf(out, "Saved guided session state for %s\nNext: %s\n", updated.ChainID, updated.NextAction)
+				return nil
+			case "1", "2":
+				return runGuidedBrainstormResume(reader, out, planningManager(), session, action == "2")
+			default:
+				return fmt.Errorf("unsupported menu action %q", action)
+			}
+		},
+	}
 
 	var ideaBody string
 	var ideaStdin bool
@@ -293,8 +357,65 @@ func newBrainstormCommand() *cobra.Command {
 		},
 	}
 
-	cmd.AddCommand(start, idea, show, refine, challenge)
+	cmd.AddCommand(start, resume, idea, show, refine, challenge)
 	return cmd
+}
+
+func runGuidedBrainstormResume(reader *bufio.Reader, out io.Writer, manager *planning.Manager, session *workspace.GuidedSessionRecord, forceCurrent bool) error {
+	cluster := guidedBrainstormClusterForSession(session, forceCurrent)
+	if cluster.index == 0 {
+		updated, err := manager.UpdateGuidedSession(session.ChainID, planning.GuidedSessionUpdateInput{
+			CurrentStage:        "brainstorm",
+			CurrentCluster:      session.CurrentCluster,
+			CurrentClusterLabel: session.CurrentClusterLabel,
+			StageStatus:         "in_progress",
+			Summary:             session.Summary,
+			NextAction:          "Guided brainstorm clarification is complete for now.",
+		})
+		if err != nil {
+			return err
+		}
+		fmt.Fprintf(out, "Nothing new to resume for %s\nNext: %s\n", updated.ChainID, updated.NextAction)
+		return nil
+	}
+
+	fmt.Fprintf(out, "%s\n", cluster.label)
+	var input planning.BrainstormRefinementInput
+	for _, prompt := range cluster.prompts {
+		value, err := promptSectionValue(reader, out, prompt.heading, prompt.help)
+		if err != nil {
+			return err
+		}
+		prompt.apply(&input, value)
+	}
+	if _, err := manager.UpdateBrainstormRefinement(session.Brainstorm, input); err != nil {
+		return err
+	}
+
+	state, err := manager.ReadBrainstormRefinement(session.Brainstorm)
+	if err != nil {
+		return err
+	}
+	reflection := renderBrainstormClusterReflection(cluster.index, state)
+	fmt.Fprintf(out, "Reflection: %s\n", reflection)
+	gap := renderBrainstormGapGuidance(cluster.index, state)
+	if gap != "" {
+		fmt.Fprintf(out, "%s\n", gap)
+	}
+
+	updated, err := manager.UpdateGuidedSession(session.ChainID, planning.GuidedSessionUpdateInput{
+		CurrentStage:        "brainstorm",
+		CurrentCluster:      cluster.nextIndex,
+		CurrentClusterLabel: cluster.nextLabel,
+		StageStatus:         "in_progress",
+		Summary:             reflection,
+		NextAction:          cluster.nextAction,
+	})
+	if err != nil {
+		return err
+	}
+	fmt.Fprintf(out, "Saved cluster %d for %s\nNext: %s\n", cluster.index, updated.ChainID, updated.NextAction)
+	return nil
 }
 
 func runRefinementCluster(reader *bufio.Reader, out io.Writer, label string, askA bool, titleA, helpA string, valueA *string, askB bool, titleB, helpB string, valueB *string) error {
@@ -342,4 +463,180 @@ func promptSectionValue(reader *bufio.Reader, out io.Writer, heading, help strin
 			return strings.TrimSpace(strings.Join(lines, "\n")), nil
 		}
 	}
+}
+
+func promptSessionAction(reader *bufio.Reader, out io.Writer) (string, error) {
+	for {
+		fmt.Fprintf(out, "Choose next step:\n1. Continue\n2. Refine\n3. Stop for now\n")
+		line, err := reader.ReadString('\n')
+		if err != nil && !errors.Is(err, io.EOF) {
+			return "", err
+		}
+		choice := strings.TrimSpace(line)
+		if choice == "1" || choice == "2" || choice == "3" {
+			return choice, nil
+		}
+		if errors.Is(err, io.EOF) && choice == "" {
+			return "", fmt.Errorf("session action is required")
+		}
+		fmt.Fprintf(out, "Enter 1, 2, or 3.\n")
+		if errors.Is(err, io.EOF) {
+			return "", fmt.Errorf("unsupported menu action %q", choice)
+		}
+	}
+}
+
+func guidedBrainstormClusterForSession(session *workspace.GuidedSessionRecord, forceCurrent bool) guidedBrainstormCluster {
+	label := session.CurrentClusterLabel
+	if label == "" {
+		label = "vision-intake"
+	}
+	if label == "vision-intake" {
+		label = "clarify-problem-user-value"
+	}
+	if forceCurrent && session.CurrentCluster > 0 && session.CurrentClusterLabel != "" && session.CurrentClusterLabel != "vision-intake" {
+		label = session.CurrentClusterLabel
+	}
+
+	switch label {
+	case "clarify-problem-user-value":
+		return guidedBrainstormCluster{
+			index: 2,
+			label: "cluster 1/3: problem and user/value",
+			prompts: []guidedClusterPrompt{
+				{
+					heading: "Problem",
+					help:    "Describe the core problem this brainstorm is trying to solve.",
+					apply: func(input *planning.BrainstormRefinementInput, value string) {
+						input.Problem = value
+					},
+				},
+				{
+					heading: "User / Value",
+					help:    "Describe who benefits and what value they get if this works.",
+					apply: func(input *planning.BrainstormRefinementInput, value string) {
+						input.UserValue = value
+					},
+				},
+			},
+			nextIndex:  3,
+			nextLabel:  "clarify-constraints-appetite",
+			nextAction: "Continue with constraints and appetite.",
+		}
+	case "clarify-constraints-appetite":
+		return guidedBrainstormCluster{
+			index: 3,
+			label: "cluster 2/3: constraints and appetite",
+			prompts: []guidedClusterPrompt{
+				{
+					heading: "Constraints",
+					help:    "List the constraints that should shape this work. Enter one per line.",
+					apply: func(input *planning.BrainstormRefinementInput, value string) {
+						input.Constraints = value
+					},
+				},
+				{
+					heading: "Appetite",
+					help:    "Describe how big this should be. Keep it as a crisp boundary, not a schedule.",
+					apply: func(input *planning.BrainstormRefinementInput, value string) {
+						input.Appetite = value
+					},
+				},
+			},
+			nextIndex:  4,
+			nextLabel:  "clarify-open-approaches",
+			nextAction: "Continue with open questions and candidate approaches.",
+		}
+	case "clarify-open-approaches":
+		return guidedBrainstormCluster{
+			index: 4,
+			label: "cluster 3/3: open questions and candidate approaches",
+			prompts: []guidedClusterPrompt{
+				{
+					heading: "Remaining Open Questions",
+					help:    "Capture unresolved questions that still matter. Enter one per line.",
+					apply: func(input *planning.BrainstormRefinementInput, value string) {
+						input.RemainingOpenQuestions = value
+					},
+				},
+				{
+					heading: "Candidate Approaches",
+					help:    "List the strongest approaches worth carrying forward. Enter one per line.",
+					apply: func(input *planning.BrainstormRefinementInput, value string) {
+						input.CandidateApproaches = value
+					},
+				},
+			},
+			nextIndex:  4,
+			nextLabel:  "clarify-open-approaches",
+			nextAction: "Review recap and decide whether to refine more or move to the next stage.",
+		}
+	default:
+		return guidedBrainstormCluster{}
+	}
+}
+
+func renderBrainstormClusterReflection(index int, state *planning.BrainstormRefinement) string {
+	switch index {
+	case 2:
+		var parts []string
+		if strings.TrimSpace(state.Problem) != "" {
+			parts = append(parts, "You are trying to solve "+strings.TrimSpace(state.Problem)+".")
+		}
+		if strings.TrimSpace(state.UserValue) != "" {
+			parts = append(parts, "The main value is "+strings.TrimSpace(state.UserValue)+".")
+		}
+		return strings.Join(parts, " ")
+	case 3:
+		var parts []string
+		if strings.TrimSpace(state.Constraints) != "" {
+			parts = append(parts, "The work is bounded by the current constraints.")
+		}
+		if strings.TrimSpace(state.Appetite) != "" {
+			parts = append(parts, "The current appetite is "+strings.TrimSpace(state.Appetite)+".")
+		}
+		return strings.Join(parts, " ")
+	case 4:
+		var parts []string
+		if strings.TrimSpace(state.RemainingOpenQuestions) != "" {
+			parts = append(parts, "There are still a few open questions to resolve.")
+		}
+		if strings.TrimSpace(state.CandidateApproaches) != "" {
+			parts = append(parts, "You have candidate approaches worth carrying forward.")
+		}
+		return strings.Join(parts, " ")
+	default:
+		return "Guided brainstorm progress updated."
+	}
+}
+
+func renderBrainstormGapGuidance(index int, state *planning.BrainstormRefinement) string {
+	switch index {
+	case 2:
+		if looksVague(state.Problem) || looksVague(state.UserValue) {
+			return "Potential gap: the problem or value is still vague.\nRecommended path: tighten the user and outcome into one concrete pain point.\nAlternative 1: narrow to one user group.\nAlternative 2: state the smallest credible value signal."
+		}
+	case 3:
+		if looksVague(state.Appetite) || strings.TrimSpace(state.Constraints) == "" {
+			return "Potential gap: scope is still too loose.\nRecommended path: set one hard boundary the work will not cross.\nAlternative 1: cap this to one focused implementation pass.\nAlternative 2: move optional depth into the roadmap parking lot."
+		}
+	case 4:
+		if strings.TrimSpace(state.CandidateApproaches) == "" || strings.TrimSpace(state.RemainingOpenQuestions) == "" {
+			return "Potential gap: the path forward is not shaped enough yet.\nRecommended path: pick one approach and name the biggest unanswered risk.\nAlternative 1: park the weaker approach for later.\nAlternative 2: rewrite the question list down to the blockers only."
+		}
+	}
+	return ""
+}
+
+func looksVague(value string) bool {
+	trimmed := strings.ToLower(strings.TrimSpace(value))
+	if trimmed == "" {
+		return true
+	}
+	for _, needle := range []string{"not sure", "maybe", "everything", "anything", "somehow", "flexible"} {
+		if strings.Contains(trimmed, needle) {
+			return true
+		}
+	}
+	return false
 }

--- a/cmd/brainstorm_test.go
+++ b/cmd/brainstorm_test.go
@@ -196,3 +196,105 @@ func TestBrainstormStartGuidesVisionIntakeAndCreatesSession(t *testing.T) {
 		t.Fatalf("expected creation output:\n%s", output.String())
 	}
 }
+
+func TestBrainstormResumeShowsMenuStopsAndPersistsNextAction(t *testing.T) {
+	root := t.TempDir()
+	ws := workspace.New(root)
+	if _, err := ws.Init(); err != nil {
+		t.Fatal(err)
+	}
+	manager := planning.New(ws)
+	if _, err := manager.CreateBrainstorm("Guided Planning"); err != nil {
+		t.Fatal(err)
+	}
+	if _, _, err := manager.UpdateGuidedBrainstormIntake("guided-planning", planning.GuidedBrainstormIntakeInput{
+		Vision:             "Guide a user from a rough feature idea into a shaped plan.",
+		SupportingMaterial: "docs/research.md",
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	var output bytes.Buffer
+	command := newRootCmd()
+	command.SetOut(&output)
+	command.SetErr(&output)
+	command.SetIn(strings.NewReader("3\n"))
+	command.SetArgs([]string{"--project", root, "brainstorm", "resume", "guided-planning"})
+	if err := command.Execute(); err != nil {
+		t.Fatalf("expected guided resume stop flow to succeed: %v\n%s", err, output.String())
+	}
+
+	state, err := ws.ReadGuidedSessionState()
+	if err != nil {
+		t.Fatal(err)
+	}
+	session := state.Sessions["brainstorm/guided-planning"]
+	if session.NextAction != "Resume the brainstorm when you are ready to continue shaping it." {
+		t.Fatalf("unexpected next action after stop: %+v", session)
+	}
+	if !strings.Contains(output.String(), "1. Continue") || !strings.Contains(output.String(), "3. Stop for now") {
+		t.Fatalf("expected numbered session menu:\n%s", output.String())
+	}
+}
+
+func TestBrainstormResumeContinuesClusterWithReflectionAndGapGuidance(t *testing.T) {
+	root := t.TempDir()
+	ws := workspace.New(root)
+	if _, err := ws.Init(); err != nil {
+		t.Fatal(err)
+	}
+	manager := planning.New(ws)
+	if _, err := manager.CreateBrainstorm("Guided Planning"); err != nil {
+		t.Fatal(err)
+	}
+	if _, _, err := manager.UpdateGuidedBrainstormIntake("guided-planning", planning.GuidedBrainstormIntakeInput{
+		Vision:             "Guide a user from a rough feature idea into a shaped plan.",
+		SupportingMaterial: "docs/research.md",
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	input := strings.Join([]string{
+		"1",
+		"Maybe everything around planning should get better.",
+		"",
+		"Not sure who benefits yet.",
+		"",
+	}, "\n")
+
+	var output bytes.Buffer
+	command := newRootCmd()
+	command.SetOut(&output)
+	command.SetErr(&output)
+	command.SetIn(strings.NewReader(input))
+	command.SetArgs([]string{"--project", root, "brainstorm", "resume", "guided-planning"})
+	if err := command.Execute(); err != nil {
+		t.Fatalf("expected guided resume continue flow to succeed: %v\n%s", err, output.String())
+	}
+
+	refinement, err := manager.ReadBrainstormRefinement("guided-planning")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if refinement.Problem != "Maybe everything around planning should get better." {
+		t.Fatalf("unexpected problem section:\n%s", refinement.Problem)
+	}
+	if refinement.UserValue != "Not sure who benefits yet." {
+		t.Fatalf("unexpected user/value section:\n%s", refinement.UserValue)
+	}
+
+	state, err := ws.ReadGuidedSessionState()
+	if err != nil {
+		t.Fatal(err)
+	}
+	session := state.Sessions["brainstorm/guided-planning"]
+	if session.CurrentClusterLabel != "clarify-constraints-appetite" {
+		t.Fatalf("expected next brainstorm cluster after continue: %+v", session)
+	}
+	if !strings.Contains(output.String(), "Reflection:") {
+		t.Fatalf("expected one-shot reflection output:\n%s", output.String())
+	}
+	if !strings.Contains(output.String(), "Potential gap: the problem or value is still vague.") {
+		t.Fatalf("expected gap guidance output:\n%s", output.String())
+	}
+}

--- a/internal/planning/guided_session.go
+++ b/internal/planning/guided_session.go
@@ -15,6 +15,15 @@ type GuidedBrainstormIntakeInput struct {
 	SupportingMaterial string
 }
 
+type GuidedSessionUpdateInput struct {
+	CurrentStage        string
+	CurrentCluster      int
+	CurrentClusterLabel string
+	Summary             string
+	NextAction          string
+	StageStatus         string
+}
+
 func (m *Manager) EnsureGuidedBrainstormSession(brainstormSlug string) (*workspace.GuidedSessionRecord, error) {
 	info, err := m.workspace.EnsureInitialized()
 	if err != nil {
@@ -72,6 +81,63 @@ func (m *Manager) ReadGuidedSession(chainID string) (*workspace.GuidedSessionRec
 	record, ok := state.Sessions[strings.TrimSpace(chainID)]
 	if !ok {
 		return nil, fmt.Errorf("guided session %q not found", chainID)
+	}
+	return &record, nil
+}
+
+func (m *Manager) ReadLastActiveGuidedSession() (*workspace.GuidedSessionRecord, error) {
+	state, err := m.workspace.ReadGuidedSessionState()
+	if err != nil {
+		return nil, err
+	}
+	if strings.TrimSpace(state.LastActiveChain) == "" {
+		return nil, fmt.Errorf("no active guided session")
+	}
+	return m.ReadGuidedSession(state.LastActiveChain)
+}
+
+func (m *Manager) UpdateGuidedSession(chainID string, input GuidedSessionUpdateInput) (*workspace.GuidedSessionRecord, error) {
+	state, err := m.workspace.ReadGuidedSessionState()
+	if err != nil {
+		return nil, err
+	}
+	chainID = strings.TrimSpace(chainID)
+	record, ok := state.Sessions[chainID]
+	if !ok {
+		return nil, fmt.Errorf("guided session %q not found", chainID)
+	}
+	now := time.Now().UTC().Format(time.RFC3339)
+	if strings.TrimSpace(input.CurrentStage) != "" {
+		record.CurrentStage = strings.TrimSpace(input.CurrentStage)
+	}
+	if input.CurrentCluster > 0 {
+		record.CurrentCluster = input.CurrentCluster
+	}
+	if strings.TrimSpace(input.CurrentClusterLabel) != "" {
+		record.CurrentClusterLabel = strings.TrimSpace(input.CurrentClusterLabel)
+	}
+	if strings.TrimSpace(input.Summary) != "" {
+		record.Summary = strings.TrimSpace(input.Summary)
+	}
+	if strings.TrimSpace(input.NextAction) != "" {
+		record.NextAction = strings.TrimSpace(input.NextAction)
+	}
+	if record.StageStatuses == nil {
+		record.StageStatuses = map[string]string{}
+	}
+	stageKey := record.CurrentStage
+	if stageKey == "" {
+		stageKey = "brainstorm"
+	}
+	if strings.TrimSpace(input.StageStatus) != "" {
+		record.StageStatuses[stageKey] = strings.TrimSpace(input.StageStatus)
+	}
+	record.UpdatedAt = now
+	state.LastActiveChain = chainID
+	state.LastUpdatedAt = now
+	state.Sessions[chainID] = record
+	if err := m.workspace.WriteGuidedSessionState(*state); err != nil {
+		return nil, err
 	}
 	return &record, nil
 }


### PR DESCRIPTION
Fixes #12
Fixes #14

## Summary
- add guided brainstorm resume with a numbered continue/refine/stop menu
- run the first clarification clusters through the guided session state machine
- reflect once per completed cluster and surface short opinionated gap guidance

## Verification
- go test ./...
- go build ./...
- go run . check --project .