### PR TITLE
docs: adopt develop-first gitflow for plan

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -3,6 +3,12 @@
 - What changed?
 - Why does it matter?
 
+## Target Branch
+
+- Normal work targets `develop`.
+- Release PRs use `release/vX.Y.Z -> main`.
+- Hotfix work must be merged back into `develop`.
+
 ## Testing
 
 - [ ] `go test ./...`

--- a/.plan/PROJECT.md
+++ b/.plan/PROJECT.md
@@ -24,6 +24,10 @@ memory/context-management bloat.
 - No hosted dependency is required for core workflows.
 - No issue-tracker clone behavior in the planning core.
 - External sync is later than local refinement quality.
+- This repo uses Gitflow with `develop` as the active integration branch,
+  `release/vX.Y.Z` as the release stabilization branch, and `main` as the
+  release-only production branch.
+- Protected branches are changed only through pull requests.
 
 ## Planning Rules
 
@@ -35,8 +39,20 @@ memory/context-management bloat.
 - If GitHub story mode is enabled, stories live in GitHub Issues rather than
   local markdown notes.
 - GitHub execution follows a queue loop: establish ready work, grab the next
-  issue or issues, ship a PR, review until ready, squash-merge, return to
-  `main`, run `plan update`, reconcile, then grab the next ready work.
+  issue or issues, ship a PR, review until ready, squash-merge into
+  `develop`, refresh local `develop` from `origin/develop`, run `plan update`,
+  reconcile, then grab the next ready work.
+
+## Delivery Rules
+
+- Normal ongoing work lands in `develop`.
+- Official releases are cut from `develop` onto `release/vX.Y.Z`, then merged
+  into `main`.
+- Release fixes land in `develop` first, then are cherry-picked into the active
+  `release/vX.Y.Z` branch.
+- Production hotfixes must be merged back into `develop`.
+- After each merge into `develop`, run
+  `./scripts/refresh-plan-develop-context.sh` to refresh local `plan` context.
 
 ## Notes
 

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ Execution loop in GitHub mode:
 3. Implement on a branch and open PR
 4. Review and iterate until ready
 5. Squash-merge
-6. Return to `main`, pull latest, update and reconcile
+6. Return to the integration branch, pull latest, update and reconcile
 7. Grab next ready issue and repeat
 
 The default path stays small. New shaping passes should improve the same
@@ -136,23 +136,32 @@ For GitHub-backed stories, use this loop:
 ```bash
 plan status --project .
 
-# do issue work on a branch and merge the PR
+# do issue work on a feature branch and merge the PR into the integration branch
 
-git switch main
-git pull --ff-only origin main
-plan update --project .
-plan github reconcile --project . --update-visible
-plan status --project .
+./scripts/refresh-plan-develop-context.sh
 ```
 
 Rules:
 
 - use `plan status --project .` as the queue view
 - take only issues shown in `ready_work`
-- work on a feature branch, not on `main`
-- squash-merge the PR when work is accepted
-- after merge, always return to `main`, pull, update, and reconcile before
-  grabbing the next issue
+- in this repo, normal work targets `develop`
+- work on a feature branch, not on `develop`, `release/*`, or `main`
+- squash-merge the PR when work is accepted unless release work needs a
+  different merge strategy
+- after merge into `develop`, run
+  `./scripts/refresh-plan-develop-context.sh` before grabbing the next issue
+
+## Repo Gitflow
+
+This repo uses Gitflow with `develop` as the active integration branch,
+`release/vX.Y.Z` as the protected stabilization branch, and `main` as the
+release-only production branch.
+
+Normal work flows into `develop`. Official releases are cut from `develop` onto
+`release/vX.Y.Z`, then merged into `main` to publish.
+
+Release and maintenance rules live in [docs/gitflow.md](docs/gitflow.md).
 
 ## Roadmap Direction
 
@@ -220,12 +229,18 @@ The fixtures live under `testdata/evals/fixtures/` and the rubric code lives in
 ## Release Flow
 
 - Pull requests run `go test ./...` and `go build ./...` in CI.
-- Every push to `main` tags the next patch release if `HEAD` is not already tagged.
+- `develop` is the default pull-request target for routine work.
+- Official releases cut `release/vX.Y.Z` from `develop`, stabilize there, then
+  merge into `main`.
+- Every push to `main` still tags the next patch release if `HEAD` is not
+  already tagged.
 - The release workflow builds platform archives and publishes a checksum file with the release assets.
 - `scripts/install.sh` only falls back to a source build when no published release can be resolved. Download or checksum failures stay hard failures.
 
 ## Maintainers
 
+- Use [docs/gitflow.md](docs/gitflow.md) as the branching source of truth for
+  this repo.
 - Keep pull request titles and descriptions release-note-friendly. The `## Release Notes` section in the PR template is the source of truth for published release changelogs.
 - Include the verification commands you ran in the PR so the release notes have a clean audit trail.
 - Use `scripts/next-release-tag.sh` if you need to preview the next patch tag locally.

--- a/docs/gitflow.md
+++ b/docs/gitflow.md
@@ -1,0 +1,97 @@
+# `plan` Gitflow
+
+This document is the gitflow source of truth for the `plan` repository.
+
+## Branch Roles
+
+- `develop` is the active long-lived integration branch and the default target
+  for routine work.
+- `release/vX.Y.Z` is a protected release stabilization branch cut from
+  `develop` when an official release is being prepared.
+- `main` is the protected production branch. Merges into `main` remain the
+  release event that triggers automatic publishing.
+
+## Protected Branches
+
+- `develop`, `release/*`, and `main` are protected branches.
+- Never push directly to `develop`, any `release/*` branch, or `main`.
+- Never delete `develop`, any `release/*` branch, or `main`.
+- All changes to protected branches land through pull requests.
+
+Current repo configuration:
+
+- `develop` exists as the active integration branch.
+- GitHub rules protect `develop` and `release/*` with pull-request-only updates,
+  required CI checks, no force pushes, and no deletions.
+- `main` remains separately protected and keeps the existing release publish
+  behavior unchanged.
+
+## Normal Development Flow
+
+1. Start feature or bug-fix work from the current integration branch, usually
+   `develop`.
+2. Open routine pull requests into `develop`.
+3. Do not merge routine work directly into `main`.
+4. When a release is ready, cut `release/vX.Y.Z` from the current `develop`.
+5. Stabilize and validate the release branch as needed.
+6. Open a pull request from `release/vX.Y.Z` into `main`.
+7. Merge into `main` only when ready to publish the official version.
+
+## Release Stabilization
+
+1. If a fix is needed while a release branch is open, land the fix in
+   `develop` first.
+2. After the fix exists in `develop`, cherry-pick the exact commit into the
+   relevant `release/vX.Y.Z` branch.
+3. Do not make one-off fixes directly on the release branch without first
+   putting the equivalent fix into `develop`.
+4. Treat `develop` as the long-term source of truth for future work.
+
+## Hotfixes
+
+1. If an urgent production-only fix is required, branch from the active
+   `release/vX.Y.Z` branch or from `main`, whichever best reflects production.
+2. Use the same pull-request-only process for that hotfix path.
+3. After the production fix is prepared or merged, make sure the equivalent fix
+   is merged back into `develop`.
+4. `develop` must end up containing every production fix.
+
+## Release Branch Retention
+
+- Preserve release branches as historical snapshots of what was prepared for
+  each official version.
+- Keep them available for inspection, regression history, and later debugging
+  questions.
+
+## `plan` Maintenance Loop
+
+After any pull request is merged into `develop`:
+
+1. Fetch latest remote state.
+2. Check out the updated `develop` branch from `origin/develop`.
+3. Refresh `plan` project context from the latest `develop` state.
+
+Repo helper:
+
+```bash
+./scripts/refresh-plan-develop-context.sh
+```
+
+That helper:
+
+- fetches latest remote refs
+- checks out and fast-forwards local `develop`
+- runs `go run . update --project .`
+- runs `go run . github reconcile --project . --update-visible` when GitHub
+  story mode is enabled
+- prints the latest `plan status --project .`
+
+## Operational Defaults
+
+- Treat `develop` as the active branch between releases.
+- Treat `main` as release-only.
+- Treat `release/vX.Y.Z` as the controlled bridge from `develop` to `main`.
+- Use semantic version naming for release branches, exactly
+  `release/vX.Y.Z`.
+- If a choice is ambiguous, prefer the path that keeps `develop` current and
+  keeps direct changes off protected branches.

--- a/docs/using-plan.md
+++ b/docs/using-plan.md
@@ -2,7 +2,7 @@
 
 This guide describes how to use `plan` as it exists right now.
 
-It is based on the current command surface on `main`, not on older roadmap
+It is based on the current command surface in the repo, not on older roadmap
 ideas.
 
 ## Current Product State
@@ -405,7 +405,7 @@ If stories are GitHub-backed, use this execution loop:
 3. Do the work on a feature branch and open a PR
 4. Review and iterate until the PR is ready
 5. Squash-merge the PR
-6. Return to `main`
+6. Return to the integration branch
 7. Pull latest changes
 8. Run `plan update --project .`
 9. Run `plan github reconcile --project . --update-visible`
@@ -417,10 +417,10 @@ Recommended commands:
 ```bash
 plan status --project .
 
-# do issue work on a branch and merge the PR
+# do issue work on a branch and merge the PR into your integration branch
 
-git switch main
-git pull --ff-only origin main
+git switch <integration-branch>
+git pull --ff-only origin <integration-branch>
 plan update --project .
 plan github reconcile --project . --update-visible
 plan status --project .
@@ -432,7 +432,8 @@ Use this model:
 - GitHub Issue = execution unit
 - PR = implementation review loop
 - squash-merge = queue advancement
-- `update` + `reconcile` = refresh local truth before taking the next issue
+- integration-branch refresh + `update` + `reconcile` = refresh local truth
+  before taking the next issue
 
 Show a story:
 

--- a/scripts/refresh-plan-develop-context.sh
+++ b/scripts/refresh-plan-develop-context.sh
@@ -1,0 +1,44 @@
+#!/bin/sh
+
+set -eu
+
+PROJECT_DIR="${1:-.}"
+
+die() {
+  printf 'refresh-plan-develop-context: %s\n' "$1" >&2
+  exit 1
+}
+
+need_clean_worktree() {
+  if [ -n "$(git status --porcelain)" ]; then
+    die "clean worktree required before switching to develop"
+  fi
+}
+
+ensure_local_develop() {
+  if git show-ref --verify --quiet refs/heads/develop; then
+    git switch develop >/dev/null
+    git branch --set-upstream-to=origin/develop develop >/dev/null 2>&1 || true
+    return
+  fi
+  git switch -c develop --track origin/develop >/dev/null
+}
+
+github_backend_enabled() {
+  workspace_file="${PROJECT_DIR}/.plan/.meta/workspace.json"
+  [ -f "${workspace_file}" ] || return 1
+  grep -q '"story_backend"[[:space:]]*:[[:space:]]*"github"' "${workspace_file}"
+}
+
+need_clean_worktree
+git fetch origin
+ensure_local_develop
+git pull --ff-only origin develop
+
+go run . update --project "${PROJECT_DIR}"
+
+if github_backend_enabled; then
+  go run . github reconcile --project "${PROJECT_DIR}" --update-visible
+fi
+
+go run . status --project "${PROJECT_DIR}"


### PR DESCRIPTION
## Summary

- make `develop` the documented integration branch for routine work
- document release flow as `develop -> release/vX.Y.Z -> main`
- add a repo-local gitflow source-of-truth doc and post-merge refresh helper

## Testing

- [x] `sh -n scripts/refresh-plan-develop-context.sh`
- [x] `git diff --check`
- [x] `go test ./...`
- [x] `go build ./...`
- [ ] Other:

## Release Notes

- User-facing change: maintainer docs now use a develop-first gitflow for this repo.
- Planning or workflow impact: routine work targets `develop`; releases flow through `release/vX.Y.Z` into `main`.
- Follow-up work: none required for `plan`; remote protections are already configured.

## Planning

- Related epic/spec/story: `.plan/PROJECT.md`

## Notes

- Repo now treats `develop` as the integration branch.
- Release path is `develop -> release/vX.Y.Z -> main`.
- Remote protections are already configured.
- Helper script added for post-merge `plan` refresh.
