### PR TITLE
fix: avoid github reconcile timestamp churn

### DIFF
--- a/internal/planning/github_backend_test.go
+++ b/internal/planning/github_backend_test.go
@@ -557,6 +557,72 @@ func TestReconcileGitHubStoriesPromotesMainLinksAndPreservesUserText(t *testing.
 	}
 }
 
+func TestReconcileGitHubStoriesNoOpDoesNotRewriteStateFile(t *testing.T) {
+	client := &stubGitHubClient{
+		preflight: &GitHubRepoInfo{
+			Repo:          "JimmyMcBride/plan",
+			RepoURL:       "https://github.com/JimmyMcBride/plan",
+			DefaultBranch: "main",
+		},
+		context: &GitHubContext{
+			Repo: GitHubRepoInfo{
+				Repo:          "JimmyMcBride/plan",
+				RepoURL:       "https://github.com/JimmyMcBride/plan",
+				DefaultBranch: "main",
+			},
+			CurrentBranch: "main",
+			CurrentSHA:    "abc123def456",
+		},
+	}
+	reset := SetGitHubClientFactoryForTesting(func() GitHubClient { return client })
+	t.Cleanup(reset)
+
+	root := t.TempDir()
+	manager := newGitHubStoryManager(t, root)
+	if _, err := manager.EnableGitHubBackend(); err != nil {
+		t.Fatal(err)
+	}
+	seedApprovedGitHubEpic(t, manager)
+	if _, err := manager.CreateStory(
+		"billing",
+		"Implement invoices",
+		"Create invoice generation flow",
+		[]string{"Generate invoices from line items"},
+		[]string{"Run focused billing tests"},
+		nil,
+	); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := manager.ReconcileGitHubStories(GitHubReconcileOptions{}); err != nil {
+		t.Fatal(err)
+	}
+	info, err := manager.workspace.Resolve()
+	if err != nil {
+		t.Fatal(err)
+	}
+	before, err := os.ReadFile(info.GitHubFile)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	result, err := manager.ReconcileGitHubStories(GitHubReconcileOptions{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(result.UpdatedIssues) != 0 {
+		t.Fatalf("expected no issue updates on no-op reconcile: %+v", result)
+	}
+
+	after, err := os.ReadFile(info.GitHubFile)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(before) != string(after) {
+		t.Fatalf("expected no-op reconcile to leave github state unchanged")
+	}
+}
+
 func TestGitHubStoryReadinessDerivesFromDependencies(t *testing.T) {
 	client := &stubGitHubClient{
 		preflight: &GitHubRepoInfo{

--- a/internal/planning/github_reconcile.go
+++ b/internal/planning/github_reconcile.go
@@ -3,6 +3,7 @@ package planning
 import (
 	"fmt"
 	"path/filepath"
+	"reflect"
 	"sort"
 	"time"
 
@@ -53,6 +54,8 @@ func (m *Manager) ReconcileGitHubStories(options GitHubReconcileOptions) (*GitHu
 	if context.CurrentBranch == context.Repo.DefaultBranch {
 		result.PlanningPromote = true
 	}
+	now := time.Now().UTC().Format(time.RFC3339)
+	stateChanged := false
 
 	slugs := make([]string, 0, len(state.Stories))
 	for slug := range state.Stories {
@@ -62,6 +65,7 @@ func (m *Manager) ReconcileGitHubStories(options GitHubReconcileOptions) (*GitHu
 
 	for _, slug := range slugs {
 		record := state.Stories[slug]
+		previous := record
 		epic, err := notes.Read(filepath.Join(info.EpicsDir, record.Epic+".md"))
 		if err != nil {
 			return nil, err
@@ -76,6 +80,7 @@ func (m *Manager) ReconcileGitHubStories(options GitHubReconcileOptions) (*GitHu
 		}
 		record.IssueURL = issue.URL
 		record.RemoteState = issue.State
+		record.VisibleReadyMarkerSet = containsString(issue.Labels, planIssueReadyLabel) || containsString(issue.Labels, planIssueBlockedLabel)
 		if result.PlanningPromote {
 			record.PlanningPRMerged = true
 			record.DocRefMode = "main"
@@ -110,16 +115,27 @@ func (m *Manager) ReconcileGitHubStories(options GitHubReconcileOptions) (*GitHu
 			record.VisibleReadyMarkerSet = containsString(labels, planIssueReadyLabel) || containsString(labels, planIssueBlockedLabel)
 			result.UpdatedIssues = append(result.UpdatedIssues, fmt.Sprintf("#%d", record.IssueNumber))
 		}
-		record.UpdatedAt = time.Now().UTC().Format(time.RFC3339)
-		state.Stories[slug] = record
+		if gitHubStoryRecordChanged(previous, record) {
+			record.UpdatedAt = now
+			state.Stories[slug] = record
+			stateChanged = true
+		}
 	}
 
-	state.LastReconciled = time.Now().UTC().Format(time.RFC3339)
-	state.LastUpdatedAt = state.LastReconciled
-	if err := m.workspace.WriteGitHubState(*state); err != nil {
-		return nil, err
+	if stateChanged {
+		state.LastReconciled = now
+		state.LastUpdatedAt = now
+		if err := m.workspace.WriteGitHubState(*state); err != nil {
+			return nil, err
+		}
 	}
 	return result, nil
+}
+
+func gitHubStoryRecordChanged(before, after workspace.GitHubStoryRecord) bool {
+	before.UpdatedAt = ""
+	after.UpdatedAt = ""
+	return !reflect.DeepEqual(before, after)
 }
 
 func sameStringSlice(a, b []string) bool {


### PR DESCRIPTION
## Summary
- stop persisting GitHub story records when reconcile is a semantic no-op
- only bump story and state timestamps when actual GitHub-backed story state changes
- add a regression test that a second reconcile pass leaves `github.json` untouched

## Verification
- go test ./internal/planning -run "Test(ReconcileGitHubStoriesPromotesMainLinksAndPreservesUserText|ReconcileGitHubStoriesNoOpDoesNotRewriteStateFile|ReconcileUpdateVisibleAppliesDerivedLabels)$"
- go test ./...
- go build ./...
- go run . check --project .
- git diff --check

## Release Notes
- prevent `plan github reconcile` from rewriting timestamp-only GitHub state on no-op runs