### PR TITLE
feat: add brainstorm handoff review and parking flows

### DIFF
--- a/.plan/.meta/github.json
+++ b/.plan/.meta/github.json
@@ -3,8 +3,8 @@
   "repo_url": "https://github.com/JimmyMcBride/plan",
   "default_branch": "main",
   "last_enabled_at": "2026-04-20T03:04:26Z",
-  "last_updated_at": "2026-04-20T04:09:51Z",
-  "last_reconciled_at": "2026-04-20T04:09:51Z",
+  "last_updated_at": "2026-04-20T04:15:03Z",
+  "last_reconciled_at": "2026-04-20T04:15:03Z",
   "stories": {
     "add-brainstorm-stage-recap-and-stop-flow": {
       "slug": "add-brainstorm-stage-recap-and-stop-flow",
@@ -28,14 +28,13 @@
       ],
       "issue_number": 15,
       "issue_url": "https://github.com/JimmyMcBride/plan/issues/15",
-      "remote_state": "open",
+      "remote_state": "closed",
       "planning_pr_number": 9,
       "planning_pr_url": "https://github.com/JimmyMcBride/plan/pull/9",
       "planning_pr_merged": true,
       "doc_ref_mode": "main",
       "doc_ref": "main",
-      "visible_ready_marker_set": true,
-      "updated_at": "2026-04-20T04:09:44Z"
+      "updated_at": "2026-04-20T04:14:52Z"
     },
     "add-cluster-reflection-and-gap-guidance": {
       "slug": "add-cluster-reflection-and-gap-guidance",
@@ -64,7 +63,7 @@
       "planning_pr_merged": true,
       "doc_ref_mode": "main",
       "doc_ref": "main",
-      "updated_at": "2026-04-20T04:09:45Z"
+      "updated_at": "2026-04-20T04:14:53Z"
     },
     "add-guided-session-state-model": {
       "slug": "add-guided-session-state-model",
@@ -90,7 +89,7 @@
       "planning_pr_merged": true,
       "doc_ref_mode": "main",
       "doc_ref": "main",
-      "updated_at": "2026-04-20T04:09:46Z"
+      "updated_at": "2026-04-20T04:14:54Z"
     },
     "add-multi-session-switching-and-coverage": {
       "slug": "add-multi-session-switching-and-coverage",
@@ -113,14 +112,13 @@
       ],
       "issue_number": 13,
       "issue_url": "https://github.com/JimmyMcBride/plan/issues/13",
-      "remote_state": "open",
+      "remote_state": "closed",
       "planning_pr_number": 9,
       "planning_pr_url": "https://github.com/JimmyMcBride/plan/pull/9",
       "planning_pr_merged": true,
       "doc_ref_mode": "main",
       "doc_ref": "main",
-      "visible_ready_marker_set": true,
-      "updated_at": "2026-04-20T04:09:47Z"
+      "updated_at": "2026-04-20T04:14:55Z"
     },
     "add-reopen-impact-summary-and-needs-review-markers": {
       "slug": "add-reopen-impact-summary-and-needs-review-markers",
@@ -143,14 +141,13 @@
       ],
       "issue_number": 19,
       "issue_url": "https://github.com/JimmyMcBride/plan/issues/19",
-      "remote_state": "open",
+      "remote_state": "closed",
       "planning_pr_number": 9,
       "planning_pr_url": "https://github.com/JimmyMcBride/plan/pull/9",
       "planning_pr_merged": true,
       "doc_ref_mode": "main",
       "doc_ref": "main",
-      "visible_ready_marker_set": true,
-      "updated_at": "2026-04-20T04:09:47Z"
+      "updated_at": "2026-04-20T04:14:56Z"
     },
     "add-roadmap-parking-writes-and-source-links": {
       "slug": "add-roadmap-parking-writes-and-source-links",
@@ -180,7 +177,7 @@
       "doc_ref_mode": "main",
       "doc_ref": "main",
       "visible_ready_marker_set": true,
-      "updated_at": "2026-04-20T04:09:47Z"
+      "updated_at": "2026-04-20T04:14:57Z"
     },
     "implement-brainstorm-to-epic-handoff": {
       "slug": "implement-brainstorm-to-epic-handoff",
@@ -211,7 +208,7 @@
       "doc_ref_mode": "main",
       "doc_ref": "main",
       "visible_ready_marker_set": true,
-      "updated_at": "2026-04-20T04:09:48Z"
+      "updated_at": "2026-04-20T04:14:58Z"
     },
     "implement-downstream-review-checkpoints": {
       "slug": "implement-downstream-review-checkpoints",
@@ -241,7 +238,7 @@
       "doc_ref_mode": "main",
       "doc_ref": "main",
       "visible_ready_marker_set": true,
-      "updated_at": "2026-04-20T04:09:48Z"
+      "updated_at": "2026-04-20T04:15:00Z"
     },
     "implement-epic-to-spec-handoff": {
       "slug": "implement-epic-to-spec-handoff",
@@ -271,7 +268,7 @@
       "doc_ref_mode": "main",
       "doc_ref": "main",
       "visible_ready_marker_set": true,
-      "updated_at": "2026-04-20T04:09:48Z"
+      "updated_at": "2026-04-20T04:15:00Z"
     },
     "implement-guided-story-creation-handoff": {
       "slug": "implement-guided-story-creation-handoff",
@@ -301,7 +298,7 @@
       "doc_ref_mode": "main",
       "doc_ref": "main",
       "visible_ready_marker_set": true,
-      "updated_at": "2026-04-20T04:09:49Z"
+      "updated_at": "2026-04-20T04:15:00Z"
     },
     "implement-guided-vision-intake": {
       "slug": "implement-guided-vision-intake",
@@ -327,7 +324,7 @@
       "planning_pr_merged": true,
       "doc_ref_mode": "main",
       "doc_ref": "main",
-      "updated_at": "2026-04-20T04:09:50Z"
+      "updated_at": "2026-04-20T04:15:01Z"
     },
     "implement-resume-flow-and-session-menu": {
       "slug": "implement-resume-flow-and-session-menu",
@@ -356,7 +353,7 @@
       "planning_pr_merged": true,
       "doc_ref_mode": "main",
       "doc_ref": "main",
-      "updated_at": "2026-04-20T04:09:51Z"
+      "updated_at": "2026-04-20T04:15:03Z"
     }
   }
 }

--- a/cmd/brainstorm.go
+++ b/cmd/brainstorm.go
@@ -207,6 +207,51 @@ func newBrainstormCommand() *cobra.Command {
 		},
 	}
 
+	review := &cobra.Command{
+		Use:   "review <brainstorm-slug>",
+		Short: "Run lightweight downstream review checkpoints for needs-review stages",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			out := cmd.OutOrStdout()
+			session, reviewed, err := planningManager().ReviewGuidedSessionStages("brainstorm/" + strings.TrimSpace(args[0]))
+			if err != nil {
+				return err
+			}
+			if len(reviewed) == 0 {
+				fmt.Fprintf(out, "No downstream review checkpoints needed for %s\n", session.ChainID)
+				return nil
+			}
+			fmt.Fprintf(out, "Reviewed stages for %s: %s\nNext: %s\n", session.ChainID, strings.Join(reviewed, ", "), session.NextAction)
+			return nil
+		},
+	}
+
+	var parkValue string
+	var parkReason string
+	var parkUnlock string
+	park := &cobra.Command{
+		Use:   "park <brainstorm-slug> <title>",
+		Short: "Park a good-but-early idea in ROADMAP.md",
+		Args:  cobra.ExactArgs(2),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			source := fmt.Sprintf("[Brainstorm](../brainstorms/%s.md)", strings.TrimSpace(args[0]))
+			if err := planningManager().AddRoadmapParkingEntry(planning.RoadmapParkingInput{
+				Title:  args[1],
+				Value:  parkValue,
+				Reason: parkReason,
+				Unlock: parkUnlock,
+				Source: source,
+			}); err != nil {
+				return err
+			}
+			fmt.Fprintf(cmd.OutOrStdout(), "Parked %s in .plan/ROADMAP.md\n", args[1])
+			return nil
+		},
+	}
+	park.Flags().StringVar(&parkValue, "value", "", "value or outcome if the idea lands later")
+	park.Flags().StringVar(&parkReason, "reason", "", "why the idea is parked now")
+	park.Flags().StringVar(&parkUnlock, "unlock", "", "what needs to happen before the idea becomes active")
+
 	var ideaBody string
 	var ideaStdin bool
 	var section string
@@ -432,25 +477,38 @@ func newBrainstormCommand() *cobra.Command {
 		},
 	}
 
-	cmd.AddCommand(start, resume, sessions, switchCmd, reopen, idea, show, refine, challenge)
+	cmd.AddCommand(start, resume, sessions, switchCmd, reopen, review, park, idea, show, refine, challenge)
 	return cmd
 }
 
 func runGuidedBrainstormResume(reader *bufio.Reader, out io.Writer, manager *planning.Manager, session *workspace.GuidedSessionRecord, forceCurrent bool) error {
 	cluster := guidedBrainstormClusterForSession(session, forceCurrent)
 	if cluster.index == 0 {
-		updated, err := manager.UpdateGuidedSession(session.ChainID, planning.GuidedSessionUpdateInput{
-			CurrentStage:        "brainstorm",
-			CurrentCluster:      session.CurrentCluster,
-			CurrentClusterLabel: session.CurrentClusterLabel,
-			StageStatus:         "in_progress",
-			Summary:             session.Summary,
-			NextAction:          "Guided brainstorm clarification is complete for now.",
-		})
+		fmt.Fprintf(out, "Brainstorm stage is shaped enough to hand off.\nContinue into epic creation? [y/N]\n")
+		confirm, err := reader.ReadString('\n')
+		if err != nil && !errors.Is(err, io.EOF) {
+			return err
+		}
+		if strings.ToLower(strings.TrimSpace(confirm)) != "y" {
+			updated, err := manager.UpdateGuidedSession(session.ChainID, planning.GuidedSessionUpdateInput{
+				CurrentStage:        "brainstorm",
+				CurrentCluster:      session.CurrentCluster,
+				CurrentClusterLabel: session.CurrentClusterLabel,
+				StageStatus:         "in_progress",
+				Summary:             session.Summary,
+				NextAction:          "Brainstorm handoff is ready when you want to continue into the epic stage.",
+			})
+			if err != nil {
+				return err
+			}
+			fmt.Fprintf(out, "Checkpoint saved for %s\nNext: %s\n", updated.ChainID, updated.NextAction)
+			return nil
+		}
+		bundle, updated, err := manager.PromoteGuidedBrainstormSession(session.Brainstorm)
 		if err != nil {
 			return err
 		}
-		fmt.Fprintf(out, "Nothing new to resume for %s\nNext: %s\n", updated.ChainID, updated.NextAction)
+		fmt.Fprintf(out, "Created epic %s\nCreated seeded spec %s\nNext: %s\n", bundle.Epic.Path, bundle.Spec.Path, updated.NextAction)
 		return nil
 	}
 
@@ -644,9 +702,9 @@ func guidedBrainstormClusterForSession(session *workspace.GuidedSessionRecord, f
 					},
 				},
 			},
-			nextIndex:  4,
-			nextLabel:  "clarify-open-approaches",
-			nextAction: "Review recap and decide whether to refine more or move to the next stage.",
+			nextIndex:  5,
+			nextLabel:  "handoff-epic",
+			nextAction: "Review recap and continue into the epic stage when ready.",
 		}
 	default:
 		return guidedBrainstormCluster{}

--- a/cmd/brainstorm_test.go
+++ b/cmd/brainstorm_test.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"bytes"
+	"os"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -341,5 +342,158 @@ func TestBrainstormSwitchSetsLastActiveSessionForResume(t *testing.T) {
 	}
 	if !strings.Contains(resumeOutput.String(), "Resuming brainstorm/alpha") {
 		t.Fatalf("expected resume to target switched session:\n%s", resumeOutput.String())
+	}
+}
+
+func TestBrainstormResumeCanPromoteIntoEpicAtCheckpoint(t *testing.T) {
+	root := t.TempDir()
+	ws := workspace.New(root)
+	if _, err := ws.Init(); err != nil {
+		t.Fatal(err)
+	}
+	manager := planning.New(ws)
+	if _, err := manager.CreateBrainstorm("Guided Planning"); err != nil {
+		t.Fatal(err)
+	}
+	if _, _, err := manager.UpdateGuidedBrainstormIntake("guided-planning", planning.GuidedBrainstormIntakeInput{
+		Vision:             "Guide a user from a rough feature idea into a shaped plan.",
+		SupportingMaterial: "docs/research.md",
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := manager.UpdateBrainstormRefinement("guided-planning", planning.BrainstormRefinementInput{
+		Problem:                "Planning starts too artifact-first.",
+		UserValue:              "Users get a collaborative planning flow.",
+		Constraints:            "Keep the tool local-first.",
+		Appetite:               "One focused planning session.",
+		RemainingOpenQuestions: "How far should the guided loop go in v1?",
+		CandidateApproaches:    "Promote at an explicit checkpoint.",
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := manager.UpdateGuidedSession("brainstorm/guided-planning", planning.GuidedSessionUpdateInput{
+		CurrentStage:        "brainstorm",
+		CurrentCluster:      5,
+		CurrentClusterLabel: "handoff-epic",
+		StageStatus:         "in_progress",
+		Summary:             "Brainstorm shaping is complete.",
+		NextAction:          "Continue into the epic stage.",
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	var output bytes.Buffer
+	command := newRootCmd()
+	command.SetOut(&output)
+	command.SetErr(&output)
+	command.SetIn(strings.NewReader("1\ny\n"))
+	command.SetArgs([]string{"--project", root, "brainstorm", "resume", "guided-planning"})
+	if err := command.Execute(); err != nil {
+		t.Fatalf("expected brainstorm handoff to epic to succeed: %v\n%s", err, output.String())
+	}
+
+	if _, err := notes.Read(filepath.Join(root, ".plan", "epics", "guided-planning.md")); err != nil {
+		t.Fatalf("expected epic to be created: %v", err)
+	}
+	if _, err := notes.Read(filepath.Join(root, ".plan", "specs", "guided-planning.md")); err != nil {
+		t.Fatalf("expected spec to be created: %v", err)
+	}
+	state, err := ws.ReadGuidedSessionState()
+	if err != nil {
+		t.Fatal(err)
+	}
+	session := state.Sessions["brainstorm/guided-planning"]
+	if session.CurrentStage != "epic" || session.Epic != "guided-planning" || session.Spec != "guided-planning" {
+		t.Fatalf("expected session to move into epic stage: %+v", session)
+	}
+}
+
+func TestBrainstormReviewMarksNeedsReviewStagesAsReviewed(t *testing.T) {
+	root := t.TempDir()
+	ws := workspace.New(root)
+	if _, err := ws.Init(); err != nil {
+		t.Fatal(err)
+	}
+	manager := planning.New(ws)
+	if _, err := manager.CreateBrainstorm("Guided Planning"); err != nil {
+		t.Fatal(err)
+	}
+	if _, _, err := manager.UpdateGuidedBrainstormIntake("guided-planning", planning.GuidedBrainstormIntakeInput{
+		Vision:             "Guide a user from a rough feature idea into a shaped plan.",
+		SupportingMaterial: "docs/research.md",
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := manager.UpdateGuidedSession("brainstorm/guided-planning", planning.GuidedSessionUpdateInput{
+		CurrentStage: "epic",
+		StageStatus:  "done",
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := manager.UpdateGuidedSession("brainstorm/guided-planning", planning.GuidedSessionUpdateInput{
+		CurrentStage: "spec",
+		StageStatus:  "done",
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if _, _, err := manager.ReopenGuidedSessionStage("brainstorm/guided-planning", "brainstorm"); err != nil {
+		t.Fatal(err)
+	}
+
+	var output bytes.Buffer
+	command := newRootCmd()
+	command.SetOut(&output)
+	command.SetErr(&output)
+	command.SetArgs([]string{"--project", root, "brainstorm", "review", "guided-planning"})
+	if err := command.Execute(); err != nil {
+		t.Fatalf("expected brainstorm review to succeed: %v\n%s", err, output.String())
+	}
+
+	state, err := ws.ReadGuidedSessionState()
+	if err != nil {
+		t.Fatal(err)
+	}
+	session := state.Sessions["brainstorm/guided-planning"]
+	if session.StageStatuses["epic"] != "reviewed" || session.StageStatuses["spec"] != "reviewed" {
+		t.Fatalf("expected downstream stages to be reviewed: %+v", session)
+	}
+}
+
+func TestBrainstormParkWritesRoadmapParkingEntry(t *testing.T) {
+	root := t.TempDir()
+	ws := workspace.New(root)
+	if _, err := ws.Init(); err != nil {
+		t.Fatal(err)
+	}
+	manager := planning.New(ws)
+	if _, err := manager.CreateBrainstorm("Guided Planning"); err != nil {
+		t.Fatal(err)
+	}
+
+	var output bytes.Buffer
+	command := newRootCmd()
+	command.SetOut(&output)
+	command.SetErr(&output)
+	command.SetArgs([]string{
+		"--project", root,
+		"brainstorm", "park", "guided-planning", "Guided Story Drafting",
+		"--value", "Turn shaped specs into first-pass stories later.",
+		"--reason", "Need the guided session foundation first.",
+		"--unlock", "After the brainstorm-to-epic checkpoint is stable.",
+	})
+	if err := command.Execute(); err != nil {
+		t.Fatalf("expected brainstorm park to succeed: %v\n%s", err, output.String())
+	}
+
+	raw, err := os.ReadFile(filepath.Join(root, ".plan", "ROADMAP.md"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	body := string(raw)
+	if !strings.Contains(body, "Guided Story Drafting | value: Turn shaped specs into first-pass stories later.") {
+		t.Fatalf("expected roadmap parking entry:\n%s", body)
+	}
+	if !strings.Contains(body, "source: [Brainstorm](../brainstorms/guided-planning.md)") {
+		t.Fatalf("expected source link in parking entry:\n%s", body)
 	}
 }

--- a/internal/planning/guided_session.go
+++ b/internal/planning/guided_session.go
@@ -2,6 +2,7 @@ package planning
 
 import (
 	"fmt"
+	"os"
 	"path/filepath"
 	"sort"
 	"strings"
@@ -218,6 +219,94 @@ func (m *Manager) ReopenGuidedSessionStage(chainID, stage string) (*workspace.Gu
 		return nil, nil, err
 	}
 	return &record, downstream, nil
+}
+
+func (m *Manager) PromoteGuidedBrainstormSession(brainstormSlug string) (*EpicBundle, *workspace.GuidedSessionRecord, error) {
+	bundle, err := m.PromoteBrainstorm(brainstormSlug)
+	if err != nil {
+		return nil, nil, err
+	}
+	_, err = m.UpdateGuidedSession(guidedChainID(brainstormSlug), GuidedSessionUpdateInput{
+		CurrentStage: "epic",
+		Summary:      "Brainstorm promoted into epic and seeded spec.",
+		NextAction:   "Continue shaping the epic before moving into the spec stage.",
+		StageStatus:  "in_progress",
+	})
+	if err != nil {
+		return nil, nil, err
+	}
+	state, err := m.workspace.ReadGuidedSessionState()
+	if err != nil {
+		return nil, nil, err
+	}
+	record := state.Sessions[guidedChainID(brainstormSlug)]
+	record.Epic = slugFromPath(bundle.Epic.Path)
+	record.Spec = slugFromPath(bundle.Spec.Path)
+	record.StageStatuses["brainstorm"] = "done"
+	record.StageStatuses["epic"] = "in_progress"
+	record.UpdatedAt = time.Now().UTC().Format(time.RFC3339)
+	state.LastActiveChain = record.ChainID
+	state.LastUpdatedAt = record.UpdatedAt
+	state.Sessions[record.ChainID] = record
+	if err := m.workspace.WriteGuidedSessionState(*state); err != nil {
+		return nil, nil, err
+	}
+	return bundle, &record, nil
+}
+
+func (m *Manager) ReviewGuidedSessionStages(chainID string) (*workspace.GuidedSessionRecord, []string, error) {
+	state, err := m.workspace.ReadGuidedSessionState()
+	if err != nil {
+		return nil, nil, err
+	}
+	record, ok := state.Sessions[strings.TrimSpace(chainID)]
+	if !ok {
+		return nil, nil, fmt.Errorf("guided session %q not found", chainID)
+	}
+	var reviewed []string
+	for _, stage := range guidedStageOrder {
+		if record.StageStatuses[stage] == "needs_review" {
+			record.StageStatuses[stage] = "reviewed"
+			reviewed = append(reviewed, stage)
+		}
+	}
+	record.NextAction = "Downstream review checkpoints complete. Continue the planning flow."
+	record.UpdatedAt = time.Now().UTC().Format(time.RFC3339)
+	state.LastActiveChain = record.ChainID
+	state.LastUpdatedAt = record.UpdatedAt
+	state.Sessions[record.ChainID] = record
+	if err := m.workspace.WriteGuidedSessionState(*state); err != nil {
+		return nil, nil, err
+	}
+	return &record, reviewed, nil
+}
+
+type RoadmapParkingInput struct {
+	Title  string
+	Value  string
+	Reason string
+	Unlock string
+	Source string
+}
+
+func (m *Manager) AddRoadmapParkingEntry(input RoadmapParkingInput) error {
+	info, err := m.workspace.EnsureInitialized()
+	if err != nil {
+		return err
+	}
+	raw, err := os.ReadFile(info.RoadmapFile)
+	if err != nil {
+		return err
+	}
+	entry := fmt.Sprintf("%s | value: %s | parked because: %s | unlock: %s | source: %s",
+		strings.TrimSpace(input.Title),
+		strings.TrimSpace(input.Value),
+		strings.TrimSpace(input.Reason),
+		strings.TrimSpace(input.Unlock),
+		strings.TrimSpace(input.Source),
+	)
+	updated := notes.AppendUnderHeading(string(raw), "Parking Lot", "- "+entry)
+	return os.WriteFile(info.RoadmapFile, []byte(updated), 0o644)
 }
 
 func (m *Manager) upsertGuidedBrainstormSession(note *notes.Note) (*workspace.GuidedSessionRecord, error) {


### PR DESCRIPTION
Fixes #16
Fixes #20
Fixes #21

## Summary
- add brainstorm-to-epic checkpoint handoff through the guided resume flow
- add lightweight downstream review checkpoints for needs-review stages
- add roadmap parking writes with source links for good-but-early ideas

## Verification
- go test ./...
- go build ./...
- go run . check --project .