### PR TITLE
chore: reconcile github story state

### DIFF
--- a/.plan/.meta/github.json
+++ b/.plan/.meta/github.json
@@ -3,8 +3,8 @@
   "repo_url": "https://github.com/JimmyMcBride/plan",
   "default_branch": "main",
   "last_enabled_at": "2026-04-20T03:04:26Z",
-  "last_updated_at": "2026-04-20T04:24:53Z",
-  "last_reconciled_at": "2026-04-20T04:24:53Z",
+  "last_updated_at": "2026-04-20T04:29:45Z",
+  "last_reconciled_at": "2026-04-20T04:29:45Z",
   "stories": {
     "add-brainstorm-stage-recap-and-stop-flow": {
       "slug": "add-brainstorm-stage-recap-and-stop-flow",
@@ -34,7 +34,7 @@
       "planning_pr_merged": true,
       "doc_ref_mode": "main",
       "doc_ref": "main",
-      "updated_at": "2026-04-20T04:24:42Z"
+      "updated_at": "2026-04-20T04:29:35Z"
     },
     "add-cluster-reflection-and-gap-guidance": {
       "slug": "add-cluster-reflection-and-gap-guidance",
@@ -63,7 +63,7 @@
       "planning_pr_merged": true,
       "doc_ref_mode": "main",
       "doc_ref": "main",
-      "updated_at": "2026-04-20T04:24:43Z"
+      "updated_at": "2026-04-20T04:29:36Z"
     },
     "add-guided-session-state-model": {
       "slug": "add-guided-session-state-model",
@@ -89,7 +89,7 @@
       "planning_pr_merged": true,
       "doc_ref_mode": "main",
       "doc_ref": "main",
-      "updated_at": "2026-04-20T04:24:44Z"
+      "updated_at": "2026-04-20T04:29:37Z"
     },
     "add-multi-session-switching-and-coverage": {
       "slug": "add-multi-session-switching-and-coverage",
@@ -118,7 +118,7 @@
       "planning_pr_merged": true,
       "doc_ref_mode": "main",
       "doc_ref": "main",
-      "updated_at": "2026-04-20T04:24:45Z"
+      "updated_at": "2026-04-20T04:29:38Z"
     },
     "add-reopen-impact-summary-and-needs-review-markers": {
       "slug": "add-reopen-impact-summary-and-needs-review-markers",
@@ -147,7 +147,7 @@
       "planning_pr_merged": true,
       "doc_ref_mode": "main",
       "doc_ref": "main",
-      "updated_at": "2026-04-20T04:24:46Z"
+      "updated_at": "2026-04-20T04:29:39Z"
     },
     "add-roadmap-parking-writes-and-source-links": {
       "slug": "add-roadmap-parking-writes-and-source-links",
@@ -176,7 +176,7 @@
       "planning_pr_merged": true,
       "doc_ref_mode": "main",
       "doc_ref": "main",
-      "updated_at": "2026-04-20T04:24:47Z"
+      "updated_at": "2026-04-20T04:29:40Z"
     },
     "implement-brainstorm-to-epic-handoff": {
       "slug": "implement-brainstorm-to-epic-handoff",
@@ -206,7 +206,7 @@
       "planning_pr_merged": true,
       "doc_ref_mode": "main",
       "doc_ref": "main",
-      "updated_at": "2026-04-20T04:24:48Z"
+      "updated_at": "2026-04-20T04:29:40Z"
     },
     "implement-downstream-review-checkpoints": {
       "slug": "implement-downstream-review-checkpoints",
@@ -235,7 +235,7 @@
       "planning_pr_merged": true,
       "doc_ref_mode": "main",
       "doc_ref": "main",
-      "updated_at": "2026-04-20T04:24:49Z"
+      "updated_at": "2026-04-20T04:29:41Z"
     },
     "implement-epic-to-spec-handoff": {
       "slug": "implement-epic-to-spec-handoff",
@@ -264,7 +264,7 @@
       "planning_pr_merged": true,
       "doc_ref_mode": "main",
       "doc_ref": "main",
-      "updated_at": "2026-04-20T04:24:50Z"
+      "updated_at": "2026-04-20T04:29:42Z"
     },
     "implement-guided-story-creation-handoff": {
       "slug": "implement-guided-story-creation-handoff",
@@ -287,14 +287,13 @@
       ],
       "issue_number": 18,
       "issue_url": "https://github.com/JimmyMcBride/plan/issues/18",
-      "remote_state": "open",
+      "remote_state": "closed",
       "planning_pr_number": 9,
       "planning_pr_url": "https://github.com/JimmyMcBride/plan/pull/9",
       "planning_pr_merged": true,
       "doc_ref_mode": "main",
       "doc_ref": "main",
-      "visible_ready_marker_set": true,
-      "updated_at": "2026-04-20T04:24:51Z"
+      "updated_at": "2026-04-20T04:29:43Z"
     },
     "implement-guided-vision-intake": {
       "slug": "implement-guided-vision-intake",
@@ -320,7 +319,7 @@
       "planning_pr_merged": true,
       "doc_ref_mode": "main",
       "doc_ref": "main",
-      "updated_at": "2026-04-20T04:24:52Z"
+      "updated_at": "2026-04-20T04:29:45Z"
     },
     "implement-resume-flow-and-session-menu": {
       "slug": "implement-resume-flow-and-session-menu",
@@ -349,7 +348,7 @@
       "planning_pr_merged": true,
       "doc_ref_mode": "main",
       "doc_ref": "main",
-      "updated_at": "2026-04-20T04:24:53Z"
+      "updated_at": "2026-04-20T04:29:45Z"
     }
   }
 }


### PR DESCRIPTION
## Summary
- persist the post-merge GitHub story index refresh
- mark issue #18 as closed in local `.plan` metadata
- keep the repo clean after the full guided-planning issue loop

## Verification
- go run . update --project .
- go run . github reconcile --project . --update-visible
- go run . status --project .
- go run . check --project .

## Release Notes
- persist refreshed GitHub story metadata after reconcile