### PR TITLE
plan: add guide packet and cli foundation scope

### DIFF
--- a/.plan/.meta/github.json
+++ b/.plan/.meta/github.json
@@ -65,6 +65,35 @@
       "doc_ref": "develop",
       "updated_at": "2026-04-20T06:05:20Z"
     },
+    "add-guide-packet-types-and-brainstorm-stage-packet-builder": {
+      "slug": "add-guide-packet-types-and-brainstorm-stage-packet-builder",
+      "title": "Add guide packet types and brainstorm-stage packet builder",
+      "epic": "guide-packet-and-cli-foundation",
+      "spec": "guide-packet-and-cli-foundation",
+      "status": "todo",
+      "description": "Add the internal guide-packet types and a brainstorm-stage packet builder that composes existing guided session state, workspace rules, and linked brainstorm artifact data into one stable read-only packet.",
+      "acceptance_criteria": [
+        "Guide packet types cover the approved v1 top-level packet sections and nested contract fields needed for brainstorm-stage guidance.",
+        "The brainstorm-stage builder maps existing guided session stage and checkpoint data into packet mode and session fields without introducing parallel durable state.",
+        "Packet generation is read-only and does not rewrite guided session metadata or planning artifacts."
+      ],
+      "verification": [
+        "Add focused tests for packet-building success, packet field coverage, and no-session or missing-artifact error paths.",
+        "Verify packet generation leaves .plan/.meta/guided_sessions.json unchanged."
+      ],
+      "resources": [
+        "Spec: .plan/specs/guide-packet-and-cli-foundation.md",
+        "Research: .plan/research/guide-packet-schema-and-cli-design.md"
+      ],
+      "issue_number": 34,
+      "issue_url": "https://github.com/JimmyMcBride/plan/issues/34",
+      "remote_state": "open",
+      "planning_pr_number": 33,
+      "planning_pr_url": "https://github.com/JimmyMcBride/plan/pull/33",
+      "doc_ref_mode": "sha",
+      "doc_ref": "d3edd3f752a39d558133ae979313ff7012cc9c10",
+      "updated_at": "2026-04-21T14:08:07Z"
+    },
     "add-guided-session-state-model": {
       "slug": "add-guided-session-state-model",
       "title": "Add Guided Session State Model",
@@ -119,6 +148,64 @@
       "doc_ref_mode": "main",
       "doc_ref": "develop",
       "updated_at": "2026-04-20T06:05:20Z"
+    },
+    "add-plan-guide-current-json-command": {
+      "slug": "add-plan-guide-current-json-command",
+      "title": "Add `plan guide current` JSON command",
+      "epic": "guide-packet-and-cli-foundation",
+      "spec": "guide-packet-and-cli-foundation",
+      "status": "todo",
+      "description": "Add `plan guide current` as the active-session entry point that resolves the last-active guided brainstorm session and emits the approved v1 guide packet as JSON.",
+      "acceptance_criteria": [
+        "The command emits valid JSON for an active guided brainstorm session using the shared packet builder.",
+        "The command returns a clear actionable error when no active guided session exists.",
+        "The command stays read-only and does not mutate guided session state while rendering output."
+      ],
+      "verification": [
+        "Add command tests for active-session success and missing-session failure behavior.",
+        "Verify JSON output includes current stage, checkpoint, summary, next action, and linked artifact path."
+      ],
+      "resources": [
+        "Spec: .plan/specs/guide-packet-and-cli-foundation.md",
+        "Research: .plan/research/guide-packet-schema-and-cli-design.md"
+      ],
+      "issue_number": 35,
+      "issue_url": "https://github.com/JimmyMcBride/plan/issues/35",
+      "remote_state": "open",
+      "planning_pr_number": 33,
+      "planning_pr_url": "https://github.com/JimmyMcBride/plan/pull/33",
+      "doc_ref_mode": "sha",
+      "doc_ref": "d3edd3f752a39d558133ae979313ff7012cc9c10",
+      "updated_at": "2026-04-21T14:08:09Z"
+    },
+    "add-plan-guide-show-json-command": {
+      "slug": "add-plan-guide-show-json-command",
+      "title": "Add `plan guide show` JSON command",
+      "epic": "guide-packet-and-cli-foundation",
+      "spec": "guide-packet-and-cli-foundation",
+      "status": "todo",
+      "description": "Add `plan guide show` as the explicit preview entry point that accepts a chain and optional stage or checkpoint overrides, then emits a compatible brainstorm-stage guide packet as JSON without mutating session state.",
+      "acceptance_criteria": [
+        "The command accepts an explicit chain and returns a compatible guide packet for the requested brainstorm-stage context.",
+        "Explicit stage or checkpoint handling rejects unsupported or incompatible values with clear errors.",
+        "The command stays compatible with the shared packet builder and remains read-only."
+      ],
+      "verification": [
+        "Add command tests for explicit-chain success, unknown-chain failure, and unsupported-stage or checkpoint failure.",
+        "Verify output remains schema-compatible with `plan guide current`."
+      ],
+      "resources": [
+        "Spec: .plan/specs/guide-packet-and-cli-foundation.md",
+        "Research: .plan/research/guide-packet-schema-and-cli-design.md"
+      ],
+      "issue_number": 36,
+      "issue_url": "https://github.com/JimmyMcBride/plan/issues/36",
+      "remote_state": "open",
+      "planning_pr_number": 33,
+      "planning_pr_url": "https://github.com/JimmyMcBride/plan/pull/33",
+      "doc_ref_mode": "sha",
+      "doc_ref": "d3edd3f752a39d558133ae979313ff7012cc9c10",
+      "updated_at": "2026-04-21T14:08:11Z"
     },
     "add-reopen-impact-summary-and-needs-review-markers": {
       "slug": "add-reopen-impact-summary-and-needs-review-markers",

--- a/.plan/epics/guide-packet-and-cli-foundation.md
+++ b/.plan/epics/guide-packet-and-cli-foundation.md
@@ -1,0 +1,97 @@
+---
+created_at: "2026-04-21T06:36:20Z"
+project: plan
+slug: guide-packet-and-cli-foundation
+spec: guide-packet-and-cli-foundation
+title: Guide Packet and CLI Foundation
+type: epic
+updated_at: "2026-04-21T06:36:20Z"
+---
+
+# Guide Packet and CLI Foundation
+
+Created: 2026-04-21T06:36:20Z
+
+## Outcome
+
+Introduce a runtime guide-packet interface so agents can ask `plan` for the
+current planning mode and stage contract instead of relying on static installed
+persona text.
+
+## Why Now
+
+The guided system is gaining durable sessions, stage checkpoints, and handoff
+behavior, but `plan` still has no first-class way to hand live guidance to an
+external agent. Without that contract, stage quality still depends on stale
+skill text and repo-specific prompt glue.
+
+## Shape
+
+### Appetite
+
+Small-to-medium. Ship one stable packet contract, one stage family, and two CLI
+entry points before expanding to later stages or richer renderers.
+
+### Outcome
+
+An agent can fetch a live brainstorm-stage guide packet with the current
+artifact, session summary, stage checkpoint, next action, and a structured
+behavior contract that is safe to follow directly.
+
+### Scope Boundary
+
+- machine-first guide packet `v1`
+- packet builder sourced from guided session state, workspace rules, and the
+  linked brainstorm note
+- `plan guide current`
+- `plan guide show`
+- brainstorm-stage checkpoints only
+- JSON output only
+- rendered prompt text derived from the structured packet
+
+### Out of Scope
+
+- direct model API calls from `plan`
+- per-agent installed personas as the primary runtime interface
+- markdown or plain-text guide renderers
+- epic, spec, or story-stage packets
+- automatic runtime or skill-consumption wiring
+
+### Success Signal
+
+A generic agent can call `plan` and receive enough live guidance to run the
+brainstorm stage cleanly without bespoke repo-local prompt glue.
+
+## Scope Boundary
+
+- reuse existing guided session state instead of adding parallel state
+- keep `plan` planning-only
+- keep the command surface to `current` and `show` for the first slice
+- keep the packet stable and versioned before layering on richer outputs
+
+Not in scope:
+
+- schema export command in the first slice
+- family overlays beyond the default packet behavior
+- bootstrap skill rewiring in the same epic
+
+## Spec
+
+- [Draft Spec](../specs/guide-packet-and-cli-foundation.md)
+
+## Resources
+
+- [Research: Guide Packet Schema and CLI Design](../research/guide-packet-schema-and-cli-design.md)
+- [Guided Session Engine and Resume Spec](../specs/guided-session-engine-and-resume.md)
+- [Vision Intake and Brainstorm Co-Planning Spec](../specs/vision-intake-and-brainstorm-co-planning.md)
+- [Guided Stage Handoffs and Artifact Writing Spec](../specs/guided-stage-handoffs-and-artifact-writing.md)
+
+## Progress
+
+- Target version: `v8`
+- Status: planned
+
+## Notes
+
+This epic should establish `plan` as the runtime source of truth for guided
+agent behavior without turning it into a model runner or orchestration layer.

--- a/.plan/research/guide-packet-schema-and-cli-design.md
+++ b/.plan/research/guide-packet-schema-and-cli-design.md
@@ -1,0 +1,563 @@
+# Guide Packet Schema and CLI Design
+
+Date: 2026-04-21
+
+## Why
+
+`plan` already knows live planning state: current chain, current stage, current
+cluster, linked artifacts, session summary, and next action. That makes `plan`
+the right runtime source of truth for agent guidance.
+
+Installed skills still help as bootstrap, but static agent personas are the
+wrong primary mechanism for guided planning because they do not know:
+
+- current chain and stage
+- active artifact path
+- current session summary and next action
+- story backend mode
+- stale downstream review state
+
+The right split is:
+
+- `plan` owns live stage guidance
+- agents ask `plan` for a guide packet
+- installed `plan` skill becomes a thin bootstrap that teaches agents to call
+  `plan guide ...`
+
+## Design Goals
+
+- keep `plan` planning-only
+- do not call model APIs from `plan`
+- make guide output machine-readable first
+- preserve a human-readable rendering for debugging and copy/paste use
+- reuse existing guided-session state instead of inventing parallel metadata
+- keep the CLI surface small
+
+## Non-Goals
+
+- per-agent installed persona bundles as the primary runtime interface
+- direct OpenAI, Anthropic, or other model invocation from `plan`
+- hidden session mutation during guide rendering
+- a second artifact hierarchy outside `.plan/`
+
+## Terms
+
+- guide packet: machine-readable stage contract emitted by `plan`
+- stage: one of `brainstorm`, `epic`, `spec`, `stories`
+- checkpoint: stage-local step such as `vision-intake` or
+  `clarify-constraints-appetite`
+- family overlay: optional style layer such as `gpt_style` or
+  `reasoning_heavy`
+
+## Core Decision
+
+The structured packet is canonical. Rendered prompt text is derived.
+
+That means:
+
+- agents should prefer structured packet fields when possible
+- `rendered_prompt` exists for runtimes that still want one prompt string
+- prompt wording can evolve without breaking the machine contract as long as
+  the structured schema stays stable
+
+## CLI Surface
+
+### `plan guide current`
+
+Purpose:
+- return the guide packet for the last-active guided session
+
+Command:
+
+```bash
+plan guide current --project . --format json
+```
+
+Behavior:
+
+- reads `.plan/.meta/guided_sessions.json`
+- resolves `last_active_chain`
+- builds a packet from current stage, checkpoint, session summary, linked
+  artifact, workspace rules, and optional family overlay
+- does not mutate session state
+
+Flags:
+
+- `--format json|md|text`
+  - default: `json`
+- `--family base|gpt_style|reasoning_heavy`
+  - default: `base`
+
+Errors:
+
+- no active guided session
+- active chain missing from session state
+
+Exit codes:
+
+- `0` success
+- `2` usage or missing-session errors
+
+### `plan guide show`
+
+Purpose:
+- return a guide packet for an explicit chain and stage
+
+Command:
+
+```bash
+plan guide show \
+  --project . \
+  --chain brainstorm/guided-planning-system \
+  --stage brainstorm \
+  --checkpoint clarify-constraints-appetite \
+  --format json
+```
+
+Behavior:
+
+- reads the requested chain
+- uses explicit stage/checkpoint if provided
+- otherwise falls back to session current stage/checkpoint
+- supports previewing a packet even when the caller wants a stage other than the
+  current active stage
+
+Flags:
+
+- `--chain <chain-id>`
+  - required
+- `--stage brainstorm|epic|spec|stories`
+  - optional if session already has a current stage
+- `--checkpoint <label>`
+  - optional
+- `--format json|md|text`
+  - default: `json`
+- `--family base|gpt_style|reasoning_heavy`
+  - default: `base`
+
+Errors:
+
+- unknown chain
+- unsupported stage
+- checkpoint incompatible with requested stage
+
+Exit codes:
+
+- `0` success
+- `2` usage or lookup errors
+
+### `plan guide schema`
+
+Purpose:
+- emit the JSON Schema for the guide packet
+
+Command:
+
+```bash
+plan guide schema --format json
+```
+
+Behavior:
+
+- emits the current packet schema definition
+- intended for tests, external integrations, and agent-runtime validation
+
+Flags:
+
+- `--format json`
+  - default and only supported value in v1
+
+Exit codes:
+
+- `0` success
+- `2` usage errors
+
+## Packet Schema V1
+
+Canonical packet shape:
+
+```json
+{
+  "schema_version": 1,
+  "kind": "guide_packet",
+  "generated_at": "2026-04-21T12:00:00Z",
+  "builder": {
+    "command": "plan guide current",
+    "family": "gpt_style"
+  },
+  "workspace": {
+    "project_root": "/home/jimmy/Projects/plan",
+    "planning_mode": "guided",
+    "story_backend": "github",
+    "integration_branch": "develop"
+  },
+  "session": {
+    "chain_id": "brainstorm/guided-planning-system",
+    "current_stage": "brainstorm",
+    "current_cluster": 3,
+    "current_cluster_label": "clarify-constraints-appetite",
+    "stage_statuses": {
+      "brainstorm": "in_progress",
+      "epic": "todo",
+      "spec": "todo",
+      "stories": "todo"
+    },
+    "summary": "Vision captured. Supporting material recorded.",
+    "next_action": "Continue with open questions and candidate approaches."
+  },
+  "artifact": {
+    "type": "brainstorm",
+    "slug": "guided-planning-system",
+    "title": "Guided planning system",
+    "path": ".plan/brainstorms/guided-planning-system.md",
+    "status": "active"
+  },
+  "mode": {
+    "stage": "brainstorm",
+    "checkpoint": "clarify-constraints-appetite",
+    "pass": "brainstorm_refine"
+  },
+  "sources": [
+    ".plan/PROJECT.md",
+    ".plan/ROADMAP.md",
+    ".plan/brainstorms/guided-planning-system.md",
+    ".plan/specs/vision-intake-and-brainstorm-co-planning.md",
+    ".plan/specs/guided-stage-handoffs-and-artifact-writing.md"
+  ],
+  "contract": {
+    "role": "co_planning_facilitator",
+    "stance": [
+      "collaborative",
+      "direct",
+      "skeptical_when_needed",
+      "keep_scope_small"
+    ],
+    "goal": "Turn raw vision into a promotable brainstorm note.",
+    "question_strategy": {
+      "cluster_size_min": 2,
+      "cluster_size_max": 4,
+      "reflect_once_per_cluster": true,
+      "gap_guidance": "one_recommended_plus_up_to_two_alternatives",
+      "menu_actions": [
+        "continue",
+        "refine",
+        "stop_for_now"
+      ]
+    },
+    "artifact_strategy": {
+      "write_mode": "additive",
+      "durable_artifact": ".plan/brainstorms/guided-planning-system.md",
+      "strengthen_sections": [
+        "Problem",
+        "User / Value",
+        "Constraints",
+        "Appetite"
+      ],
+      "preserve_rules": [
+        "User input first",
+        "Do not draft epic/spec/story content during brainstorm stage"
+      ]
+    },
+    "do": [
+      "Ask only the current question cluster.",
+      "Explain gaps when they appear.",
+      "Push toward smaller, clearer scope boundaries."
+    ],
+    "avoid": [
+      "Do not jump ahead into implementation details.",
+      "Do not turn the interaction into a giant intake form.",
+      "Do not silently rewrite the user intent."
+    ],
+    "quality_bar": [
+      "Problem and user value are concrete.",
+      "Scope boundary is visible.",
+      "Open questions are blocker-shaped, not vague brainstorming sprawl."
+    ],
+    "completion_gate": [
+      "The brainstorm can promote into an epic without hidden assumptions.",
+      "The recommended next stage is clear."
+    ],
+    "command_hints": [
+      {
+        "purpose": "resume_current_stage",
+        "command": "plan brainstorm resume guided-planning-system --project ."
+      },
+      {
+        "purpose": "move_to_next_stage",
+        "command": "plan brainstorm resume guided-planning-system --project ."
+      }
+    ]
+  },
+  "rendered_prompt": "You are guiding the brainstorm stage for `plan`..."
+}
+```
+
+## Field Contract
+
+### Required Top-Level Fields
+
+- `schema_version`
+  - integer
+  - packet schema version
+- `kind`
+  - string
+  - always `guide_packet`
+- `generated_at`
+  - RFC3339 UTC timestamp
+- `builder`
+  - object
+- `workspace`
+  - object
+- `mode`
+  - object
+- `contract`
+  - object
+- `rendered_prompt`
+  - string
+
+### Optional Top-Level Fields
+
+- `session`
+  - object
+  - required for `guide current`
+  - optional for explicit preview use cases later
+- `artifact`
+  - object
+  - omitted only if no durable artifact exists yet
+- `sources`
+  - string array
+
+### `builder`
+
+- `command`
+  - source command such as `plan guide current`
+- `family`
+  - `base`, `gpt_style`, or `reasoning_heavy`
+
+### `workspace`
+
+- `project_root`
+  - absolute project path
+- `planning_mode`
+  - current planning mode such as `guided`
+- `story_backend`
+  - `local` or `github`
+- `integration_branch`
+  - current integration branch name when available
+
+### `session`
+
+Derived from existing guided-session state.
+
+- `chain_id`
+- `current_stage`
+- `current_cluster`
+- `current_cluster_label`
+- `stage_statuses`
+- `summary`
+- `next_action`
+
+This should map cleanly onto current fields in
+`.plan/.meta/guided_sessions.json`.
+
+### `artifact`
+
+- `type`
+  - `brainstorm`, `epic`, `spec`, or `story_set`
+- `slug`
+- `title`
+- `path`
+  - repo-relative path when local
+- `status`
+
+### `mode`
+
+- `stage`
+  - `brainstorm`, `epic`, `spec`, `stories`
+- `checkpoint`
+  - stage-local checkpoint label
+- `pass`
+  - one of:
+    - `brainstorm_start`
+    - `brainstorm_refine`
+    - `brainstorm_challenge`
+    - `epic_shape`
+    - `spec_analyze`
+    - `spec_checklist`
+    - `story_slice`
+    - `story_critique`
+    - `handoff`
+
+### `contract`
+
+- `role`
+  - concise machine-friendly role id
+- `stance`
+  - array of behavioral anchors
+- `goal`
+  - single sentence stage goal
+- `question_strategy`
+  - interaction contract
+- `artifact_strategy`
+  - artifact writing contract
+- `do`
+  - required behavior list
+- `avoid`
+  - forbidden or discouraged behavior list
+- `quality_bar`
+  - stage quality expectations
+- `completion_gate`
+  - what must be true before leaving stage
+- `command_hints`
+  - exact follow-up commands the agent can run
+
+### `rendered_prompt`
+
+Derived string rendering of the structured fields above.
+
+Rules:
+
+- machine contract stays authoritative
+- rendering may change wording
+- meaning must stay semantically equivalent
+
+## Initial Checkpoint Vocabulary
+
+Exact checkpoint labels should be reused from guided session and stage logic
+where they already exist.
+
+For brainstorm v1:
+
+- `vision-intake`
+- `clarify-problem-user-value`
+- `clarify-constraints-appetite`
+- `clarify-open-approaches`
+- `handoff-epic`
+
+For later stages:
+
+- use stage-local labels
+- keep labels stable once emitted in packets
+- prefer descriptive ids over display text
+
+## Markdown Rendering Contract
+
+`--format md` should render:
+
+1. stage and checkpoint
+2. current artifact
+3. current summary and next action
+4. role and goal
+5. do / avoid
+6. quality bar
+7. completion gate
+8. command hints
+9. rendered prompt block
+
+This keeps one human-debug view without inventing a second schema.
+
+## Text Rendering Contract
+
+`--format text` should be concise and terminal-friendly:
+
+- one-line stage summary
+- one-line artifact pointer
+- short behavior bullets
+- short next-command hints
+
+No prose banner. No explanatory fluff. Deterministic ordering.
+
+## Example Commands
+
+Agent bootstrap flow:
+
+```bash
+plan brainstorm start --project . "Billing export"
+plan guide current --project . --format json
+```
+
+Resume flow:
+
+```bash
+plan brainstorm resume billing-export --project .
+plan guide current --project . --format json
+```
+
+Explicit stage preview:
+
+```bash
+plan guide show \
+  --project . \
+  --chain brainstorm/billing-export \
+  --stage brainstorm \
+  --checkpoint clarify-open-approaches \
+  --family reasoning_heavy \
+  --format md
+```
+
+Schema export:
+
+```bash
+plan guide schema --format json
+```
+
+## Error Contract
+
+JSON mode:
+
+- emit error text to stderr
+- emit no partial JSON to stdout
+- return exit code `2`
+
+Markdown and text mode:
+
+- print concise error
+- print one next-best-action hint when possible
+
+Examples:
+
+- no active session:
+  - `No active guided session. Start one with 'plan brainstorm start --project . "<topic>"'.`
+- unknown chain:
+  - `Guided session "brainstorm/foo" not found.`
+- unsupported stage:
+  - `Unsupported guide stage "release". Expected brainstorm, epic, spec, or stories.`
+
+## Integration With Existing Skill
+
+The installed `plan` skill should shrink to a bootstrap contract:
+
+- detect `.plan/`
+- call `plan guide current --project . --format json` after guided stage entry
+- follow returned contract
+- use `plan` commands for durable mutations
+
+That keeps:
+
+- installed skill small
+- runtime guidance live
+- agent coupling low
+- model-family overlays optional instead of mandatory install targets
+
+## Rollout Fit
+
+This design fits existing v8 work:
+
+- guided session engine provides packet input state
+- vision intake and brainstorm co-planning provides first stage contract
+- guided stage handoffs provide later-stage packet builders
+
+Relevant specs:
+
+- [Guided Session Engine and Resume](../specs/guided-session-engine-and-resume.md)
+- [Vision Intake and Brainstorm Co-Planning](../specs/vision-intake-and-brainstorm-co-planning.md)
+- [Guided Stage Handoffs and Artifact Writing](../specs/guided-stage-handoffs-and-artifact-writing.md)
+
+## Recommended Next Slice
+
+If this direction holds:
+
+1. add `plan guide current|show|schema`
+2. build brainstorm-stage packet first
+3. convert `skills/plan/agents/*.yaml` into family overlays for packet building
+4. update installed `plan` skill to use guide packets instead of static stage prose

--- a/.plan/specs/guide-packet-and-cli-foundation.md
+++ b/.plan/specs/guide-packet-and-cli-foundation.md
@@ -1,0 +1,218 @@
+---
+created_at: "2026-04-21T06:36:20Z"
+epic: guide-packet-and-cli-foundation
+project: plan
+slug: guide-packet-and-cli-foundation
+status: approved
+target_version: v8
+title: Guide Packet and CLI Foundation Spec
+type: spec
+updated_at: "2026-04-21T06:39:20Z"
+---
+
+# Guide Packet and CLI Foundation Spec
+
+Created: 2026-04-21T06:36:20Z
+
+## Why
+
+Guided planning quality should come from live `plan` state, not from static
+persona text installed into each agent runtime.
+
+## Problem
+
+The agent-facing guidance for `plan` is still too static. An external agent can
+learn the general workflow, but it cannot ask `plan` what guidance applies to
+the current guided stage right now, so stage behavior drifts away from the live
+planning state.
+
+## Goals
+
+- let an agent ask `plan` what guidance applies right now
+- give the brainstorm stage one live source of truth for agent guidance
+- support both current-session lookup and explicit chain lookup
+- reduce reliance on stale installed prompt glue
+- keep `plan` planning-only and model-free
+- keep the first slice small enough to validate quickly
+
+## Non-Goals
+
+- direct model API calls from `plan`
+- installed per-agent personas as the primary runtime interface
+- full guide coverage for epic, spec, or story stages
+- markdown or text guide rendering in the first slice
+- automatic consumption by Codex, Claude, or other runtimes in the same scope
+- schema export command in the first slice
+
+## Constraints
+
+- guide rendering must not mutate session state
+- reuse `.plan/.meta/guided_sessions.json` as the session source of truth
+- keep the CLI surface to `plan guide current` and `plan guide show`
+- keep brainstorm checkpoint labels aligned with existing cluster ids
+- packet output must be deterministic and versioned
+- JSON mode must emit full packets to stdout and errors to stderr only
+- actionable error text should exist when there is no active guided session
+- the brainstorm note remains the durable artifact; guide packets are runtime
+  contracts, not new planning documents
+
+## Solution Shape
+
+- add a guide-packet builder that composes:
+  - current workspace rules
+  - current guided session state
+  - linked brainstorm artifact metadata
+  - brainstorm-stage contract data
+- add `plan guide current --project . --format json`
+- add `plan guide show --project . --chain ... --stage ... --checkpoint ... --format json`
+- emit one machine-first packet with these top-level sections:
+  - `schema_version`
+  - `kind`
+  - `generated_at`
+  - `builder`
+  - `workspace`
+  - `session`
+  - `artifact`
+  - `mode`
+  - `sources`
+  - `contract`
+  - `rendered_prompt`
+- treat the structured packet as canonical and derive `rendered_prompt` from it
+- support brainstorm-stage checkpoints:
+  - `vision-intake`
+  - `clarify-problem-user-value`
+  - `clarify-constraints-appetite`
+  - `clarify-open-approaches`
+  - `handoff-epic`
+
+## Flows
+
+1. User starts or resumes a guided brainstorm.
+2. The agent calls `plan guide current --project . --format json`.
+3. `plan` reads the last-active guided session and linked brainstorm note.
+4. `plan` returns a JSON guide packet for the current brainstorm checkpoint.
+5. The agent uses the packet contract to guide the next user interaction.
+6. If the runtime needs an explicit preview instead of the active session, it
+   calls `plan guide show --chain ... --stage brainstorm --checkpoint ...`.
+7. `plan` returns the requested packet without mutating the session.
+
+## Data / Interfaces
+
+- new CLI group:
+  - `plan guide current`
+  - `plan guide show`
+- packet schema v1:
+  - `schema_version`: integer
+  - `kind`: `guide_packet`
+  - `generated_at`: RFC3339 UTC timestamp
+  - `builder`: command metadata
+  - `workspace`: project root, planning mode, story backend, integration branch
+  - `session`: chain id, stage, checkpoint, summary, next action, statuses
+  - `artifact`: type, slug, title, path, status
+  - `mode`: stage, checkpoint, pass
+  - `sources`: supporting local files used to shape the packet
+  - `contract`: role, goal, question strategy, artifact strategy, do, avoid,
+    quality bar, completion gate, command hints
+  - `rendered_prompt`: derived prompt string
+- initial supported format:
+  - `json`
+- initial supported stage:
+  - `brainstorm`
+
+Reference design source:
+
+- [Guide Packet Schema and CLI Design](../research/guide-packet-schema-and-cli-design.md)
+
+## Risks / Open Questions
+
+- whether family overlays belong in the first implementation slice or a follow-up
+- whether `rendered_prompt` will tempt callers to ignore structured fields
+- how much source context belongs in the packet before it becomes noisy
+- whether `plan guide show` should require an explicit stage when the chain is
+  already known
+- the first slice should stay read-only; if packet work starts demanding stored
+  metadata changes, that likely means the scope is too large
+- no guided-session migration is planned in this slice, so follow-up work should
+  prefer trimming packet fields over mutating durable session state
+
+## Rollout
+
+- land packet schema and builder types first
+- ship brainstorm-stage packet generation plus `guide current`
+- add `guide show` next
+- validate the workflow manually with agent usage before changing installed
+  skill behavior
+- extend into later stages only after the brainstorm-stage packet proves useful
+- keep rollout read-only against current guided-session state; if migration
+  pressure appears, defer it to a separate follow-up spec
+
+## Verification
+
+- `plan guide current --format json` returns a valid packet when an active
+  guided brainstorm session exists
+- `plan guide current --format json` fails with a clear actionable error when
+  no active guided session exists
+- `plan guide show` returns a compatible packet for an explicit chain and
+  checkpoint
+- returned packets contain the current stage, checkpoint, summary, next action,
+  and linked artifact path
+- packet rendering does not rewrite `.plan/.meta/guided_sessions.json`
+- `rendered_prompt` stays semantically aligned with the structured contract
+- brainstorm checkpoint ids in the packet match current guided brainstorm
+  cluster labels
+
+## Story Breakdown
+
+- Add guide packet types and brainstorm-stage packet builder
+- Add `plan guide current` JSON command
+- Add `plan guide show` JSON command
+
+## Analysis
+
+### Missing Constraints
+
+- None.
+
+### Success Criteria Gaps
+
+- None.
+
+### Hidden Dependencies
+
+- None.
+
+### Risk Gaps
+
+- None.
+
+### What/Why vs How Leakage
+
+- [warn] The narrative sections include implementation detail that belongs in Solution Shape or Data / Interfaces.
+
+### Recommended Revisions
+
+- [warn] Keep ## Why, ## Problem, ## Goals, and ## Non-Goals product-facing, then move technical detail into ## Solution Shape or ## Data / Interfaces.
+
+## Checklist
+
+### general
+
+status: ok
+blocking_findings: 0
+guidance_findings: 0
+
+- [ok] No findings.
+## Resources
+
+- [Epic](../epics/guide-packet-and-cli-foundation.md)
+- [Research: Guide Packet Schema and CLI Design](../research/guide-packet-schema-and-cli-design.md)
+- [Guided Session Engine and Resume Spec](../specs/guided-session-engine-and-resume.md)
+- [Vision Intake and Brainstorm Co-Planning Spec](../specs/vision-intake-and-brainstorm-co-planning.md)
+- [Guided Stage Handoffs and Artifact Writing Spec](../specs/guided-stage-handoffs-and-artifact-writing.md)
+- [Product Direction](../PRODUCT.md)
+
+## Notes
+
+Recommendation locked during planning: use installed skills as bootstrap only,
+and make live guide packets the runtime source of truth for guided agent
+behavior.


### PR DESCRIPTION
## Summary
- add guide packet schema and CLI design research note
- add v8 epic and approved spec for guide packet + guide CLI foundation
- lock v1 scope to brainstorm stage, JSON output, and `guide current|show`

## Verification
- plan spec checklist --project . guide-packet-and-cli-foundation --profile general
- plan check spec guide-packet-and-cli-foundation --project .
- plan status --project .