### PR TITLE
fix: reconcile github state after default branch changes

### DIFF
--- a/.plan/.meta/github.json
+++ b/.plan/.meta/github.json
@@ -1,10 +1,10 @@
 {
   "repo": "JimmyMcBride/plan",
   "repo_url": "https://github.com/JimmyMcBride/plan",
-  "default_branch": "main",
+  "default_branch": "develop",
   "last_enabled_at": "2026-04-20T03:04:26Z",
-  "last_updated_at": "2026-04-20T04:29:45Z",
-  "last_reconciled_at": "2026-04-20T04:29:45Z",
+  "last_updated_at": "2026-04-20T06:12:21Z",
+  "last_reconciled_at": "2026-04-20T06:12:21Z",
   "stories": {
     "add-brainstorm-stage-recap-and-stop-flow": {
       "slug": "add-brainstorm-stage-recap-and-stop-flow",
@@ -33,8 +33,8 @@
       "planning_pr_url": "https://github.com/JimmyMcBride/plan/pull/9",
       "planning_pr_merged": true,
       "doc_ref_mode": "main",
-      "doc_ref": "main",
-      "updated_at": "2026-04-20T04:29:35Z"
+      "doc_ref": "develop",
+      "updated_at": "2026-04-20T06:05:20Z"
     },
     "add-cluster-reflection-and-gap-guidance": {
       "slug": "add-cluster-reflection-and-gap-guidance",
@@ -62,8 +62,8 @@
       "planning_pr_url": "https://github.com/JimmyMcBride/plan/pull/9",
       "planning_pr_merged": true,
       "doc_ref_mode": "main",
-      "doc_ref": "main",
-      "updated_at": "2026-04-20T04:29:36Z"
+      "doc_ref": "develop",
+      "updated_at": "2026-04-20T06:05:20Z"
     },
     "add-guided-session-state-model": {
       "slug": "add-guided-session-state-model",
@@ -88,8 +88,8 @@
       "planning_pr_url": "https://github.com/JimmyMcBride/plan/pull/9",
       "planning_pr_merged": true,
       "doc_ref_mode": "main",
-      "doc_ref": "main",
-      "updated_at": "2026-04-20T04:29:37Z"
+      "doc_ref": "develop",
+      "updated_at": "2026-04-20T06:05:20Z"
     },
     "add-multi-session-switching-and-coverage": {
       "slug": "add-multi-session-switching-and-coverage",
@@ -117,8 +117,8 @@
       "planning_pr_url": "https://github.com/JimmyMcBride/plan/pull/9",
       "planning_pr_merged": true,
       "doc_ref_mode": "main",
-      "doc_ref": "main",
-      "updated_at": "2026-04-20T04:29:38Z"
+      "doc_ref": "develop",
+      "updated_at": "2026-04-20T06:05:20Z"
     },
     "add-reopen-impact-summary-and-needs-review-markers": {
       "slug": "add-reopen-impact-summary-and-needs-review-markers",
@@ -146,8 +146,8 @@
       "planning_pr_url": "https://github.com/JimmyMcBride/plan/pull/9",
       "planning_pr_merged": true,
       "doc_ref_mode": "main",
-      "doc_ref": "main",
-      "updated_at": "2026-04-20T04:29:39Z"
+      "doc_ref": "develop",
+      "updated_at": "2026-04-20T06:05:20Z"
     },
     "add-roadmap-parking-writes-and-source-links": {
       "slug": "add-roadmap-parking-writes-and-source-links",
@@ -175,8 +175,8 @@
       "planning_pr_url": "https://github.com/JimmyMcBride/plan/pull/9",
       "planning_pr_merged": true,
       "doc_ref_mode": "main",
-      "doc_ref": "main",
-      "updated_at": "2026-04-20T04:29:40Z"
+      "doc_ref": "develop",
+      "updated_at": "2026-04-20T06:05:20Z"
     },
     "implement-brainstorm-to-epic-handoff": {
       "slug": "implement-brainstorm-to-epic-handoff",
@@ -205,8 +205,8 @@
       "planning_pr_url": "https://github.com/JimmyMcBride/plan/pull/9",
       "planning_pr_merged": true,
       "doc_ref_mode": "main",
-      "doc_ref": "main",
-      "updated_at": "2026-04-20T04:29:40Z"
+      "doc_ref": "develop",
+      "updated_at": "2026-04-20T06:05:20Z"
     },
     "implement-downstream-review-checkpoints": {
       "slug": "implement-downstream-review-checkpoints",
@@ -234,8 +234,8 @@
       "planning_pr_url": "https://github.com/JimmyMcBride/plan/pull/9",
       "planning_pr_merged": true,
       "doc_ref_mode": "main",
-      "doc_ref": "main",
-      "updated_at": "2026-04-20T04:29:41Z"
+      "doc_ref": "develop",
+      "updated_at": "2026-04-20T06:05:20Z"
     },
     "implement-epic-to-spec-handoff": {
       "slug": "implement-epic-to-spec-handoff",
@@ -263,8 +263,8 @@
       "planning_pr_url": "https://github.com/JimmyMcBride/plan/pull/9",
       "planning_pr_merged": true,
       "doc_ref_mode": "main",
-      "doc_ref": "main",
-      "updated_at": "2026-04-20T04:29:42Z"
+      "doc_ref": "develop",
+      "updated_at": "2026-04-20T06:05:20Z"
     },
     "implement-guided-story-creation-handoff": {
       "slug": "implement-guided-story-creation-handoff",
@@ -292,8 +292,8 @@
       "planning_pr_url": "https://github.com/JimmyMcBride/plan/pull/9",
       "planning_pr_merged": true,
       "doc_ref_mode": "main",
-      "doc_ref": "main",
-      "updated_at": "2026-04-20T04:29:43Z"
+      "doc_ref": "develop",
+      "updated_at": "2026-04-20T06:05:20Z"
     },
     "implement-guided-vision-intake": {
       "slug": "implement-guided-vision-intake",
@@ -318,8 +318,8 @@
       "planning_pr_url": "https://github.com/JimmyMcBride/plan/pull/9",
       "planning_pr_merged": true,
       "doc_ref_mode": "main",
-      "doc_ref": "main",
-      "updated_at": "2026-04-20T04:29:45Z"
+      "doc_ref": "develop",
+      "updated_at": "2026-04-20T06:05:20Z"
     },
     "implement-resume-flow-and-session-menu": {
       "slug": "implement-resume-flow-and-session-menu",
@@ -347,8 +347,8 @@
       "planning_pr_url": "https://github.com/JimmyMcBride/plan/pull/9",
       "planning_pr_merged": true,
       "doc_ref_mode": "main",
-      "doc_ref": "main",
-      "updated_at": "2026-04-20T04:29:45Z"
+      "doc_ref": "develop",
+      "updated_at": "2026-04-20T06:05:20Z"
     }
   }
 }

--- a/internal/planning/github_backend_test.go
+++ b/internal/planning/github_backend_test.go
@@ -70,7 +70,9 @@ func (s *stubGitHubClient) UpdateIssue(projectDir, repo string, issueNumber int,
 	if strings.TrimSpace(input.State) != "" {
 		issue.State = input.State
 	}
-	issue.Labels = append([]string(nil), input.Labels...)
+	if input.Labels != nil {
+		issue.Labels = append([]string(nil), input.Labels...)
+	}
 	return issue, nil
 }
 
@@ -623,6 +625,70 @@ func TestReconcileGitHubStoriesNoOpDoesNotRewriteStateFile(t *testing.T) {
 	}
 }
 
+func TestReconcileGitHubStoriesRefreshesRepoDefaultBranchInState(t *testing.T) {
+	client := &stubGitHubClient{
+		preflight: &GitHubRepoInfo{
+			Repo:          "JimmyMcBride/plan",
+			RepoURL:       "https://github.com/JimmyMcBride/plan",
+			DefaultBranch: "main",
+		},
+		context: &GitHubContext{
+			Repo: GitHubRepoInfo{
+				Repo:          "JimmyMcBride/plan",
+				RepoURL:       "https://github.com/JimmyMcBride/plan",
+				DefaultBranch: "main",
+			},
+			CurrentBranch: "main",
+			CurrentSHA:    "abc123def456",
+		},
+	}
+	reset := SetGitHubClientFactoryForTesting(func() GitHubClient { return client })
+	t.Cleanup(reset)
+
+	root := t.TempDir()
+	manager := newGitHubStoryManager(t, root)
+	if _, err := manager.EnableGitHubBackend(); err != nil {
+		t.Fatal(err)
+	}
+	seedApprovedGitHubEpic(t, manager)
+	if _, err := manager.CreateStory(
+		"billing",
+		"Implement invoices",
+		"Create invoice generation flow",
+		[]string{"Generate invoices from line items"},
+		[]string{"Run focused billing tests"},
+		nil,
+	); err != nil {
+		t.Fatal(err)
+	}
+
+	client.context.Repo.DefaultBranch = "develop"
+	client.context.CurrentBranch = "develop"
+
+	result, err := manager.ReconcileGitHubStories(GitHubReconcileOptions{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.DefaultBranch != "develop" {
+		t.Fatalf("expected reconcile result to report develop default branch: %+v", result)
+	}
+
+	state, err := manager.workspace.ReadGitHubState()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if state.DefaultBranch != "develop" {
+		t.Fatalf("expected github state default branch to refresh to develop: %+v", state)
+	}
+	record := state.Stories["implement-invoices"]
+	if record.DocRef != "develop" || record.DocRefMode != "main" {
+		t.Fatalf("expected record to promote links to develop: %+v", record)
+	}
+	if !strings.Contains(client.issues[101].Body, "/blob/develop/.plan/specs/billing.md") {
+		t.Fatalf("expected issue body to point at develop after reconcile:\n%s", client.issues[101].Body)
+	}
+}
+
 func TestGitHubStoryReadinessDerivesFromDependencies(t *testing.T) {
 	client := &stubGitHubClient{
 		preflight: &GitHubRepoInfo{
@@ -736,6 +802,86 @@ func TestReconcileUpdateVisibleAppliesDerivedLabels(t *testing.T) {
 	}
 	if !containsString(client.issues[102].Labels, planIssueBlockedLabel) {
 		t.Fatalf("expected blocked label on dependent issue: %+v", client.issues[102].Labels)
+	}
+}
+
+func TestReconcileUpdateVisibleClearsDerivedLabelsAndBecomesNoOp(t *testing.T) {
+	client := &stubGitHubClient{
+		preflight: &GitHubRepoInfo{
+			Repo:          "JimmyMcBride/plan",
+			RepoURL:       "https://github.com/JimmyMcBride/plan",
+			DefaultBranch: "main",
+		},
+		context: &GitHubContext{
+			Repo: GitHubRepoInfo{
+				Repo:          "JimmyMcBride/plan",
+				RepoURL:       "https://github.com/JimmyMcBride/plan",
+				DefaultBranch: "main",
+			},
+			CurrentBranch: "main",
+			CurrentSHA:    "abc123def456",
+		},
+	}
+	reset := SetGitHubClientFactoryForTesting(func() GitHubClient { return client })
+	t.Cleanup(reset)
+
+	root := t.TempDir()
+	manager := newGitHubStoryManager(t, root)
+	if _, err := manager.EnableGitHubBackend(); err != nil {
+		t.Fatal(err)
+	}
+	seedApprovedGitHubEpic(t, manager)
+	if _, err := manager.CreateStory("billing", "Implement invoices", "Create invoice generation flow", []string{"Generate invoices"}, []string{"Run billing tests"}, nil); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := manager.ReconcileGitHubStories(GitHubReconcileOptions{UpdateVisible: true}); err != nil {
+		t.Fatal(err)
+	}
+	if !containsString(client.issues[101].Labels, planIssueReadyLabel) {
+		t.Fatalf("expected ready label after first reconcile: %+v", client.issues[101].Labels)
+	}
+
+	if _, err := manager.UpdateStory("implement-invoices", StoryChanges{Status: "done"}); err != nil {
+		t.Fatal(err)
+	}
+	if !containsString(client.issues[101].Labels, planIssueReadyLabel) {
+		t.Fatalf("expected done issue to still carry stale ready label before cleanup: %+v", client.issues[101].Labels)
+	}
+
+	result, err := manager.ReconcileGitHubStories(GitHubReconcileOptions{UpdateVisible: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(result.UpdatedIssues) != 1 {
+		t.Fatalf("expected reconcile to clear stale derived labels once: %+v", result)
+	}
+	if containsString(client.issues[101].Labels, planIssueReadyLabel) || containsString(client.issues[101].Labels, planIssueBlockedLabel) {
+		t.Fatalf("expected derived labels to clear on done issue: %+v", client.issues[101].Labels)
+	}
+
+	info, err := manager.workspace.Resolve()
+	if err != nil {
+		t.Fatal(err)
+	}
+	before, err := os.ReadFile(info.GitHubFile)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	result, err = manager.ReconcileGitHubStories(GitHubReconcileOptions{UpdateVisible: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(result.UpdatedIssues) != 0 {
+		t.Fatalf("expected second reconcile to be a no-op after label cleanup: %+v", result)
+	}
+	after, err := os.ReadFile(info.GitHubFile)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(before) != string(after) {
+		t.Fatalf("expected second reconcile to leave github state unchanged")
 	}
 }
 

--- a/internal/planning/github_reconcile.go
+++ b/internal/planning/github_reconcile.go
@@ -51,11 +51,26 @@ func (m *Manager) ReconcileGitHubStories(options GitHubReconcileOptions) (*GitHu
 		CurrentBranch: context.CurrentBranch,
 		DefaultBranch: context.Repo.DefaultBranch,
 	}
+	stateChanged := false
+	if state.Repo != context.Repo.Repo {
+		state.Repo = context.Repo.Repo
+		stateChanged = true
+	}
+	if state.RepoURL != context.Repo.RepoURL {
+		state.RepoURL = context.Repo.RepoURL
+		stateChanged = true
+	}
+	if state.DefaultBranch != context.Repo.DefaultBranch {
+		state.DefaultBranch = context.Repo.DefaultBranch
+		stateChanged = true
+	}
 	if context.CurrentBranch == context.Repo.DefaultBranch {
 		result.PlanningPromote = true
 	}
 	now := time.Now().UTC().Format(time.RFC3339)
-	stateChanged := false
+	if stateChanged {
+		state.LastUpdatedAt = now
+	}
 
 	slugs := make([]string, 0, len(state.Stories))
 	for slug := range state.Stories {

--- a/internal/planning/github_story_backend.go
+++ b/internal/planning/github_story_backend.go
@@ -514,7 +514,7 @@ func mergeManagedIssueBody(existingBody, managedBody string) string {
 }
 
 func applyDerivedReadyLabels(labels []string, status string, ready bool) []string {
-	var out []string
+	out := make([]string, 0, len(labels))
 	for _, label := range labels {
 		if label == planIssueReadyLabel || label == planIssueBlockedLabel {
 			continue


### PR DESCRIPTION
## Summary

- refresh GitHub-backed planning state when the repo default branch changes
- make `plan github reconcile --update-visible` clear stale derived labels correctly
- add regressions for default-branch refresh and update-visible idempotence

## Testing

- [x] `go test ./internal/planning -run 'TestReconcileGitHubStoriesRefreshesRepoDefaultBranchInState|TestReconcileUpdateVisibleClearsDerivedLabelsAndBecomesNoOp|TestReconcileGitHubStoriesNoOpDoesNotRewriteStateFile|TestReconcileUpdateVisibleAppliesDerivedLabels' -count=1`
- [x] `go test ./internal/planning -count=1`
- [x] `go test ./...`
- [x] `go build ./...`
- [x] `git diff --check`
- [ ] Other:

## Release Notes

- User-facing change: `plan github reconcile` now tracks default-branch changes and stops repeatedly rewriting GitHub issue state after visible-label cleanup.
- Planning or workflow impact: post-merge refresh on `develop` no longer leaves stale `main` planning links in tracked GitHub state.
- Follow-up work: none required.

## Planning

- Related epic/spec/story: `.plan/.meta/github.json` reconcile fix
