### PR TITLE
feat: add epic to spec handoff checkpoint

### DIFF
--- a/.plan/.meta/github.json
+++ b/.plan/.meta/github.json
@@ -3,8 +3,8 @@
   "repo_url": "https://github.com/JimmyMcBride/plan",
   "default_branch": "main",
   "last_enabled_at": "2026-04-20T03:04:26Z",
-  "last_updated_at": "2026-04-20T04:15:03Z",
-  "last_reconciled_at": "2026-04-20T04:15:03Z",
+  "last_updated_at": "2026-04-20T04:20:12Z",
+  "last_reconciled_at": "2026-04-20T04:20:12Z",
   "stories": {
     "add-brainstorm-stage-recap-and-stop-flow": {
       "slug": "add-brainstorm-stage-recap-and-stop-flow",
@@ -34,7 +34,7 @@
       "planning_pr_merged": true,
       "doc_ref_mode": "main",
       "doc_ref": "main",
-      "updated_at": "2026-04-20T04:14:52Z"
+      "updated_at": "2026-04-20T04:20:01Z"
     },
     "add-cluster-reflection-and-gap-guidance": {
       "slug": "add-cluster-reflection-and-gap-guidance",
@@ -63,7 +63,7 @@
       "planning_pr_merged": true,
       "doc_ref_mode": "main",
       "doc_ref": "main",
-      "updated_at": "2026-04-20T04:14:53Z"
+      "updated_at": "2026-04-20T04:20:02Z"
     },
     "add-guided-session-state-model": {
       "slug": "add-guided-session-state-model",
@@ -89,7 +89,7 @@
       "planning_pr_merged": true,
       "doc_ref_mode": "main",
       "doc_ref": "main",
-      "updated_at": "2026-04-20T04:14:54Z"
+      "updated_at": "2026-04-20T04:20:03Z"
     },
     "add-multi-session-switching-and-coverage": {
       "slug": "add-multi-session-switching-and-coverage",
@@ -118,7 +118,7 @@
       "planning_pr_merged": true,
       "doc_ref_mode": "main",
       "doc_ref": "main",
-      "updated_at": "2026-04-20T04:14:55Z"
+      "updated_at": "2026-04-20T04:20:04Z"
     },
     "add-reopen-impact-summary-and-needs-review-markers": {
       "slug": "add-reopen-impact-summary-and-needs-review-markers",
@@ -147,7 +147,7 @@
       "planning_pr_merged": true,
       "doc_ref_mode": "main",
       "doc_ref": "main",
-      "updated_at": "2026-04-20T04:14:56Z"
+      "updated_at": "2026-04-20T04:20:05Z"
     },
     "add-roadmap-parking-writes-and-source-links": {
       "slug": "add-roadmap-parking-writes-and-source-links",
@@ -170,14 +170,13 @@
       ],
       "issue_number": 21,
       "issue_url": "https://github.com/JimmyMcBride/plan/issues/21",
-      "remote_state": "open",
+      "remote_state": "closed",
       "planning_pr_number": 9,
       "planning_pr_url": "https://github.com/JimmyMcBride/plan/pull/9",
       "planning_pr_merged": true,
       "doc_ref_mode": "main",
       "doc_ref": "main",
-      "visible_ready_marker_set": true,
-      "updated_at": "2026-04-20T04:14:57Z"
+      "updated_at": "2026-04-20T04:20:06Z"
     },
     "implement-brainstorm-to-epic-handoff": {
       "slug": "implement-brainstorm-to-epic-handoff",
@@ -201,14 +200,13 @@
       ],
       "issue_number": 16,
       "issue_url": "https://github.com/JimmyMcBride/plan/issues/16",
-      "remote_state": "open",
+      "remote_state": "closed",
       "planning_pr_number": 9,
       "planning_pr_url": "https://github.com/JimmyMcBride/plan/pull/9",
       "planning_pr_merged": true,
       "doc_ref_mode": "main",
       "doc_ref": "main",
-      "visible_ready_marker_set": true,
-      "updated_at": "2026-04-20T04:14:58Z"
+      "updated_at": "2026-04-20T04:20:07Z"
     },
     "implement-downstream-review-checkpoints": {
       "slug": "implement-downstream-review-checkpoints",
@@ -231,14 +229,13 @@
       ],
       "issue_number": 20,
       "issue_url": "https://github.com/JimmyMcBride/plan/issues/20",
-      "remote_state": "open",
+      "remote_state": "closed",
       "planning_pr_number": 9,
       "planning_pr_url": "https://github.com/JimmyMcBride/plan/pull/9",
       "planning_pr_merged": true,
       "doc_ref_mode": "main",
       "doc_ref": "main",
-      "visible_ready_marker_set": true,
-      "updated_at": "2026-04-20T04:15:00Z"
+      "updated_at": "2026-04-20T04:20:08Z"
     },
     "implement-epic-to-spec-handoff": {
       "slug": "implement-epic-to-spec-handoff",
@@ -268,7 +265,7 @@
       "doc_ref_mode": "main",
       "doc_ref": "main",
       "visible_ready_marker_set": true,
-      "updated_at": "2026-04-20T04:15:00Z"
+      "updated_at": "2026-04-20T04:20:09Z"
     },
     "implement-guided-story-creation-handoff": {
       "slug": "implement-guided-story-creation-handoff",
@@ -298,7 +295,7 @@
       "doc_ref_mode": "main",
       "doc_ref": "main",
       "visible_ready_marker_set": true,
-      "updated_at": "2026-04-20T04:15:00Z"
+      "updated_at": "2026-04-20T04:20:10Z"
     },
     "implement-guided-vision-intake": {
       "slug": "implement-guided-vision-intake",
@@ -324,7 +321,7 @@
       "planning_pr_merged": true,
       "doc_ref_mode": "main",
       "doc_ref": "main",
-      "updated_at": "2026-04-20T04:15:01Z"
+      "updated_at": "2026-04-20T04:20:11Z"
     },
     "implement-resume-flow-and-session-menu": {
       "slug": "implement-resume-flow-and-session-menu",
@@ -353,7 +350,7 @@
       "planning_pr_merged": true,
       "doc_ref_mode": "main",
       "doc_ref": "main",
-      "updated_at": "2026-04-20T04:15:03Z"
+      "updated_at": "2026-04-20T04:20:12Z"
     }
   }
 }

--- a/cmd/epic.go
+++ b/cmd/epic.go
@@ -2,7 +2,10 @@ package cmd
 
 import (
 	"bufio"
+	"errors"
 	"fmt"
+	"io"
+	"strings"
 
 	"plan/internal/planning"
 
@@ -164,6 +167,35 @@ func newEpicCommand() *cobra.Command {
 		},
 	}
 
-	cmd.AddCommand(create, promote, list, show, shape)
+	handoff := &cobra.Command{
+		Use:   "handoff <epic-slug>",
+		Short: "Continue a guided epic into the spec stage at a stable checkpoint",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			reader := bufio.NewReader(cmd.InOrStdin())
+			out := cmd.OutOrStdout()
+			session, err := planningManager().ReadGuidedSessionByEpic(args[0])
+			if err != nil {
+				return err
+			}
+			fmt.Fprintf(out, "Epic recap:\nCurrent understanding: %s\nRecommended next stage: continue into spec.\nProceed? [y/N]\n", session.Summary)
+			confirm, err := reader.ReadString('\n')
+			if err != nil && !errors.Is(err, io.EOF) {
+				return err
+			}
+			if strings.ToLower(strings.TrimSpace(confirm)) != "y" {
+				fmt.Fprintf(out, "Canceled epic handoff for %s\n", args[0])
+				return nil
+			}
+			updated, spec, err := planningManager().AdvanceGuidedSessionToSpec(args[0])
+			if err != nil {
+				return err
+			}
+			fmt.Fprintf(out, "Using spec %s\nNext: %s\n", spec.Path, updated.NextAction)
+			return nil
+		},
+	}
+
+	cmd.AddCommand(create, promote, list, show, shape, handoff)
 	return cmd
 }

--- a/cmd/epic_test.go
+++ b/cmd/epic_test.go
@@ -71,3 +71,59 @@ func TestEpicShapeCommandPersistsClustersAndResumes(t *testing.T) {
 		t.Fatalf("expected out-of-scope bullets in shape section:\n%s", note.Content)
 	}
 }
+
+func TestEpicHandoffAdvancesGuidedSessionToSpec(t *testing.T) {
+	root := t.TempDir()
+	ws := workspace.New(root)
+	if _, err := ws.Init(); err != nil {
+		t.Fatal(err)
+	}
+	manager := planning.New(ws)
+	if _, err := manager.CreateBrainstorm("Guided Planning"); err != nil {
+		t.Fatal(err)
+	}
+	if _, _, err := manager.UpdateGuidedBrainstormIntake("guided-planning", planning.GuidedBrainstormIntakeInput{
+		Vision:             "Guide a user from a rough feature idea into a shaped plan.",
+		SupportingMaterial: "docs/research.md",
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := manager.UpdateBrainstormRefinement("guided-planning", planning.BrainstormRefinementInput{
+		Problem:                "Planning starts too artifact-first.",
+		UserValue:              "Users get a collaborative planning flow.",
+		Constraints:            "Keep the tool local-first.",
+		Appetite:               "One focused planning session.",
+		RemainingOpenQuestions: "How far should the guided loop go in v1?",
+		CandidateApproaches:    "Promote at an explicit checkpoint.",
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if _, _, err := manager.PromoteGuidedBrainstormSession("guided-planning"); err != nil {
+		t.Fatal(err)
+	}
+
+	var output bytes.Buffer
+	command := newRootCmd()
+	command.SetOut(&output)
+	command.SetErr(&output)
+	command.SetIn(strings.NewReader("y\n"))
+	command.SetArgs([]string{"--project", root, "epic", "handoff", "guided-planning"})
+	if err := command.Execute(); err != nil {
+		t.Fatalf("expected epic handoff to succeed: %v\n%s", err, output.String())
+	}
+
+	state, err := ws.ReadGuidedSessionState()
+	if err != nil {
+		t.Fatal(err)
+	}
+	session := state.Sessions["brainstorm/guided-planning"]
+	if session.CurrentStage != "spec" {
+		t.Fatalf("expected session to advance to spec stage: %+v", session)
+	}
+	if session.StageStatuses["epic"] != "done" || session.StageStatuses["spec"] != "in_progress" {
+		t.Fatalf("expected stage handoff statuses: %+v", session)
+	}
+	if !strings.Contains(output.String(), "Using spec .plan/specs/guided-planning.md") {
+		t.Fatalf("expected spec handoff output:\n%s", output.String())
+	}
+}

--- a/internal/planning/guided_session.go
+++ b/internal/planning/guided_session.go
@@ -254,6 +254,56 @@ func (m *Manager) PromoteGuidedBrainstormSession(brainstormSlug string) (*EpicBu
 	return bundle, &record, nil
 }
 
+func (m *Manager) ReadGuidedSessionByEpic(epicSlug string) (*workspace.GuidedSessionRecord, error) {
+	state, err := m.workspace.ReadGuidedSessionState()
+	if err != nil {
+		return nil, err
+	}
+	needle := slugify(epicSlug)
+	for _, record := range state.Sessions {
+		if record.Epic == needle {
+			copy := record
+			return &copy, nil
+		}
+	}
+	return nil, fmt.Errorf("no guided session linked to epic %q", epicSlug)
+}
+
+func (m *Manager) AdvanceGuidedSessionToSpec(epicSlug string) (*workspace.GuidedSessionRecord, *notes.Note, error) {
+	session, err := m.ReadGuidedSessionByEpic(epicSlug)
+	if err != nil {
+		return nil, nil, err
+	}
+	spec, err := m.ReadSpec(epicSlug)
+	if err != nil {
+		return nil, nil, err
+	}
+	updated, err := m.UpdateGuidedSession(session.ChainID, GuidedSessionUpdateInput{
+		CurrentStage: "spec",
+		Summary:      "Epic handoff complete. Continue the planning flow in the spec stage.",
+		NextAction:   "Continue refining the spec at the next checkpoint.",
+		StageStatus:  "in_progress",
+	})
+	if err != nil {
+		return nil, nil, err
+	}
+	state, err := m.workspace.ReadGuidedSessionState()
+	if err != nil {
+		return nil, nil, err
+	}
+	record := state.Sessions[updated.ChainID]
+	record.StageStatuses["epic"] = "done"
+	record.StageStatuses["spec"] = "in_progress"
+	record.UpdatedAt = time.Now().UTC().Format(time.RFC3339)
+	state.LastActiveChain = record.ChainID
+	state.LastUpdatedAt = record.UpdatedAt
+	state.Sessions[record.ChainID] = record
+	if err := m.workspace.WriteGuidedSessionState(*state); err != nil {
+		return nil, nil, err
+	}
+	return &record, spec, nil
+}
+
 func (m *Manager) ReviewGuidedSessionStages(chainID string) (*workspace.GuidedSessionRecord, []string, error) {
 	state, err := m.workspace.ReadGuidedSessionState()
 	if err != nil {


### PR DESCRIPTION
Fixes #17

## Summary
- add an explicit epic handoff checkpoint into the spec stage
- advance the guided session from epic to spec without forcing context restatement
- cover the guided epic handoff with CLI and session-state tests

## Verification
- go test ./...
- go build ./...
- go run . check --project .