### PR TITLE
feat: add spec to story handoff checkpoint

### DIFF
--- a/.plan/.meta/github.json
+++ b/.plan/.meta/github.json
@@ -3,8 +3,8 @@
   "repo_url": "https://github.com/JimmyMcBride/plan",
   "default_branch": "main",
   "last_enabled_at": "2026-04-20T03:04:26Z",
-  "last_updated_at": "2026-04-20T04:20:12Z",
-  "last_reconciled_at": "2026-04-20T04:20:12Z",
+  "last_updated_at": "2026-04-20T04:24:53Z",
+  "last_reconciled_at": "2026-04-20T04:24:53Z",
   "stories": {
     "add-brainstorm-stage-recap-and-stop-flow": {
       "slug": "add-brainstorm-stage-recap-and-stop-flow",
@@ -34,7 +34,7 @@
       "planning_pr_merged": true,
       "doc_ref_mode": "main",
       "doc_ref": "main",
-      "updated_at": "2026-04-20T04:20:01Z"
+      "updated_at": "2026-04-20T04:24:42Z"
     },
     "add-cluster-reflection-and-gap-guidance": {
       "slug": "add-cluster-reflection-and-gap-guidance",
@@ -63,7 +63,7 @@
       "planning_pr_merged": true,
       "doc_ref_mode": "main",
       "doc_ref": "main",
-      "updated_at": "2026-04-20T04:20:02Z"
+      "updated_at": "2026-04-20T04:24:43Z"
     },
     "add-guided-session-state-model": {
       "slug": "add-guided-session-state-model",
@@ -89,7 +89,7 @@
       "planning_pr_merged": true,
       "doc_ref_mode": "main",
       "doc_ref": "main",
-      "updated_at": "2026-04-20T04:20:03Z"
+      "updated_at": "2026-04-20T04:24:44Z"
     },
     "add-multi-session-switching-and-coverage": {
       "slug": "add-multi-session-switching-and-coverage",
@@ -118,7 +118,7 @@
       "planning_pr_merged": true,
       "doc_ref_mode": "main",
       "doc_ref": "main",
-      "updated_at": "2026-04-20T04:20:04Z"
+      "updated_at": "2026-04-20T04:24:45Z"
     },
     "add-reopen-impact-summary-and-needs-review-markers": {
       "slug": "add-reopen-impact-summary-and-needs-review-markers",
@@ -147,7 +147,7 @@
       "planning_pr_merged": true,
       "doc_ref_mode": "main",
       "doc_ref": "main",
-      "updated_at": "2026-04-20T04:20:05Z"
+      "updated_at": "2026-04-20T04:24:46Z"
     },
     "add-roadmap-parking-writes-and-source-links": {
       "slug": "add-roadmap-parking-writes-and-source-links",
@@ -176,7 +176,7 @@
       "planning_pr_merged": true,
       "doc_ref_mode": "main",
       "doc_ref": "main",
-      "updated_at": "2026-04-20T04:20:06Z"
+      "updated_at": "2026-04-20T04:24:47Z"
     },
     "implement-brainstorm-to-epic-handoff": {
       "slug": "implement-brainstorm-to-epic-handoff",
@@ -206,7 +206,7 @@
       "planning_pr_merged": true,
       "doc_ref_mode": "main",
       "doc_ref": "main",
-      "updated_at": "2026-04-20T04:20:07Z"
+      "updated_at": "2026-04-20T04:24:48Z"
     },
     "implement-downstream-review-checkpoints": {
       "slug": "implement-downstream-review-checkpoints",
@@ -235,7 +235,7 @@
       "planning_pr_merged": true,
       "doc_ref_mode": "main",
       "doc_ref": "main",
-      "updated_at": "2026-04-20T04:20:08Z"
+      "updated_at": "2026-04-20T04:24:49Z"
     },
     "implement-epic-to-spec-handoff": {
       "slug": "implement-epic-to-spec-handoff",
@@ -258,14 +258,13 @@
       ],
       "issue_number": 17,
       "issue_url": "https://github.com/JimmyMcBride/plan/issues/17",
-      "remote_state": "open",
+      "remote_state": "closed",
       "planning_pr_number": 9,
       "planning_pr_url": "https://github.com/JimmyMcBride/plan/pull/9",
       "planning_pr_merged": true,
       "doc_ref_mode": "main",
       "doc_ref": "main",
-      "visible_ready_marker_set": true,
-      "updated_at": "2026-04-20T04:20:09Z"
+      "updated_at": "2026-04-20T04:24:50Z"
     },
     "implement-guided-story-creation-handoff": {
       "slug": "implement-guided-story-creation-handoff",
@@ -295,7 +294,7 @@
       "doc_ref_mode": "main",
       "doc_ref": "main",
       "visible_ready_marker_set": true,
-      "updated_at": "2026-04-20T04:20:10Z"
+      "updated_at": "2026-04-20T04:24:51Z"
     },
     "implement-guided-vision-intake": {
       "slug": "implement-guided-vision-intake",
@@ -321,7 +320,7 @@
       "planning_pr_merged": true,
       "doc_ref_mode": "main",
       "doc_ref": "main",
-      "updated_at": "2026-04-20T04:20:11Z"
+      "updated_at": "2026-04-20T04:24:52Z"
     },
     "implement-resume-flow-and-session-menu": {
       "slug": "implement-resume-flow-and-session-menu",
@@ -350,7 +349,7 @@
       "planning_pr_merged": true,
       "doc_ref_mode": "main",
       "doc_ref": "main",
-      "updated_at": "2026-04-20T04:20:12Z"
+      "updated_at": "2026-04-20T04:24:53Z"
     }
   }
 }

--- a/cmd/spec.go
+++ b/cmd/spec.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"bufio"
 	"fmt"
 	"io"
 
@@ -119,7 +120,52 @@ func newSpecCommand() *cobra.Command {
 	}
 	checklist.Flags().StringVar(&profile, "profile", "general", "checklist profile: general, ui-flow, api-integration, data-migration")
 
-	cmd.AddCommand(show, edit, statusCmd, analyze, checklist)
+	handoff := &cobra.Command{
+		Use:   "handoff <epic-slug>",
+		Short: "Continue a guided spec into the first story set",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			session, err := planningManager().ReadGuidedSessionByEpic(args[0])
+			if err != nil {
+				return err
+			}
+			fmt.Fprintf(cmd.OutOrStdout(), "Spec recap:\nCurrent understanding: %s\nRecommended next stage: continue into stories.\n", session.Summary)
+			preview, err := planningManager().PreviewStorySlices(args[0])
+			if err != nil {
+				return err
+			}
+			printStorySlicePreview(cmd.OutOrStdout(), preview)
+			ok, err := confirmStorySliceApply(bufio.NewReader(cmd.InOrStdin()), cmd.OutOrStdout())
+			if err != nil {
+				return err
+			}
+			if !ok {
+				updated, err := planningManager().UpdateGuidedSession(session.ChainID, planning.GuidedSessionUpdateInput{
+					CurrentStage: "spec",
+					StageStatus:  "in_progress",
+					NextAction:   "Spec handoff is ready when you want to create the first story set.",
+				})
+				if err != nil {
+					return err
+				}
+				fmt.Fprintf(cmd.OutOrStdout(), "Checkpoint saved for %s\nNext: %s\n", updated.ChainID, updated.NextAction)
+				return nil
+			}
+			result, err := planningManager().ApplyStorySlices(args[0])
+			if err != nil {
+				return err
+			}
+			printStorySliceApplyResult(cmd.OutOrStdout(), result)
+			updated, err := planningManager().AdvanceGuidedSessionToStories(args[0])
+			if err != nil {
+				return err
+			}
+			fmt.Fprintf(cmd.OutOrStdout(), "Next: %s\n", updated.NextAction)
+			return nil
+		},
+	}
+
+	cmd.AddCommand(show, edit, statusCmd, analyze, checklist, handoff)
 	return cmd
 }
 

--- a/cmd/spec_test.go
+++ b/cmd/spec_test.go
@@ -193,3 +193,130 @@ func TestSpecChecklistCommandWritesChecklistAndFailsOnBlockingFindings(t *testin
 		t.Fatalf("expected checklist section in spec note:\n%s", note.Content)
 	}
 }
+
+func TestSpecHandoffAppliesStorySlicesAndAdvancesSessionToStories(t *testing.T) {
+	root := t.TempDir()
+	ws := workspace.New(root)
+	if _, err := ws.Init(); err != nil {
+		t.Fatal(err)
+	}
+	manager := planning.New(ws)
+	if _, err := manager.CreateBrainstorm("Guided Planning"); err != nil {
+		t.Fatal(err)
+	}
+	if _, _, err := manager.UpdateGuidedBrainstormIntake("guided-planning", planning.GuidedBrainstormIntakeInput{
+		Vision:             "Guide a user from a rough feature idea into a shaped plan.",
+		SupportingMaterial: "docs/research.md",
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := manager.UpdateBrainstormRefinement("guided-planning", planning.BrainstormRefinementInput{
+		Problem:                "Planning starts too artifact-first.",
+		UserValue:              "Users get a collaborative planning flow.",
+		Constraints:            "Keep the tool local-first.",
+		Appetite:               "One focused planning session.",
+		RemainingOpenQuestions: "How far should the guided loop go in v1?",
+		CandidateApproaches:    "Promote at an explicit checkpoint.",
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if _, _, err := manager.PromoteGuidedBrainstormSession("guided-planning"); err != nil {
+		t.Fatal(err)
+	}
+	if _, _, err := manager.AdvanceGuidedSessionToSpec("guided-planning"); err != nil {
+		t.Fatal(err)
+	}
+
+	body := strings.Join([]string{
+		"# Guided Planning Spec",
+		"",
+		"Created: now",
+		"",
+		"## Why",
+		"",
+		"Guided planning needs execution-ready stories.",
+		"",
+		"## Problem",
+		"",
+		"Story creation is still manual.",
+		"",
+		"## Goals",
+		"",
+		"- derive a first story set",
+		"",
+		"## Non-Goals",
+		"",
+		"- reinvent task tracking",
+		"",
+		"## Constraints",
+		"",
+		"- keep the output local-first",
+		"",
+		"## Solution Shape",
+		"",
+		"Use the approved spec to drive story creation.",
+		"",
+		"## Flows",
+		"",
+		"1. Review spec.",
+		"2. Create stories.",
+		"",
+		"## Data / Interfaces",
+		"",
+		"- guided session state",
+		"",
+		"## Risks / Open Questions",
+		"",
+		"- duplicate stories",
+		"",
+		"## Rollout",
+		"",
+		"- dogfood locally",
+		"",
+		"## Verification",
+		"",
+		"- run story slice coverage",
+		"",
+		"## Story Breakdown",
+		"",
+		"- Carry forward recap state",
+		"- Apply first story set",
+		"",
+	}, "\n")
+	if _, err := manager.UpdateSpec("guided-planning", notes.UpdateInput{
+		Body: &body,
+		Metadata: map[string]any{
+			"status": "approved",
+		},
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	var output bytes.Buffer
+	command := newRootCmd()
+	command.SetOut(&output)
+	command.SetErr(&output)
+	command.SetIn(strings.NewReader("y\n"))
+	command.SetArgs([]string{"--project", root, "spec", "handoff", "guided-planning"})
+	if err := command.Execute(); err != nil {
+		t.Fatalf("expected spec handoff to succeed: %v\n%s", err, output.String())
+	}
+
+	state, err := ws.ReadGuidedSessionState()
+	if err != nil {
+		t.Fatal(err)
+	}
+	session := state.Sessions["brainstorm/guided-planning"]
+	if session.CurrentStage != "stories" {
+		t.Fatalf("expected session to advance to stories stage: %+v", session)
+	}
+	if session.StageStatuses["spec"] != "done" || session.StageStatuses["stories"] != "in_progress" {
+		t.Fatalf("expected story-stage handoff statuses: %+v", session)
+	}
+	if _, err := notes.Read(filepath.Join(root, ".plan", "stories", "carry-forward-recap-state.md")); err != nil {
+		t.Fatalf("expected first story to be created: %v", err)
+	}
+	if !strings.Contains(output.String(), "story_slice_apply: .plan/specs/guided-planning.md") {
+		t.Fatalf("expected story handoff output:\n%s", output.String())
+	}
+}

--- a/internal/planning/guided_session.go
+++ b/internal/planning/guided_session.go
@@ -304,6 +304,37 @@ func (m *Manager) AdvanceGuidedSessionToSpec(epicSlug string) (*workspace.Guided
 	return &record, spec, nil
 }
 
+func (m *Manager) AdvanceGuidedSessionToStories(epicSlug string) (*workspace.GuidedSessionRecord, error) {
+	session, err := m.ReadGuidedSessionByEpic(epicSlug)
+	if err != nil {
+		return nil, err
+	}
+	updated, err := m.UpdateGuidedSession(session.ChainID, GuidedSessionUpdateInput{
+		CurrentStage: "stories",
+		Summary:      "Spec handoff complete. Continue the planning flow in the stories stage.",
+		NextAction:   "Start implementation from the created execution-ready story set.",
+		StageStatus:  "in_progress",
+	})
+	if err != nil {
+		return nil, err
+	}
+	state, err := m.workspace.ReadGuidedSessionState()
+	if err != nil {
+		return nil, err
+	}
+	record := state.Sessions[updated.ChainID]
+	record.StageStatuses["spec"] = "done"
+	record.StageStatuses["stories"] = "in_progress"
+	record.UpdatedAt = time.Now().UTC().Format(time.RFC3339)
+	state.LastActiveChain = record.ChainID
+	state.LastUpdatedAt = record.UpdatedAt
+	state.Sessions[record.ChainID] = record
+	if err := m.workspace.WriteGuidedSessionState(*state); err != nil {
+		return nil, err
+	}
+	return &record, nil
+}
+
 func (m *Manager) ReviewGuidedSessionStages(chainID string) (*workspace.GuidedSessionRecord, []string, error) {
 	state, err := m.workspace.ReadGuidedSessionState()
 	if err != nil {


### PR DESCRIPTION
Fixes #18

## Summary
- add a guided `spec handoff` command that previews and applies the first story set from an approved spec
- advance guided sessions into the stories stage and keep next-action summaries current
- cover the handoff flow with command tests

## Verification
- go test ./cmd -run "TestSpec(HandoffAppliesStorySlicesAndAdvancesSessionToStories|AnalyzeCommandWritesAnalysisAndFailsOnBlockingFindings|ChecklistCommandWritesChecklistAndFailsOnBlockingFindings)$"
- go test ./internal/planning -run "Test(GuidedBrainstormSessionPersistsChainStateAndStaysStable|SwitchAndReopenGuidedSessionState)$"
- go test ./...
- go build ./...
- go run . check --project .
- git diff --check

## Release Notes
- add the guided spec-to-story handoff flow