### PR TITLE
build: add codex cloud brain setup

### DIFF
--- a/.brain/context/architecture.md
+++ b/.brain/context/architecture.md
@@ -1,0 +1,25 @@
+# Architecture
+
+<!-- brain:begin context-architecture -->
+Use this file for the structural shape of the repository.
+
+## Internal Packages
+
+- `internal/buildinfo/`
+- `internal/notes/`
+- `internal/planning/`
+- `internal/skills/`
+- `internal/templates/`
+- `internal/workspace/`
+
+## Architecture Notes
+
+- Favor small package boundaries and explicit CLI/app wiring.
+- Keep public CLI behavior stable; add internal seams only when they improve testability or safety.
+- Treat generated project context as deterministic repo state, not LLM-authored prose.
+- Treat session enforcement as the hard-control layer above soft context files.
+<!-- brain:end context-architecture -->
+
+## Local Notes
+
+Add repo-specific notes here. `brain context refresh` preserves content outside managed blocks.

--- a/.brain/context/current-state.md
+++ b/.brain/context/current-state.md
@@ -1,0 +1,26 @@
+# Current State
+
+<!-- brain:begin context-current-state -->
+This file is a deterministic snapshot of the repository state at the last refresh.
+
+## Repository
+
+- Project: `plan`
+- Root: `.`
+- Runtime: `go`
+- Go module: `plan`
+- Current branch: `codex/codex-cloud-brain-setup`
+- Default branch: `main`
+- Remote: `https://github.com/JimmyMcBride/plan.git`
+- Go test files: `561`
+
+## Docs
+
+- `README.md`
+- `docs/gitflow.md`
+- `docs/using-plan.md`
+<!-- brain:end context-current-state -->
+
+## Local Notes
+
+Add repo-specific notes here. `brain context refresh` preserves content outside managed blocks.

--- a/.brain/context/current-state.md
+++ b/.brain/context/current-state.md
@@ -18,6 +18,9 @@ This file is a deterministic snapshot of the repository state at the last refres
 
 - `README.md`
 - `docs/gitflow.md`
+- `docs/project-architecture.md`
+- `docs/project-overview.md`
+- `docs/project-workflows.md`
 - `docs/using-plan.md`
 <!-- brain:end context-current-state -->
 

--- a/.brain/context/memory-policy.md
+++ b/.brain/context/memory-policy.md
@@ -1,0 +1,28 @@
+# Memory Policy
+
+<!-- brain:begin context-memory-policy -->
+Use this file to decide what is worth keeping in project memory.
+
+## Capture Required
+
+- Non-obvious implementation decisions.
+- Bugs, regressions, and the fix or mitigation.
+- Config, schema, deployment, or interface changes.
+- Risks, follow-ups, and unresolved tradeoffs.
+
+## Capture Optional
+
+- Small implementation details that are likely to matter later.
+- Helpful command sequences worth repeating.
+
+## Do Not Capture
+
+- Trivial edits with no future value.
+- Temporary command noise already obvious from code or tests.
+- Speculative reasoning, transient scratch, or dead-end experiments unless they recur as real traps.
+- Duplicate notes when an existing note can be updated.
+<!-- brain:end context-memory-policy -->
+
+## Local Notes
+
+Add repo-specific notes here. `brain context refresh` preserves content outside managed blocks.

--- a/.brain/context/overview.md
+++ b/.brain/context/overview.md
@@ -1,0 +1,31 @@
+# Overview
+
+<!-- brain:begin context-overview -->
+Project: `plan`
+
+Go module: `plan`
+
+Primary runtime: `go`
+
+## Manifests
+
+- `go.mod`
+
+## Repo Map
+
+- `.brain/`
+- `.codex/`
+- `.plan/`
+- `cmd/`
+- `docs/`
+- `examples/`
+- `internal/`
+- `scripts/`
+- `skills/`
+- `templates/`
+- `testdata/`
+<!-- brain:end context-overview -->
+
+## Local Notes
+
+Add repo-specific notes here. `brain context refresh` preserves content outside managed blocks.

--- a/.brain/context/standards.md
+++ b/.brain/context/standards.md
@@ -1,0 +1,21 @@
+# Standards
+
+<!-- brain:begin context-standards -->
+Use this file for implementation and review expectations.
+
+## Standards
+
+- Keep code idiomatic Go with small, concrete abstractions.
+- Prefer explicit tests for CLI behavior, indexing, retrieval, safety flows, and session enforcement.
+- Record required verification through `brain session run -- ...` so finish-stage enforcement can validate it.
+
+## CI
+
+- `.github/workflows/ci.yml`
+- `.github/workflows/release.yml`
+- `.github/workflows/tag-main-release.yml`
+<!-- brain:end context-standards -->
+
+## Local Notes
+
+Add repo-specific notes here. `brain context refresh` preserves content outside managed blocks.

--- a/.brain/context/workflows.md
+++ b/.brain/context/workflows.md
@@ -42,4 +42,13 @@ Use this file for agent operating workflow inside the repo.
 
 ## Local Notes
 
-Add repo-specific notes here. `brain context refresh` preserves content outside managed blocks.
+### Project Override: Spec Queue Loop
+
+- Establish queue with `plan status --project .`.
+- Take the next approved spec, not the next individual issue.
+- Run `plan story slice --project . <epic-slug>` and then `--apply` to materialize the current spec's slices.
+- Implement one slice at a time.
+- Review and verify each slice before committing that slice.
+- Repeat until the current spec is done, then move to the next queued spec.
+- Open one PR after the queued specs for the branch are complete.
+- If GitHub story mode is enabled, run `plan update --project .` and `plan github reconcile --project . --update-visible` after merge before taking more queue work.

--- a/.brain/context/workflows.md
+++ b/.brain/context/workflows.md
@@ -1,0 +1,45 @@
+# Workflows
+
+<!-- brain:begin context-workflows -->
+Use this file for agent operating workflow inside the repo.
+
+## Startup
+
+1. If no validated session is active, run `brain prep --task "<task>"`.
+2. If a session already exists, run `brain prep`.
+3. Read `AGENTS.md`, `.brain/policy.yaml`, and the linked context files still needed for the task.
+4. Use `brain context compile --task "<task>"` only when you need the lower-level packet compiler directly.
+5. If project memory still matters, run `brain find plan` or `brain search "plan <task>"`.
+
+## During Work
+
+- Keep durable discoveries, decisions, and risks in AGENTS.md, /docs, or .brain notes.
+- Update existing durable notes instead of duplicating context.
+- Run required verification commands through `brain session run -- <command>`.
+- If you change Brain command behavior or agent-facing workflow guidance, update `skills/brain/SKILL.md` in the same branch.
+- Re-read context before large changes if the task shifts.
+
+## Ticket Loop
+
+1. Start one task or ticket at a time and keep the scope narrow.
+2. Implement the task, then run focused tests for the touched packages.
+3. Run the required full checks through `brain session run -- go test ./...` and `brain session run -- go build ./...`.
+4. Review the diff against the task goal and user-facing behavior.
+5. If review finds issues, patch the work and repeat the test and review steps.
+6. When the task is clean, commit it, push it, and only then move to the next task.
+
+## Close-Out
+
+- Refresh or update durable notes for meaningful behavior, config, or architecture changes.
+- If `brain session finish` blocks, inspect the promotion suggestions first; run `brain distill --session --dry-run` only when you need the full review without creating a proposal note.
+- Before switching away from a working branch or back to `develop`, run `git status --short` and resolve repo-owned leftovers. If `.brain/resources/changes/*`, `.brain/`, `docs/`, or contract files belong to the task, keep them in the same branch/PR; otherwise review and intentionally remove them instead of carrying them onto `develop`, `release/*`, or `main`.
+- If `skills/brain/` changed, reinstall the local Brain skill for Codex and OpenClaw with `brain skills install --scope local --agent codex --agent openclaw --project .`.
+- When opening a PR, make the title and body release-note friendly because GitHub release notes are generated from merged PR metadata.
+- Summarize shipped behavior in the PR, not just implementation steps, so future changelogs stay human-readable.
+- Finish with `brain session finish`.
+- If you must bypass enforcement, use `brain session finish --force --reason "..."` so the override is recorded.
+<!-- brain:end context-workflows -->
+
+## Local Notes
+
+Add repo-specific notes here. `brain context refresh` preserves content outside managed blocks.

--- a/.brain/policy.yaml
+++ b/.brain/policy.yaml
@@ -1,0 +1,42 @@
+version: 1
+project:
+    name: plan
+    slug: plan
+    runtime: go
+    memory:
+        accepted_note_globs:
+            - AGENTS.md
+            - docs/**
+            - .brain/context/**
+            - .brain/resources/**
+session:
+    require_task: true
+    single_active: true
+    active_file: .brain/session.json
+    ledger_dir: .brain/sessions
+preflight:
+    require_brain_doctor: true
+    required_docs:
+        - AGENTS.md
+        - .brain/context/overview.md
+        - .brain/context/workflows.md
+        - .brain/context/memory-policy.md
+    suggested_commands:
+        - brain find plan
+        - brain search "plan {task}"
+closeout:
+    acceptable_history_operations:
+        - create
+        - update
+        - move
+        - rename
+        - publish
+        - seed
+    require_memory_update_on_repo_change: true
+    verification_profiles:
+        - name: tests
+          commands:
+            - go test ./...
+        - name: build
+          commands:
+            - go build ./...

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,10 @@ dist/
 .DS_Store
 .codex/bin/
 .codex/skills/brain/
+
+# brain:begin gitignore-session
+.brain/session.json
+.brain/sessions/
+.brain/policy.override.yaml
+.brain/state/
+# brain:end gitignore-session

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@ dist/
 /plan
 *.exe
 .DS_Store
+.codex/bin/
+.codex/skills/brain/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,36 @@
+# AGENTS
+
+## Repo Contract
+
+- `plan` owns planning under `.plan/`.
+- Do not store planning artifacts in Brain.
+- Use `develop` as the default PR target for routine work.
+- Never push directly to protected branches: `develop`, `release/*`, `main`.
+
+## Optional Brain Setup
+
+For Codex cloud environments, run:
+
+```bash
+./scripts/setup-codex-cloud.sh
+```
+
+That setup installs:
+
+- repo-local Brain binary at `.codex/bin/brain`
+- repo-local Brain skill at `.codex/skills/brain`
+
+## Brain Usage Rules
+
+- If `.codex/bin/brain` exists and the repo has a `.brain/` workspace, use Brain for context retrieval, prep, and session hygiene.
+- If `.brain/` does not exist, skip Brain workflows. Do not create or adopt a Brain workspace unless the task explicitly asks for it.
+- Keep `plan` as the source of truth for roadmap, brainstorms, epics, specs, and stories.
+
+## Useful Commands
+
+```bash
+go run . update --project .
+go run . check --project .
+./scripts/refresh-plan-develop-context.sh
+```
+

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -19,6 +19,9 @@ Read the linked context files before substantial work. Prefer the `brain` skill 
 
 - [README.md](./README.md)
 - [gitflow.md](./docs/gitflow.md)
+- [project-architecture.md](./docs/project-architecture.md)
+- [project-overview.md](./docs/project-overview.md)
+- [project-workflows.md](./docs/project-workflows.md)
 - [using-plan.md](./docs/using-plan.md)
 
 ## Required Workflow
@@ -70,3 +73,12 @@ go run . update --project .
 go run . check --project .
 ./scripts/refresh-plan-develop-context.sh
 ```
+
+### Project Workflow Override
+
+- Build from approved specs.
+- Slice the current spec into execution-ready stories before coding.
+- Finish one slice, review it, verify it, then commit that slice.
+- Repeat until the current spec is complete.
+- Move to the next queued spec only after the current spec is done.
+- Open one PR after the queued specs for the branch are complete.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,13 +1,50 @@
-# AGENTS
+# Project Agent Contract
 
-## Repo Contract
+<!-- brain:begin agents-contract -->
+Use this file as a Brain-managed project context entrypoint for `plan`.
+
+Read the linked context files before substantial work. Prefer the `brain` skill and `brain` CLI for project memory, retrieval, and durable context updates.
+
+## Table Of Contents
+
+- [Overview](./.brain/context/overview.md)
+- [Architecture](./.brain/context/architecture.md)
+- [Standards](./.brain/context/standards.md)
+- [Workflows](./.brain/context/workflows.md)
+- [Memory Policy](./.brain/context/memory-policy.md)
+- [Current State](./.brain/context/current-state.md)
+- [Policy](./.brain/policy.yaml)
+
+## Human Docs
+
+- [README.md](./README.md)
+- [gitflow.md](./docs/gitflow.md)
+- [using-plan.md](./docs/using-plan.md)
+
+## Required Workflow
+
+1. If no validated session is active, run `brain prep --task "<task>"`.
+2. If a session is already active, run `brain prep`.
+3. Read this file and the linked context files still needed for the task.
+4. Use `brain context compile --task "<task>"` only when you need the lower-level packet compiler directly.
+5. Retrieve project memory with `brain find plan` or `brain search "plan <task>"` when the compiled packet is not enough.
+6. Use `brain edit` for durable context updates to AGENTS.md, docs, or .brain notes.
+7. Use `brain session run -- <command>` for required verification commands.
+8. Finish with `brain session finish` so policy checks can enforce verification and surface promotion review when durable follow-through is still needed.
+<!-- brain:end agents-contract -->
+
+## Local Notes
+
+Add repo-specific notes here. `brain context refresh` preserves content outside managed blocks.
+
+### Repo Contract
 
 - `plan` owns planning under `.plan/`.
 - Do not store planning artifacts in Brain.
 - Use `develop` as the default PR target for routine work.
 - Never push directly to protected branches: `develop`, `release/*`, `main`.
 
-## Optional Brain Setup
+### Optional Brain Setup
 
 For Codex cloud environments, run:
 
@@ -20,17 +57,16 @@ That setup installs:
 - repo-local Brain binary at `.codex/bin/brain`
 - repo-local Brain skill at `.codex/skills/brain`
 
-## Brain Usage Rules
+### Brain Usage Rules
 
 - If `.codex/bin/brain` exists and the repo has a `.brain/` workspace, use Brain for context retrieval, prep, and session hygiene.
 - If `.brain/` does not exist, skip Brain workflows. Do not create or adopt a Brain workspace unless the task explicitly asks for it.
 - Keep `plan` as the source of truth for roadmap, brainstorms, epics, specs, and stories.
 
-## Useful Commands
+### Useful Commands
 
 ```bash
 go run . update --project .
 go run . check --project .
 ./scripts/refresh-plan-develop-context.sh
 ```
-

--- a/README.md
+++ b/README.md
@@ -40,15 +40,16 @@ Workflow entry:
 8. Slice into stories
 9. Critique story readiness
 
-Execution loop in GitHub mode:
+Execution loop:
 
-1. Establish queue
-2. Grab next ready issue or issues
-3. Implement on a branch and open PR
-4. Review and iterate until ready
-5. Squash-merge
-6. Return to the integration branch, pull latest, update and reconcile
-7. Grab next ready issue and repeat
+1. Establish spec queue
+2. Take next approved spec
+3. Slice the spec into execution-ready stories
+4. Implement one slice
+5. Review and verify that slice before committing it
+6. Repeat until the spec is done
+7. Move to the next spec in queue
+8. Open one PR when the queued specs are complete
 
 The default path stays small. New shaping passes should improve the same
 artifacts rather than add new top-level planning objects.
@@ -129,28 +130,41 @@ Full guide:
 - `plan status`
 - `plan skills install|targets`
 
-## GitHub Queue Workflow
+## Spec Queue Workflow
 
-For GitHub-backed stories, use this loop:
+Use this loop when implementing planned work:
 
 ```bash
 plan status --project .
 
-# do issue work on a feature branch and merge the PR into the integration branch
+# take next approved spec
+plan story slice --project . <epic-slug>
+plan story slice --project . <epic-slug> --apply
 
-./scripts/refresh-plan-develop-context.sh
+# implement one slice
+# review + verify slice
+# commit slice
+
+# repeat until spec done
+# move to next queued spec
+
+# once queued specs are done, open one PR
 ```
 
 Rules:
 
 - use `plan status --project .` as the queue view
-- take only issues shown in `ready_work`
+- queue work at the spec level, not the single-issue level
+- slice one approved spec into execution-ready stories before coding
+- complete one slice at a time
+- review and verify each slice before committing that slice
+- once the current spec is done, move to the next queued spec
 - in this repo, normal work targets `develop`
 - work on a feature branch, not on `develop`, `release/*`, or `main`
-- squash-merge the PR when work is accepted unless release work needs a
-  different merge strategy
-- after merge into `develop`, run
-  `./scripts/refresh-plan-develop-context.sh` before grabbing the next issue
+- open one PR after the queued specs for that branch are complete
+- if GitHub story mode is enabled, run
+  `./scripts/refresh-plan-develop-context.sh` after merge before taking more
+  queue work
 
 ## Repo Gitflow
 

--- a/README.md
+++ b/README.md
@@ -212,6 +212,25 @@ Preview install targets:
 plan skills targets --scope both --agent codex --project .
 ```
 
+## Codex Cloud + Brain
+
+If you want a Codex cloud environment for this repo to have optional access to
+[`brain`](https://github.com/JimmyMcBride/brain), point the environment setup
+step at:
+
+```bash
+./scripts/setup-codex-cloud.sh
+```
+
+That script:
+
+- installs a repo-local Brain binary at `.codex/bin/brain`
+- installs the repo-local Brain skill for Codex at `.codex/skills/brain`
+- leaves Brain optional when the repo does not contain a `.brain/` workspace
+
+`plan` remains the planning source of truth. Brain is only for context,
+retrieval, and session hygiene when present.
+
 ## Evaluating Prompt And Workflow Changes
 
 `v5` adds a local benchmark and rubric harness for maintainers. `v6` adds

--- a/docs/project-architecture.md
+++ b/docs/project-architecture.md
@@ -1,0 +1,25 @@
+# Project Architecture
+
+<!-- brain:begin project-doc-architecture -->
+Use this file for the structural shape of the repository.
+
+## Internal Packages
+
+- `internal/buildinfo/`
+- `internal/notes/`
+- `internal/planning/`
+- `internal/skills/`
+- `internal/templates/`
+- `internal/workspace/`
+
+## Architecture Notes
+
+- Favor small package boundaries and explicit CLI/app wiring.
+- Keep public CLI behavior stable; add internal seams only when they improve testability or safety.
+- Treat generated project context as deterministic repo state, not LLM-authored prose.
+- Treat session enforcement as the hard-control layer above soft context files.
+<!-- brain:end project-doc-architecture -->
+
+## Local Notes
+
+Add repo-specific notes here. `brain context refresh` preserves content outside managed blocks.

--- a/docs/project-overview.md
+++ b/docs/project-overview.md
@@ -1,0 +1,31 @@
+# Project Overview
+
+<!-- brain:begin project-doc-overview -->
+Project: `plan`
+
+Go module: `plan`
+
+Primary runtime: `go`
+
+## Manifests
+
+- `go.mod`
+
+## Repo Map
+
+- `.brain/`
+- `.codex/`
+- `.plan/`
+- `cmd/`
+- `docs/`
+- `examples/`
+- `internal/`
+- `scripts/`
+- `skills/`
+- `templates/`
+- `testdata/`
+<!-- brain:end project-doc-overview -->
+
+## Local Notes
+
+Add repo-specific notes here. `brain context refresh` preserves content outside managed blocks.

--- a/docs/project-workflows.md
+++ b/docs/project-workflows.md
@@ -42,4 +42,13 @@ Use this file for agent operating workflow inside the repo.
 
 ## Local Notes
 
-Add repo-specific notes here. `brain context refresh` preserves content outside managed blocks.
+### Project Override: Spec Queue Loop
+
+- Establish queue with `plan status --project .`.
+- Take the next approved spec, not the next individual issue.
+- Run `plan story slice --project . <epic-slug>` and then `--apply` to materialize the current spec's slices.
+- Implement one slice at a time.
+- Review and verify each slice before committing that slice.
+- Repeat until the current spec is done, then move to the next queued spec.
+- Open one PR after the queued specs for the branch are complete.
+- If GitHub story mode is enabled, run `plan update --project .` and `plan github reconcile --project . --update-visible` after merge before taking more queue work.

--- a/docs/project-workflows.md
+++ b/docs/project-workflows.md
@@ -1,0 +1,45 @@
+# Project Workflows
+
+<!-- brain:begin project-doc-workflows -->
+Use this file for agent operating workflow inside the repo.
+
+## Startup
+
+1. If no validated session is active, run `brain prep --task "<task>"`.
+2. If a session already exists, run `brain prep`.
+3. Read `AGENTS.md`, `.brain/policy.yaml`, and the linked context files still needed for the task.
+4. Use `brain context compile --task "<task>"` only when you need the lower-level packet compiler directly.
+5. If project memory still matters, run `brain find plan` or `brain search "plan <task>"`.
+
+## During Work
+
+- Keep durable discoveries, decisions, and risks in AGENTS.md, /docs, or .brain notes.
+- Update existing durable notes instead of duplicating context.
+- Run required verification commands through `brain session run -- <command>`.
+- If you change Brain command behavior or agent-facing workflow guidance, update `skills/brain/SKILL.md` in the same branch.
+- Re-read context before large changes if the task shifts.
+
+## Ticket Loop
+
+1. Start one task or ticket at a time and keep the scope narrow.
+2. Implement the task, then run focused tests for the touched packages.
+3. Run the required full checks through `brain session run -- go test ./...` and `brain session run -- go build ./...`.
+4. Review the diff against the task goal and user-facing behavior.
+5. If review finds issues, patch the work and repeat the test and review steps.
+6. When the task is clean, commit it, push it, and only then move to the next task.
+
+## Close-Out
+
+- Refresh or update durable notes for meaningful behavior, config, or architecture changes.
+- If `brain session finish` blocks, inspect the promotion suggestions first; run `brain distill --session --dry-run` only when you need the full review without creating a proposal note.
+- Before switching away from a working branch or back to `develop`, run `git status --short` and resolve repo-owned leftovers. If `.brain/resources/changes/*`, `.brain/`, `docs/`, or contract files belong to the task, keep them in the same branch/PR; otherwise review and intentionally remove them instead of carrying them onto `develop`, `release/*`, or `main`.
+- If `skills/brain/` changed, reinstall the local Brain skill for Codex and OpenClaw with `brain skills install --scope local --agent codex --agent openclaw --project .`.
+- When opening a PR, make the title and body release-note friendly because GitHub release notes are generated from merged PR metadata.
+- Summarize shipped behavior in the PR, not just implementation steps, so future changelogs stay human-readable.
+- Finish with `brain session finish`.
+- If you must bypass enforcement, use `brain session finish --force --reason "..."` so the override is recorded.
+<!-- brain:end project-doc-workflows -->
+
+## Local Notes
+
+Add repo-specific notes here. `brain context refresh` preserves content outside managed blocks.

--- a/docs/using-plan.md
+++ b/docs/using-plan.md
@@ -396,29 +396,48 @@ Important rules:
 - a story requires at least one verification step
 - story creation is blocked until the spec is `approved`
 
-### 11A. GitHub Queue Workflow
+### 11A. Spec Queue Workflow
 
-If stories are GitHub-backed, use this execution loop:
+Preferred execution loop is spec-first, not issue-first:
 
 1. Establish queue with `plan status --project .`
-2. Grab issue or issues from `ready_work`
-3. Do the work on a feature branch and open a PR
-4. Review and iterate until the PR is ready
-5. Squash-merge the PR
-6. Return to the integration branch
-7. Pull latest changes
-8. Run `plan update --project .`
-9. Run `plan github reconcile --project . --update-visible`
-10. Re-check `plan status --project .`
-11. Grab the next ready issue or issues and repeat
+2. Take the next approved spec from the queue
+3. Run `plan story slice --project . <epic-slug>` to preview the slices
+4. Run `plan story slice --project . <epic-slug> --apply` when the slice set is sound
+5. Implement one slice
+6. Review and verify that slice before committing it
+7. Repeat slice-by-slice until the spec is done
+8. Move to the next spec in queue if more queued specs remain
+9. Open one PR when the queued specs for the branch are complete
 
 Recommended commands:
 
 ```bash
 plan status --project .
 
-# do issue work on a branch and merge the PR into your integration branch
+# take next approved spec
+plan story slice --project . <epic-slug>
+plan story slice --project . <epic-slug> --apply
 
+# implement one slice
+# run review + verification
+# commit slice
+
+# repeat until the spec is done
+# then move to the next queued spec
+```
+
+Use this model:
+
+- `plan status` = queue view
+- approved spec = execution batch
+- story slices = execution units inside the current spec
+- review + verification happen before each slice commit
+- PR = review for the completed queued spec batch
+
+If GitHub story mode is enabled, reconcile after merge:
+
+```bash
 git switch <integration-branch>
 git pull --ff-only origin <integration-branch>
 plan update --project .
@@ -426,14 +445,14 @@ plan github reconcile --project . --update-visible
 plan status --project .
 ```
 
-Use this model:
+If GitHub story mode is not enabled, use the same refresh without reconcile:
 
-- `plan status` = queue view
-- GitHub Issue = execution unit
-- PR = implementation review loop
-- squash-merge = queue advancement
-- integration-branch refresh + `update` + `reconcile` = refresh local truth
-  before taking the next issue
+```bash
+git switch <integration-branch>
+git pull --ff-only origin <integration-branch>
+plan update --project .
+plan status --project .
+```
 
 Show a story:
 
@@ -571,13 +590,8 @@ plan spec analyze --project . billing-export
 plan spec checklist --project . billing-export --profile api-integration
 plan spec status --project . billing-export --set approved
 
-plan story create --project . billing-export "Trigger export job" \
-  --criteria "Export job can be triggered from billing UI" \
-  --verify "Run focused billing export tests"
-
-plan story create --project . billing-export "Deliver export payload" \
-  --criteria "Payload matches the external API contract" \
-  --verify "Validate payload against fixture contract"
+plan story slice --project . billing-export
+plan story slice --project . billing-export --apply
 
 plan status --project .
 plan check --project .

--- a/scripts/setup-codex-cloud.sh
+++ b/scripts/setup-codex-cloud.sh
@@ -1,0 +1,65 @@
+#!/bin/sh
+
+set -eu
+
+PROJECT_DIR="${1:-.}"
+SCRIPT_DIR="$(CDPATH= cd -- "$(dirname "$0")" && pwd)"
+ROOT_DIR="$(CDPATH= cd -- "${SCRIPT_DIR}/.." && pwd)"
+PROJECT_DIR_ABS="$(CDPATH= cd -- "${PROJECT_DIR}" && pwd)"
+BIN_DIR="${ROOT_DIR}/.codex/bin"
+BRAIN_BIN="${BIN_DIR}/brain"
+BRAIN_INSTALLER_URL="https://raw.githubusercontent.com/JimmyMcBride/brain/main/scripts/install.sh"
+
+die() {
+  printf 'setup-codex-cloud: %s\n' "$1" >&2
+  exit 1
+}
+
+need_cmd() {
+  command -v "$1" >/dev/null 2>&1
+}
+
+fetch() {
+  url="$1"
+  out="$2"
+
+  if need_cmd curl; then
+    curl -fsSL "$url" -o "$out"
+    return
+  fi
+
+  if need_cmd wget; then
+    wget -qO "$out" "$url"
+    return
+  fi
+
+  die "need curl or wget to download Brain installer"
+}
+
+mkdir -p "${BIN_DIR}"
+
+TMPDIR="$(mktemp -d)"
+trap 'rm -rf "${TMPDIR}"' EXIT INT TERM
+
+INSTALLER_PATH="${TMPDIR}/brain-install.sh"
+fetch "${BRAIN_INSTALLER_URL}" "${INSTALLER_PATH}"
+
+printf 'Installing Brain into %s\n' "${BIN_DIR}"
+BRAIN_INSTALL_DIR="${BIN_DIR}" sh "${INSTALLER_PATH}"
+
+[ -x "${BRAIN_BIN}" ] || die "Brain binary not found at ${BRAIN_BIN} after install"
+
+printf 'Installing repo-local Brain skill for Codex\n'
+"${BRAIN_BIN}" skills install --scope local --agent codex --project "${PROJECT_DIR_ABS}"
+
+printf 'Verifying Brain install\n'
+"${BRAIN_BIN}" --help >/dev/null
+"${BRAIN_BIN}" skills targets --scope local --agent codex --project "${PROJECT_DIR_ABS}" >/dev/null
+
+if [ -d "${PROJECT_DIR_ABS}/.brain" ]; then
+  printf 'Brain workspace detected at %s/.brain\n' "${PROJECT_DIR_ABS}"
+else
+  printf 'No .brain workspace detected. Brain installed as optional context tool only.\n'
+fi
+
+printf 'Codex cloud setup complete\n'


### PR DESCRIPTION
## Summary
- add a repo-root `AGENTS.md` contract for Codex and optional Brain usage
- add `scripts/setup-codex-cloud.sh` to install a repo-local Brain binary and local Codex Brain skill
- document the optional Codex cloud + Brain setup in the README and ignore runtime install paths

## Verification
- ./scripts/setup-codex-cloud.sh /home/jimmy/Projects/plan
- sh -n scripts/setup-codex-cloud.sh
- ./.codex/bin/brain skills targets --scope local --agent codex --project /home/jimmy/Projects/plan
- go test ./...
- go build ./...
- git diff --check

## Release Notes
- add optional Codex cloud setup for repo-local Brain install and skill wiring