### PR TITLE
feat: add guided session switching and reopen flow

### DIFF
--- a/.plan/.meta/github.json
+++ b/.plan/.meta/github.json
@@ -3,8 +3,8 @@
   "repo_url": "https://github.com/JimmyMcBride/plan",
   "default_branch": "main",
   "last_enabled_at": "2026-04-20T03:04:26Z",
-  "last_updated_at": "2026-04-20T04:03:37Z",
-  "last_reconciled_at": "2026-04-20T04:03:37Z",
+  "last_updated_at": "2026-04-20T04:09:51Z",
+  "last_reconciled_at": "2026-04-20T04:09:51Z",
   "stories": {
     "add-brainstorm-stage-recap-and-stop-flow": {
       "slug": "add-brainstorm-stage-recap-and-stop-flow",
@@ -35,7 +35,7 @@
       "doc_ref_mode": "main",
       "doc_ref": "main",
       "visible_ready_marker_set": true,
-      "updated_at": "2026-04-20T04:03:31Z"
+      "updated_at": "2026-04-20T04:09:44Z"
     },
     "add-cluster-reflection-and-gap-guidance": {
       "slug": "add-cluster-reflection-and-gap-guidance",
@@ -58,14 +58,13 @@
       ],
       "issue_number": 14,
       "issue_url": "https://github.com/JimmyMcBride/plan/issues/14",
-      "remote_state": "open",
+      "remote_state": "closed",
       "planning_pr_number": 9,
       "planning_pr_url": "https://github.com/JimmyMcBride/plan/pull/9",
       "planning_pr_merged": true,
       "doc_ref_mode": "main",
       "doc_ref": "main",
-      "visible_ready_marker_set": true,
-      "updated_at": "2026-04-20T04:03:31Z"
+      "updated_at": "2026-04-20T04:09:45Z"
     },
     "add-guided-session-state-model": {
       "slug": "add-guided-session-state-model",
@@ -91,7 +90,7 @@
       "planning_pr_merged": true,
       "doc_ref_mode": "main",
       "doc_ref": "main",
-      "updated_at": "2026-04-20T04:03:32Z"
+      "updated_at": "2026-04-20T04:09:46Z"
     },
     "add-multi-session-switching-and-coverage": {
       "slug": "add-multi-session-switching-and-coverage",
@@ -121,7 +120,7 @@
       "doc_ref_mode": "main",
       "doc_ref": "main",
       "visible_ready_marker_set": true,
-      "updated_at": "2026-04-20T04:03:33Z"
+      "updated_at": "2026-04-20T04:09:47Z"
     },
     "add-reopen-impact-summary-and-needs-review-markers": {
       "slug": "add-reopen-impact-summary-and-needs-review-markers",
@@ -151,7 +150,7 @@
       "doc_ref_mode": "main",
       "doc_ref": "main",
       "visible_ready_marker_set": true,
-      "updated_at": "2026-04-20T04:03:33Z"
+      "updated_at": "2026-04-20T04:09:47Z"
     },
     "add-roadmap-parking-writes-and-source-links": {
       "slug": "add-roadmap-parking-writes-and-source-links",
@@ -181,7 +180,7 @@
       "doc_ref_mode": "main",
       "doc_ref": "main",
       "visible_ready_marker_set": true,
-      "updated_at": "2026-04-20T04:03:33Z"
+      "updated_at": "2026-04-20T04:09:47Z"
     },
     "implement-brainstorm-to-epic-handoff": {
       "slug": "implement-brainstorm-to-epic-handoff",
@@ -212,7 +211,7 @@
       "doc_ref_mode": "main",
       "doc_ref": "main",
       "visible_ready_marker_set": true,
-      "updated_at": "2026-04-20T04:03:34Z"
+      "updated_at": "2026-04-20T04:09:48Z"
     },
     "implement-downstream-review-checkpoints": {
       "slug": "implement-downstream-review-checkpoints",
@@ -242,7 +241,7 @@
       "doc_ref_mode": "main",
       "doc_ref": "main",
       "visible_ready_marker_set": true,
-      "updated_at": "2026-04-20T04:03:34Z"
+      "updated_at": "2026-04-20T04:09:48Z"
     },
     "implement-epic-to-spec-handoff": {
       "slug": "implement-epic-to-spec-handoff",
@@ -272,7 +271,7 @@
       "doc_ref_mode": "main",
       "doc_ref": "main",
       "visible_ready_marker_set": true,
-      "updated_at": "2026-04-20T04:03:34Z"
+      "updated_at": "2026-04-20T04:09:48Z"
     },
     "implement-guided-story-creation-handoff": {
       "slug": "implement-guided-story-creation-handoff",
@@ -302,7 +301,7 @@
       "doc_ref_mode": "main",
       "doc_ref": "main",
       "visible_ready_marker_set": true,
-      "updated_at": "2026-04-20T04:03:35Z"
+      "updated_at": "2026-04-20T04:09:49Z"
     },
     "implement-guided-vision-intake": {
       "slug": "implement-guided-vision-intake",
@@ -328,7 +327,7 @@
       "planning_pr_merged": true,
       "doc_ref_mode": "main",
       "doc_ref": "main",
-      "updated_at": "2026-04-20T04:03:36Z"
+      "updated_at": "2026-04-20T04:09:50Z"
     },
     "implement-resume-flow-and-session-menu": {
       "slug": "implement-resume-flow-and-session-menu",
@@ -351,14 +350,13 @@
       ],
       "issue_number": 12,
       "issue_url": "https://github.com/JimmyMcBride/plan/issues/12",
-      "remote_state": "open",
+      "remote_state": "closed",
       "planning_pr_number": 9,
       "planning_pr_url": "https://github.com/JimmyMcBride/plan/pull/9",
       "planning_pr_merged": true,
       "doc_ref_mode": "main",
       "doc_ref": "main",
-      "visible_ready_marker_set": true,
-      "updated_at": "2026-04-20T04:03:37Z"
+      "updated_at": "2026-04-20T04:09:51Z"
     }
   }
 }

--- a/cmd/brainstorm.go
+++ b/cmd/brainstorm.go
@@ -132,6 +132,81 @@ func newBrainstormCommand() *cobra.Command {
 		},
 	}
 
+	sessions := &cobra.Command{
+		Use:   "sessions",
+		Short: "List guided brainstorm sessions",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			out := cmd.OutOrStdout()
+			list, err := planningManager().ListGuidedSessions()
+			if err != nil {
+				return err
+			}
+			last, err := planningManager().ReadLastActiveGuidedSession()
+			if err != nil && !strings.Contains(err.Error(), "no active guided session") {
+				return err
+			}
+			lastActive := ""
+			if last != nil {
+				lastActive = last.ChainID
+			}
+			for _, session := range list {
+				marker := " "
+				if session.ChainID == lastActive {
+					marker = "*"
+				}
+				fmt.Fprintf(out, "%s %s stage=%s next=%s\n", marker, session.ChainID, session.CurrentStage, session.NextAction)
+			}
+			return nil
+		},
+	}
+
+	switchCmd := &cobra.Command{
+		Use:   "switch <brainstorm-slug>",
+		Short: "Switch the last-active guided brainstorm session",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			out := cmd.OutOrStdout()
+			session, err := planningManager().SwitchGuidedSession("brainstorm/" + strings.TrimSpace(args[0]))
+			if err != nil {
+				return err
+			}
+			fmt.Fprintf(out, "Switched to %s\nSummary: %s\nNext: %s\n", session.ChainID, session.Summary, session.NextAction)
+			return nil
+		},
+	}
+
+	reopen := &cobra.Command{
+		Use:   "reopen <brainstorm-slug> <stage>",
+		Short: "Reopen a stage and mark downstream stages as needs review",
+		Args:  cobra.ExactArgs(2),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			reader := bufio.NewReader(cmd.InOrStdin())
+			out := cmd.OutOrStdout()
+			chainID := "brainstorm/" + strings.TrimSpace(args[0])
+			stage := strings.TrimSpace(args[1])
+			session, err := planningManager().ReadGuidedSession(chainID)
+			if err != nil {
+				return err
+			}
+			downstream := guidedDownstreamStagesForOutput(stage)
+			fmt.Fprintf(out, "Reopen stage: %s\nDownstream stages affected: %s\nRecommended path: reopen this stage and mark downstream work as needs review.\nAlternative 1: stay on the current stage and refine locally.\nAlternative 2: stop for now and revisit after a recap pass.\nProceed? [y/N]\n", stage, strings.Join(downstream, ", "))
+			confirm, err := reader.ReadString('\n')
+			if err != nil && !errors.Is(err, io.EOF) {
+				return err
+			}
+			if strings.ToLower(strings.TrimSpace(confirm)) != "y" {
+				fmt.Fprintf(out, "Canceled reopen for %s\n", session.ChainID)
+				return nil
+			}
+			updated, impacted, err := planningManager().ReopenGuidedSessionStage(chainID, stage)
+			if err != nil {
+				return err
+			}
+			fmt.Fprintf(out, "Reopened %s for %s\nMarked needs review: %s\nNext: %s\n", stage, updated.ChainID, strings.Join(impacted, ", "), updated.NextAction)
+			return nil
+		},
+	}
+
 	var ideaBody string
 	var ideaStdin bool
 	var section string
@@ -357,7 +432,7 @@ func newBrainstormCommand() *cobra.Command {
 		},
 	}
 
-	cmd.AddCommand(start, resume, idea, show, refine, challenge)
+	cmd.AddCommand(start, resume, sessions, switchCmd, reopen, idea, show, refine, challenge)
 	return cmd
 }
 
@@ -402,13 +477,15 @@ func runGuidedBrainstormResume(reader *bufio.Reader, out io.Writer, manager *pla
 	if gap != "" {
 		fmt.Fprintf(out, "%s\n", gap)
 	}
+	recap := renderBrainstormStageRecap(state, cluster.nextAction)
+	fmt.Fprintf(out, "%s\n", recap)
 
 	updated, err := manager.UpdateGuidedSession(session.ChainID, planning.GuidedSessionUpdateInput{
 		CurrentStage:        "brainstorm",
 		CurrentCluster:      cluster.nextIndex,
 		CurrentClusterLabel: cluster.nextLabel,
 		StageStatus:         "in_progress",
-		Summary:             reflection,
+		Summary:             recap,
 		NextAction:          cluster.nextAction,
 	})
 	if err != nil {
@@ -639,4 +716,40 @@ func looksVague(value string) bool {
 		}
 	}
 	return false
+}
+
+func renderBrainstormStageRecap(state *planning.BrainstormRefinement, nextAction string) string {
+	currentUnderstanding := "Current understanding: vision shaping is in progress."
+	if strings.TrimSpace(state.Problem) != "" && strings.TrimSpace(state.UserValue) != "" {
+		currentUnderstanding = fmt.Sprintf("Current understanding: %s / %s", strings.TrimSpace(state.Problem), strings.TrimSpace(state.UserValue))
+	}
+	keyDecisions := "Key decisions: none yet."
+	if strings.TrimSpace(state.Appetite) != "" {
+		keyDecisions = "Key decisions: appetite captured."
+	}
+	unresolved := "Unresolved risks or questions: none captured yet."
+	if strings.TrimSpace(state.RemainingOpenQuestions) != "" {
+		unresolved = "Unresolved risks or questions: there are still open questions to review."
+	}
+	return strings.Join([]string{
+		"Recap:",
+		currentUnderstanding,
+		keyDecisions,
+		unresolved,
+		"Parked items: none.",
+		"Recommended next stage: " + nextAction,
+	}, "\n")
+}
+
+func guidedDownstreamStagesForOutput(stage string) []string {
+	switch strings.TrimSpace(stage) {
+	case "brainstorm":
+		return []string{"epic", "spec", "stories"}
+	case "epic":
+		return []string{"spec", "stories"}
+	case "spec":
+		return []string{"stories"}
+	default:
+		return []string{"none"}
+	}
 }

--- a/cmd/brainstorm_test.go
+++ b/cmd/brainstorm_test.go
@@ -297,4 +297,49 @@ func TestBrainstormResumeContinuesClusterWithReflectionAndGapGuidance(t *testing
 	if !strings.Contains(output.String(), "Potential gap: the problem or value is still vague.") {
 		t.Fatalf("expected gap guidance output:\n%s", output.String())
 	}
+	if !strings.Contains(output.String(), "Recap:\nCurrent understanding:") {
+		t.Fatalf("expected structured recap output:\n%s", output.String())
+	}
+}
+
+func TestBrainstormSwitchSetsLastActiveSessionForResume(t *testing.T) {
+	root := t.TempDir()
+	ws := workspace.New(root)
+	if _, err := ws.Init(); err != nil {
+		t.Fatal(err)
+	}
+	manager := planning.New(ws)
+	for _, slug := range []string{"alpha", "beta"} {
+		if _, err := manager.CreateBrainstorm(slug); err != nil {
+			t.Fatal(err)
+		}
+		if _, _, err := manager.UpdateGuidedBrainstormIntake(slug, planning.GuidedBrainstormIntakeInput{
+			Vision:             "Vision for " + slug,
+			SupportingMaterial: "docs/" + slug + ".md",
+		}); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	var switchOutput bytes.Buffer
+	command := newRootCmd()
+	command.SetOut(&switchOutput)
+	command.SetErr(&switchOutput)
+	command.SetArgs([]string{"--project", root, "brainstorm", "switch", "alpha"})
+	if err := command.Execute(); err != nil {
+		t.Fatalf("expected brainstorm switch to succeed: %v\n%s", err, switchOutput.String())
+	}
+
+	var resumeOutput bytes.Buffer
+	command = newRootCmd()
+	command.SetOut(&resumeOutput)
+	command.SetErr(&resumeOutput)
+	command.SetIn(strings.NewReader("3\n"))
+	command.SetArgs([]string{"--project", root, "brainstorm", "resume"})
+	if err := command.Execute(); err != nil {
+		t.Fatalf("expected resume without slug to use last active session: %v\n%s", err, resumeOutput.String())
+	}
+	if !strings.Contains(resumeOutput.String(), "Resuming brainstorm/alpha") {
+		t.Fatalf("expected resume to target switched session:\n%s", resumeOutput.String())
+	}
 }

--- a/internal/planning/guided_session.go
+++ b/internal/planning/guided_session.go
@@ -3,6 +3,7 @@ package planning
 import (
 	"fmt"
 	"path/filepath"
+	"sort"
 	"strings"
 	"time"
 
@@ -23,6 +24,8 @@ type GuidedSessionUpdateInput struct {
 	NextAction          string
 	StageStatus         string
 }
+
+var guidedStageOrder = []string{"brainstorm", "epic", "spec", "stories"}
 
 func (m *Manager) EnsureGuidedBrainstormSession(brainstormSlug string) (*workspace.GuidedSessionRecord, error) {
 	info, err := m.workspace.EnsureInitialized()
@@ -96,6 +99,43 @@ func (m *Manager) ReadLastActiveGuidedSession() (*workspace.GuidedSessionRecord,
 	return m.ReadGuidedSession(state.LastActiveChain)
 }
 
+func (m *Manager) ListGuidedSessions() ([]workspace.GuidedSessionRecord, error) {
+	state, err := m.workspace.ReadGuidedSessionState()
+	if err != nil {
+		return nil, err
+	}
+	keys := make([]string, 0, len(state.Sessions))
+	for key := range state.Sessions {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	out := make([]workspace.GuidedSessionRecord, 0, len(keys))
+	for _, key := range keys {
+		out = append(out, state.Sessions[key])
+	}
+	return out, nil
+}
+
+func (m *Manager) SwitchGuidedSession(chainID string) (*workspace.GuidedSessionRecord, error) {
+	state, err := m.workspace.ReadGuidedSessionState()
+	if err != nil {
+		return nil, err
+	}
+	record, ok := state.Sessions[strings.TrimSpace(chainID)]
+	if !ok {
+		return nil, fmt.Errorf("guided session %q not found", chainID)
+	}
+	now := time.Now().UTC().Format(time.RFC3339)
+	record.UpdatedAt = now
+	state.LastActiveChain = record.ChainID
+	state.LastUpdatedAt = now
+	state.Sessions[record.ChainID] = record
+	if err := m.workspace.WriteGuidedSessionState(*state); err != nil {
+		return nil, err
+	}
+	return &record, nil
+}
+
 func (m *Manager) UpdateGuidedSession(chainID string, input GuidedSessionUpdateInput) (*workspace.GuidedSessionRecord, error) {
 	state, err := m.workspace.ReadGuidedSessionState()
 	if err != nil {
@@ -140,6 +180,44 @@ func (m *Manager) UpdateGuidedSession(chainID string, input GuidedSessionUpdateI
 		return nil, err
 	}
 	return &record, nil
+}
+
+func (m *Manager) ReopenGuidedSessionStage(chainID, stage string) (*workspace.GuidedSessionRecord, []string, error) {
+	stage = strings.TrimSpace(stage)
+	if stage == "" {
+		return nil, nil, fmt.Errorf("stage is required")
+	}
+	state, err := m.workspace.ReadGuidedSessionState()
+	if err != nil {
+		return nil, nil, err
+	}
+	chainID = strings.TrimSpace(chainID)
+	record, ok := state.Sessions[chainID]
+	if !ok {
+		return nil, nil, fmt.Errorf("guided session %q not found", chainID)
+	}
+	if !isGuidedStage(stage) {
+		return nil, nil, fmt.Errorf("unsupported guided stage %q", stage)
+	}
+	if record.StageStatuses == nil {
+		record.StageStatuses = map[string]string{}
+	}
+	now := time.Now().UTC().Format(time.RFC3339)
+	record.CurrentStage = stage
+	record.StageStatuses[stage] = "in_progress"
+	downstream := guidedDownstreamStages(stage)
+	for _, later := range downstream {
+		record.StageStatuses[later] = "needs_review"
+	}
+	record.NextAction = fmt.Sprintf("Review %s after reopening %s.", strings.Join(downstream, ", "), stage)
+	record.UpdatedAt = now
+	state.LastActiveChain = chainID
+	state.LastUpdatedAt = now
+	state.Sessions[chainID] = record
+	if err := m.workspace.WriteGuidedSessionState(*state); err != nil {
+		return nil, nil, err
+	}
+	return &record, downstream, nil
 }
 
 func (m *Manager) upsertGuidedBrainstormSession(note *notes.Note) (*workspace.GuidedSessionRecord, error) {
@@ -191,6 +269,24 @@ func (m *Manager) upsertGuidedBrainstormSession(note *notes.Note) (*workspace.Gu
 
 func guidedChainID(brainstormSlug string) string {
 	return fmt.Sprintf("brainstorm/%s", slugify(brainstormSlug))
+}
+
+func isGuidedStage(stage string) bool {
+	for _, candidate := range guidedStageOrder {
+		if candidate == stage {
+			return true
+		}
+	}
+	return false
+}
+
+func guidedDownstreamStages(stage string) []string {
+	for index, candidate := range guidedStageOrder {
+		if candidate == stage {
+			return append([]string(nil), guidedStageOrder[index+1:]...)
+		}
+	}
+	return nil
 }
 
 func summarizeBrainstormSession(note *notes.Note) string {

--- a/internal/planning/guided_session_test.go
+++ b/internal/planning/guided_session_test.go
@@ -79,3 +79,58 @@ func TestGuidedBrainstormSessionPersistsChainStateAndStaysStable(t *testing.T) {
 		t.Fatalf("unexpected updated note path: %+v", updatedNote)
 	}
 }
+
+func TestSwitchAndReopenGuidedSessionState(t *testing.T) {
+	root := t.TempDir()
+	ws := workspace.New(root)
+	if _, err := ws.Init(); err != nil {
+		t.Fatal(err)
+	}
+	manager := New(ws)
+	for _, slug := range []string{"alpha", "beta"} {
+		if _, err := manager.CreateBrainstorm(slug); err != nil {
+			t.Fatal(err)
+		}
+		if _, _, err := manager.UpdateGuidedBrainstormIntake(slug, GuidedBrainstormIntakeInput{
+			Vision:             "Vision for " + slug,
+			SupportingMaterial: "docs/" + slug + ".md",
+		}); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	if _, err := manager.SwitchGuidedSession("brainstorm/alpha"); err != nil {
+		t.Fatal(err)
+	}
+	last, err := manager.ReadLastActiveGuidedSession()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if last.ChainID != "brainstorm/alpha" {
+		t.Fatalf("unexpected last active session: %+v", last)
+	}
+
+	if _, err := manager.UpdateGuidedSession("brainstorm/alpha", GuidedSessionUpdateInput{
+		CurrentStage: "epic",
+		StageStatus:  "done",
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := manager.UpdateGuidedSession("brainstorm/alpha", GuidedSessionUpdateInput{
+		CurrentStage: "spec",
+		StageStatus:  "done",
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	updated, downstream, err := manager.ReopenGuidedSessionStage("brainstorm/alpha", "brainstorm")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(downstream) != 3 {
+		t.Fatalf("unexpected downstream stage count: %+v", downstream)
+	}
+	if updated.StageStatuses["epic"] != "needs_review" || updated.StageStatuses["spec"] != "needs_review" || updated.StageStatuses["stories"] != "needs_review" {
+		t.Fatalf("expected downstream stages to be marked needs_review: %+v", updated)
+	}
+}


### PR DESCRIPTION
Fixes #13
Fixes #15
Fixes #19

## Summary
- add guided session listing and switching for multiple planning chains
- add structured brainstorm recap output and consistent stop/continue flow
- add explicit reopen-stage impact summaries and needs-review stage markers

## Verification
- go test ./...
- go build ./...
- go run . check --project .