### PR TITLE
feat: ship spec-first planning workflow

### DIFF
--- a/.plan/.meta/migrations.json
+++ b/.plan/.meta/migrations.json
@@ -1,11 +1,15 @@
 {
   "schema_version": 1,
   "known": [],
-  "last_run_at": "2026-04-20T04:03:30Z",
+  "last_run_at": "2026-04-22T04:17:54Z",
   "status": "current",
   "last_operation": "update",
   "last_created": [
-    ".plan/.meta/guided_sessions.json"
+    ".plan/ideas",
+    ".plan/archive"
+  ],
+  "last_updated": [
+    ".plan/.meta/workspace.json"
   ],
   "history": [
     {
@@ -30,6 +34,18 @@
       "status": "current",
       "created": [
         ".plan/.meta/guided_sessions.json"
+      ]
+    },
+    {
+      "operation": "update",
+      "at": "2026-04-22T04:17:54Z",
+      "status": "current",
+      "created": [
+        ".plan/ideas",
+        ".plan/archive"
+      ],
+      "updated": [
+        ".plan/.meta/workspace.json"
       ]
     }
   ]

--- a/.plan/.meta/workspace.json
+++ b/.plan/.meta/workspace.json
@@ -1,7 +1,7 @@
 {
   "schema_version": 1,
-  "planning_model": "epic_spec_story_v1",
+  "planning_model": "spec_first_v1",
   "story_backend": "github",
   "created_at": "2026-04-16T05:33:06Z",
-  "updated_at": "2026-04-20T03:04:26Z"
+  "updated_at": "2026-04-22T04:17:54Z"
 }

--- a/README.md
+++ b/README.md
@@ -5,8 +5,9 @@
 It keeps planning material in `.plan/` and focuses on one job: turning rough
 ideas into shaped, execution-ready plans that agents can follow cleanly.
 
-If GitHub story mode is enabled, brainstorms, epics, and specs stay local in
-`.plan/`, while stories execute as GitHub Issues.
+If GitHub execution mode is enabled, active planning stays local in `.plan/`
+while GitHub Issues can still carry legacy execution stories during the
+transition.
 
 ## Philosophy
 
@@ -22,29 +23,36 @@ need that layer.
 
 ## Core Model
 
-Canonical hierarchy:
+Active planning model:
 
-1. Epic
-2. Spec
-3. Story
+1. Brainstorm session
+2. Idea doc (optional)
+3. Spec
+4. Execution slices at runtime
+
+`initiative` is optional lightweight grouping for multiple specs. In GitHub
+mode, an initiative can map to a milestone.
+
+Legacy `epic` and `story` commands still exist during the transition, but they
+are no longer the active model the workspace reports by default.
 
 Workflow entry:
 
 1. Brainstorm
 2. Refine
 3. Challenge
-4. Promote to epic
-5. Shape the epic
-6. Write and approve spec
-7. Analyze or checklist the spec
-8. Slice into stories
-9. Critique story readiness
+4. Promote or shape the work into a spec
+5. Write and approve spec
+6. Analyze or checklist the spec
+7. Assign initiative metadata when needed
+8. Start spec execution
+9. Work the execution slices one commit at a time
 
 Execution loop:
 
 1. Establish spec queue
 2. Take next approved spec
-3. Slice the spec into execution-ready stories
+3. Start execution from the approved spec
 4. Implement one slice
 5. Review and verify that slice before committing it
 6. Repeat until the spec is done
@@ -62,9 +70,9 @@ my-project/
     PROJECT.md
     ROADMAP.md
     brainstorms/
-    epics/
+    ideas/
+    archive/
     specs/
-    stories/
     .meta/
       workspace.json
       migrations.json
@@ -76,9 +84,9 @@ User-authored planning material lives in:
 - `.plan/PROJECT.md`
 - `.plan/ROADMAP.md`
 - `.plan/brainstorms/`
-- `.plan/epics/`
+- `.plan/ideas/`
+- `.plan/archive/` for preserved legacy material
 - `.plan/specs/`
-- `.plan/stories/` in local story mode
 
 Tool-owned state lives only in:
 
@@ -86,8 +94,9 @@ Tool-owned state lives only in:
 - `.plan/.meta/migrations.json`
 - `.plan/.meta/github.json` when GitHub story mode is enabled
 
-`plan update` may repair or normalize tool-owned state. It must not rewrite
-user-authored planning notes just to migrate product direction.
+`plan update` may repair or normalize tool-owned state. Use
+`plan update --archive-legacy` to move legacy `epics/` and `stories/` into
+`.plan/archive/` without mutating the active spec-first surfaces.
 
 ## Quick Start
 
@@ -97,14 +106,12 @@ plan brainstorm start --project . "Newsletter system"
 plan brainstorm refine --project . newsletter-system
 plan brainstorm challenge --project . newsletter-system
 plan epic promote --project . newsletter-system
-plan epic shape --project . newsletter-system
 plan spec show --project . newsletter-system
 plan spec analyze --project . newsletter-system
 plan spec checklist --project . newsletter-system --profile general
+plan spec initiative --project . newsletter-system --set guide-packet-foundation --title "Guide Packet Foundation"
 plan spec status --project . newsletter-system --set approved
-plan story slice --project . newsletter-system
-plan story slice --project . newsletter-system --apply
-plan story critique --project . build-template-editor
+plan spec execute --project . newsletter-system
 plan status --project .
 plan check --project .
 ```
@@ -121,9 +128,9 @@ Full guide:
 - `plan update`
 - `plan brainstorm start|idea|show|refine`
 - `plan brainstorm challenge`
-- `plan epic create|promote|list|show|shape`
-- `plan spec show|edit|status|analyze|checklist`
-- `plan story create|update|list|show|slice|critique`
+- `plan epic create|promote|list|show|shape` for legacy compatibility during migration
+- `plan spec show|edit|status|analyze|checklist|initiative|execute|handoff`
+- `plan story create|update|list|show|slice|critique` for legacy compatibility during migration
 - `plan github enable|reconcile`
 - `plan roadmap show|edit`
 - `plan check`
@@ -138,8 +145,7 @@ Use this loop when implementing planned work:
 plan status --project .
 
 # take next approved spec
-plan story slice --project . <epic-slug>
-plan story slice --project . <epic-slug> --apply
+plan spec execute --project . <spec-slug>
 
 # implement one slice
 # review + verify slice
@@ -155,7 +161,7 @@ Rules:
 
 - use `plan status --project .` as the queue view
 - queue work at the spec level, not the single-issue level
-- slice one approved spec into execution-ready stories before coding
+- start execution from one approved spec before coding
 - complete one slice at a time
 - review and verify each slice before committing that slice
 - once the current spec is done, move to the next queued spec

--- a/cmd/brainstorm.go
+++ b/cmd/brainstorm.go
@@ -802,11 +802,11 @@ func renderBrainstormStageRecap(state *planning.BrainstormRefinement, nextAction
 func guidedDownstreamStagesForOutput(stage string) []string {
 	switch strings.TrimSpace(stage) {
 	case "brainstorm":
-		return []string{"epic", "spec", "stories"}
+		return []string{"epic", "spec", "execution"}
 	case "epic":
-		return []string{"spec", "stories"}
+		return []string{"spec", "execution"}
 	case "spec":
-		return []string{"stories"}
+		return []string{"execution"}
 	default:
 		return []string{"none"}
 	}

--- a/cmd/check_test.go
+++ b/cmd/check_test.go
@@ -227,7 +227,7 @@ func createHealthyPlanFixture(t *testing.T, root string, manager *planning.Manag
 	}
 }
 
-func TestCheckCommandFlagsImplementingSpecWithoutStoryCoverage(t *testing.T) {
+func TestCheckCommandDoesNotRequireStoryCoverageForImplementingSpecs(t *testing.T) {
 	root := t.TempDir()
 	ws := workspace.New(root)
 	if _, err := ws.Init(); err != nil {
@@ -288,10 +288,6 @@ func TestCheckCommandFlagsImplementingSpecWithoutStoryCoverage(t *testing.T) {
 		"",
 		"- run check tests",
 		"",
-		"## Story Breakdown",
-		"",
-		"- Trigger export job",
-		"",
 	}, "\n")
 	if _, err := manager.UpdateSpec("billing", notes.UpdateInput{
 		Body: &specBody,
@@ -307,11 +303,10 @@ func TestCheckCommandFlagsImplementingSpecWithoutStoryCoverage(t *testing.T) {
 	command.SetOut(&buf)
 	command.SetErr(&buf)
 	command.SetArgs([]string{"--project", root, "check", "spec", "billing"})
-	err := command.Execute()
-	if err == nil {
-		t.Fatalf("expected readiness findings to fail command:\n%s", buf.String())
+	if err := command.Execute(); err != nil {
+		t.Fatalf("expected implementing spec check to avoid legacy story-coverage failure: %v\n%s", err, buf.String())
 	}
-	if !strings.Contains(buf.String(), "no child stories are linked to it") {
-		t.Fatalf("expected missing story coverage finding:\n%s", buf.String())
+	if strings.Contains(buf.String(), "no child stories are linked to it") {
+		t.Fatalf("expected story coverage requirement to be removed:\n%s", buf.String())
 	}
 }

--- a/cmd/github_test.go
+++ b/cmd/github_test.go
@@ -36,6 +36,10 @@ func (s *stubGitHubEnableClient) GetIssue(projectDir, repo string, issueNumber i
 	panic("unexpected GetIssue call")
 }
 
+func (s *stubGitHubEnableClient) FindMilestone(projectDir, repo, title string) (*planning.GitHubMilestone, error) {
+	panic("unexpected FindMilestone call")
+}
+
 func TestGitHubEnableCommandPrintsBackendSummary(t *testing.T) {
 	reset := planning.SetGitHubClientFactoryForTesting(func() planning.GitHubClient {
 		return &stubGitHubEnableClient{

--- a/cmd/spec.go
+++ b/cmd/spec.go
@@ -4,6 +4,7 @@ import (
 	"bufio"
 	"fmt"
 	"io"
+	"strings"
 
 	"plan/internal/notes"
 	"plan/internal/planning"
@@ -18,8 +19,8 @@ func newSpecCommand() *cobra.Command {
 	}
 
 	show := &cobra.Command{
-		Use:   "show <epic-slug>",
-		Short: "Show the canonical spec for an epic",
+		Use:   "show <spec-slug>",
+		Short: "Show a canonical spec",
 		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			note, err := planningManager().ReadSpec(args[0])
@@ -35,7 +36,7 @@ func newSpecCommand() *cobra.Command {
 	var useStdin bool
 	var editor string
 	edit := &cobra.Command{
-		Use:   "edit <epic-slug>",
+		Use:   "edit <spec-slug>",
 		Short: "Edit a spec via --body, --stdin, or $EDITOR",
 		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
@@ -69,7 +70,7 @@ func newSpecCommand() *cobra.Command {
 
 	var status string
 	statusCmd := &cobra.Command{
-		Use:   "status <epic-slug>",
+		Use:   "status <spec-slug>",
 		Short: "Set spec status",
 		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
@@ -85,7 +86,7 @@ func newSpecCommand() *cobra.Command {
 	_ = statusCmd.MarkFlagRequired("set")
 
 	analyze := &cobra.Command{
-		Use:   "analyze <epic-slug>",
+		Use:   "analyze <spec-slug>",
 		Short: "Analyze a spec for refinement gaps without rewriting its canonical sections",
 		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
@@ -103,7 +104,7 @@ func newSpecCommand() *cobra.Command {
 
 	var profile string
 	checklist := &cobra.Command{
-		Use:   "checklist <epic-slug>",
+		Use:   "checklist <spec-slug>",
 		Short: "Run a profile-driven checklist pass against a spec",
 		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
@@ -120,22 +121,76 @@ func newSpecCommand() *cobra.Command {
 	}
 	checklist.Flags().StringVar(&profile, "profile", "general", "checklist profile: general, ui-flow, api-integration, data-migration")
 
+	var initiativeSlug string
+	var initiativeTitle string
+	var initiativeSummary string
+	var clearInitiative bool
+	initiative := &cobra.Command{
+		Use:   "initiative <spec-slug>",
+		Short: "Set or clear lightweight initiative metadata on a spec",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if !clearInitiative && strings.TrimSpace(initiativeSlug) == "" {
+				return fmt.Errorf("initiative --set value is required unless --clear is used")
+			}
+			var (
+				note *notes.Note
+				err  error
+			)
+			if clearInitiative {
+				note, err = planningManager().ClearSpecInitiative(args[0])
+			} else {
+				note, err = planningManager().SetSpecInitiative(args[0], planning.InitiativeRef{
+					Slug:    initiativeSlug,
+					Title:   initiativeTitle,
+					Summary: initiativeSummary,
+				})
+			}
+			if err != nil {
+				return err
+			}
+			fmt.Printf("Updated initiative metadata for %s\n", note.Path)
+			return nil
+		},
+	}
+	initiative.Flags().StringVar(&initiativeSlug, "set", "", "initiative slug or shared reference")
+	initiative.Flags().StringVar(&initiativeTitle, "title", "", "human title for the initiative")
+	initiative.Flags().StringVar(&initiativeSummary, "summary", "", "optional initiative summary or goal")
+	initiative.Flags().BoolVar(&clearInitiative, "clear", false, "clear initiative metadata from the spec")
+
+	var executeBranchPrefix string
+	execute := &cobra.Command{
+		Use:   "execute <spec-slug>",
+		Short: "Start spec execution with a suggested branch and ephemeral slices",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			plan, err := planningManager().BeginSpecExecution(args[0], executeBranchPrefix)
+			if err != nil {
+				return err
+			}
+			printSpecExecutionPlan(cmd.OutOrStdout(), plan)
+			return nil
+		},
+	}
+	execute.Flags().StringVar(&executeBranchPrefix, "branch-prefix", "feature/", "prefix for the suggested execution branch")
+
+	var handoffBranchPrefix string
 	handoff := &cobra.Command{
-		Use:   "handoff <epic-slug>",
-		Short: "Continue a guided spec into the first story set",
+		Use:   "handoff <spec-slug>",
+		Short: "Continue a guided spec into the execution stage",
 		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			session, err := planningManager().ReadGuidedSessionByEpic(args[0])
 			if err != nil {
 				return err
 			}
-			fmt.Fprintf(cmd.OutOrStdout(), "Spec recap:\nCurrent understanding: %s\nRecommended next stage: continue into stories.\n", session.Summary)
-			preview, err := planningManager().PreviewStorySlices(args[0])
+			fmt.Fprintf(cmd.OutOrStdout(), "Spec recap:\nCurrent understanding: %s\nRecommended next stage: continue into execution.\n", session.Summary)
+			preview, err := planningManager().PreviewSpecExecution(args[0], handoffBranchPrefix)
 			if err != nil {
 				return err
 			}
-			printStorySlicePreview(cmd.OutOrStdout(), preview)
-			ok, err := confirmStorySliceApply(bufio.NewReader(cmd.InOrStdin()), cmd.OutOrStdout())
+			printSpecExecutionPlan(cmd.OutOrStdout(), preview)
+			ok, err := confirmSpecExecutionStart(bufio.NewReader(cmd.InOrStdin()), cmd.OutOrStdout())
 			if err != nil {
 				return err
 			}
@@ -143,7 +198,7 @@ func newSpecCommand() *cobra.Command {
 				updated, err := planningManager().UpdateGuidedSession(session.ChainID, planning.GuidedSessionUpdateInput{
 					CurrentStage: "spec",
 					StageStatus:  "in_progress",
-					NextAction:   "Spec handoff is ready when you want to create the first story set.",
+					NextAction:   "Spec execution handoff is ready when you want to start implementation.",
 				})
 				if err != nil {
 					return err
@@ -151,21 +206,22 @@ func newSpecCommand() *cobra.Command {
 				fmt.Fprintf(cmd.OutOrStdout(), "Checkpoint saved for %s\nNext: %s\n", updated.ChainID, updated.NextAction)
 				return nil
 			}
-			result, err := planningManager().ApplyStorySlices(args[0])
+			plan, err := planningManager().BeginSpecExecution(args[0], handoffBranchPrefix)
 			if err != nil {
 				return err
 			}
-			printStorySliceApplyResult(cmd.OutOrStdout(), result)
-			updated, err := planningManager().AdvanceGuidedSessionToStories(args[0])
+			updated, err := planningManager().AdvanceGuidedSessionToExecution(args[0])
 			if err != nil {
 				return err
 			}
+			printSpecExecutionPlan(cmd.OutOrStdout(), plan)
 			fmt.Fprintf(cmd.OutOrStdout(), "Next: %s\n", updated.NextAction)
 			return nil
 		},
 	}
+	handoff.Flags().StringVar(&handoffBranchPrefix, "branch-prefix", "feature/", "prefix for the suggested execution branch")
 
-	cmd.AddCommand(show, edit, statusCmd, analyze, checklist, handoff)
+	cmd.AddCommand(show, edit, statusCmd, analyze, checklist, initiative, execute, handoff)
 	return cmd
 }
 
@@ -213,4 +269,32 @@ func printSpecChecklist(out io.Writer, report *planning.SpecChecklistReport) {
 			fmt.Fprintf(out, "  fix: %s\n", item.Recommendation)
 		}
 	}
+}
+
+func printSpecExecutionPlan(out io.Writer, plan *planning.SpecExecutionPlan) {
+	fmt.Fprintf(out, "spec_execution: %s\n", plan.SpecPath)
+	fmt.Fprintf(out, "status: %s\n", plan.Status)
+	fmt.Fprintf(out, "branch: %s\n", plan.SuggestedBranch)
+	fmt.Fprintf(out, "slices: %d\n", len(plan.Slices))
+	for index, slice := range plan.Slices {
+		fmt.Fprintf(out, "%d. %s\n", index+1, slice.Title)
+		fmt.Fprintf(out, "   goal: %s\n", slice.Goal)
+		for _, verify := range slice.Verification {
+			fmt.Fprintf(out, "   verify: %s\n", verify)
+		}
+	}
+	fmt.Fprintln(out, "workflow:")
+	fmt.Fprintln(out, "- implement one slice at a time")
+	fmt.Fprintln(out, "- review and verify each slice before committing it")
+	fmt.Fprintln(out, "- open a PR after the full spec is built")
+}
+
+func confirmSpecExecutionStart(reader *bufio.Reader, out io.Writer) (bool, error) {
+	fmt.Fprint(out, "Start execution from this spec plan? [y/N]: ")
+	line, err := reader.ReadString('\n')
+	if err != nil && err != io.EOF {
+		return false, err
+	}
+	answer := strings.ToLower(strings.TrimSpace(line))
+	return answer == "y" || answer == "yes", nil
 }

--- a/cmd/spec.go
+++ b/cmd/spec.go
@@ -180,7 +180,7 @@ func newSpecCommand() *cobra.Command {
 		Short: "Continue a guided spec into the execution stage",
 		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			session, err := planningManager().ReadGuidedSessionByEpic(args[0])
+			session, err := planningManager().ReadGuidedSessionBySpec(args[0])
 			if err != nil {
 				return err
 			}
@@ -210,7 +210,7 @@ func newSpecCommand() *cobra.Command {
 			if err != nil {
 				return err
 			}
-			updated, err := planningManager().AdvanceGuidedSessionToExecution(args[0])
+			updated, err := planningManager().AdvanceGuidedSessionToExecutionBySpec(args[0])
 			if err != nil {
 				return err
 			}

--- a/cmd/spec_test.go
+++ b/cmd/spec_test.go
@@ -365,8 +365,9 @@ func TestSpecHandoffStartsExecutionAndAdvancesSessionToExecution(t *testing.T) {
 		t.Fatal(err)
 	}
 
+	const specSlug = "guided-planning-spec"
 	body := strings.Join([]string{
-		"# Guided Planning Spec",
+		"# Guided Planning Execution Spec",
 		"",
 		"Created: now",
 		"",
@@ -421,12 +422,21 @@ func TestSpecHandoffStartsExecutionAndAdvancesSessionToExecution(t *testing.T) {
 		"- Build the first guided execution pass",
 		"",
 	}, "\n")
-	if _, err := manager.UpdateSpec("guided-planning", notes.UpdateInput{
-		Body: &body,
-		Metadata: map[string]any{
-			"status": "approved",
-		},
+	if _, err := notes.Create(filepath.Join(root, ".plan", "specs", specSlug+".md"), "Guided Planning Execution Spec", "spec", body, map[string]any{
+		"slug":   specSlug,
+		"status": "approved",
+		"epic":   "guided-planning",
 	}); err != nil {
+		t.Fatal(err)
+	}
+	state, err := ws.ReadGuidedSessionState()
+	if err != nil {
+		t.Fatal(err)
+	}
+	session := state.Sessions["brainstorm/guided-planning"]
+	session.Spec = specSlug
+	state.Sessions[session.ChainID] = session
+	if err := ws.WriteGuidedSessionState(*state); err != nil {
 		t.Fatal(err)
 	}
 
@@ -435,23 +445,23 @@ func TestSpecHandoffStartsExecutionAndAdvancesSessionToExecution(t *testing.T) {
 	command.SetOut(&output)
 	command.SetErr(&output)
 	command.SetIn(strings.NewReader("y\n"))
-	command.SetArgs([]string{"--project", root, "spec", "handoff", "guided-planning"})
+	command.SetArgs([]string{"--project", root, "spec", "handoff", specSlug})
 	if err := command.Execute(); err != nil {
 		t.Fatalf("expected spec handoff to succeed: %v\n%s", err, output.String())
 	}
 
-	state, err := ws.ReadGuidedSessionState()
+	state, err = ws.ReadGuidedSessionState()
 	if err != nil {
 		t.Fatal(err)
 	}
-	session := state.Sessions["brainstorm/guided-planning"]
+	session = state.Sessions["brainstorm/guided-planning"]
 	if session.CurrentStage != "execution" {
 		t.Fatalf("expected session to advance to execution stage: %+v", session)
 	}
 	if session.StageStatuses["spec"] != "done" || session.StageStatuses["execution"] != "in_progress" {
 		t.Fatalf("expected execution-stage handoff statuses: %+v", session)
 	}
-	spec, err := notes.Read(filepath.Join(root, ".plan", "specs", "guided-planning.md"))
+	spec, err := notes.Read(filepath.Join(root, ".plan", "specs", specSlug+".md"))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -461,7 +471,7 @@ func TestSpecHandoffStartsExecutionAndAdvancesSessionToExecution(t *testing.T) {
 	if _, err := notes.Read(filepath.Join(root, ".plan", "stories", "carry-forward-recap-state.md")); !os.IsNotExist(err) {
 		t.Fatalf("expected handoff to avoid creating stories, got %v", err)
 	}
-	if !strings.Contains(output.String(), "spec_execution: .plan/specs/guided-planning.md") || !strings.Contains(output.String(), "branch: feature/guided-planning") {
+	if !strings.Contains(output.String(), "spec_execution: .plan/specs/"+specSlug+".md") || !strings.Contains(output.String(), "branch: feature/"+specSlug) {
 		t.Fatalf("expected execution handoff output:\n%s", output.String())
 	}
 }

--- a/cmd/spec_test.go
+++ b/cmd/spec_test.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"bytes"
+	"os"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -194,7 +195,144 @@ func TestSpecChecklistCommandWritesChecklistAndFailsOnBlockingFindings(t *testin
 	}
 }
 
-func TestSpecHandoffAppliesStorySlicesAndAdvancesSessionToStories(t *testing.T) {
+func TestSpecInitiativeCommandUpdatesMetadata(t *testing.T) {
+	root := t.TempDir()
+	ws := workspace.New(root)
+	if _, err := ws.Init(); err != nil {
+		t.Fatal(err)
+	}
+	manager := planning.New(ws)
+	if _, err := manager.CreateEpic("Billing", ""); err != nil {
+		t.Fatal(err)
+	}
+
+	var output bytes.Buffer
+	command := newRootCmd()
+	command.SetOut(&output)
+	command.SetErr(&output)
+	command.SetArgs([]string{
+		"--project", root,
+		"spec", "initiative", "billing",
+		"--set", "guide-packet-foundation",
+		"--title", "Guide Packet Foundation",
+		"--summary", "Ship the first guide-packet workflow slices.",
+	})
+	if err := command.Execute(); err != nil {
+		t.Fatalf("expected spec initiative command to succeed: %v\n%s", err, output.String())
+	}
+
+	spec, err := notes.Read(filepath.Join(root, ".plan", "specs", "billing.md"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if spec.Metadata["initiative"] != "guide-packet-foundation" || spec.Metadata["initiative_title"] != "Guide Packet Foundation" {
+		t.Fatalf("expected initiative metadata on spec: %+v", spec.Metadata)
+	}
+}
+
+func TestSpecExecuteCommandStartsImplementingWithoutCreatingStories(t *testing.T) {
+	root := t.TempDir()
+	ws := workspace.New(root)
+	if _, err := ws.Init(); err != nil {
+		t.Fatal(err)
+	}
+	manager := planning.New(ws)
+
+	if _, err := manager.CreateEpic("Billing", ""); err != nil {
+		t.Fatal(err)
+	}
+	body := strings.Join([]string{
+		"# Billing Spec",
+		"",
+		"Created: now",
+		"",
+		"## Why",
+		"",
+		"Billing execution needs a spec-driven workflow.",
+		"",
+		"## Problem",
+		"",
+		"Execution still depends on durable story files.",
+		"",
+		"## Goals",
+		"",
+		"- start execution from the spec",
+		"",
+		"## Non-Goals",
+		"",
+		"- rebuilding project management",
+		"",
+		"## Constraints",
+		"",
+		"- keep slices ephemeral",
+		"",
+		"## Solution Shape",
+		"",
+		"Drive execution directly from the approved spec.",
+		"",
+		"## Flows",
+		"",
+		"1. Start execution from the approved spec.",
+		"2. Work through slices in order.",
+		"",
+		"## Data / Interfaces",
+		"",
+		"- spec execution plan",
+		"",
+		"## Risks / Open Questions",
+		"",
+		"- branch naming consistency",
+		"",
+		"## Rollout",
+		"",
+		"- dogfood in the repo",
+		"",
+		"## Verification",
+		"",
+		"- go test ./...",
+		"",
+		"## Execution Plan",
+		"",
+		"- Prepare billing execution",
+		"  - description: validate the interfaces and rollout constraints before writing code",
+		"- Implement billing execution",
+		"  - description: build the main billing behavior from the spec",
+		"",
+	}, "\n")
+	if _, err := manager.UpdateSpec("billing", notes.UpdateInput{
+		Body: &body,
+		Metadata: map[string]any{
+			"status": "approved",
+		},
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	var output bytes.Buffer
+	command := newRootCmd()
+	command.SetOut(&output)
+	command.SetErr(&output)
+	command.SetArgs([]string{"--project", root, "spec", "execute", "billing"})
+	if err := command.Execute(); err != nil {
+		t.Fatalf("expected spec execute to succeed: %v\n%s", err, output.String())
+	}
+
+	spec, err := notes.Read(filepath.Join(root, ".plan", "specs", "billing.md"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if spec.Metadata["status"] != "implementing" {
+		t.Fatalf("expected execute to mark spec implementing: %+v", spec.Metadata)
+	}
+	if _, err := notes.Read(filepath.Join(root, ".plan", "stories", "prepare-billing-execution.md")); !os.IsNotExist(err) {
+		t.Fatalf("expected execute to avoid creating story artifacts, got %v", err)
+	}
+	if !strings.Contains(output.String(), "spec_execution: .plan/specs/billing.md") || !strings.Contains(output.String(), "branch: feature/billing") {
+		t.Fatalf("expected execution output in command result:\n%s", output.String())
+	}
+}
+
+func TestSpecHandoffStartsExecutionAndAdvancesSessionToExecution(t *testing.T) {
 	root := t.TempDir()
 	ws := workspace.New(root)
 	if _, err := ws.Init(); err != nil {
@@ -234,15 +372,15 @@ func TestSpecHandoffAppliesStorySlicesAndAdvancesSessionToStories(t *testing.T) 
 		"",
 		"## Why",
 		"",
-		"Guided planning needs execution-ready stories.",
+		"Guided planning needs a spec-driven execution handoff.",
 		"",
 		"## Problem",
 		"",
-		"Story creation is still manual.",
+		"Execution still depends on persistent story creation.",
 		"",
 		"## Goals",
 		"",
-		"- derive a first story set",
+		"- derive a first execution pass",
 		"",
 		"## Non-Goals",
 		"",
@@ -254,12 +392,12 @@ func TestSpecHandoffAppliesStorySlicesAndAdvancesSessionToStories(t *testing.T) 
 		"",
 		"## Solution Shape",
 		"",
-		"Use the approved spec to drive story creation.",
+		"Use the approved spec to drive execution guidance.",
 		"",
 		"## Flows",
 		"",
 		"1. Review spec.",
-		"2. Create stories.",
+		"2. Start execution.",
 		"",
 		"## Data / Interfaces",
 		"",
@@ -275,12 +413,12 @@ func TestSpecHandoffAppliesStorySlicesAndAdvancesSessionToStories(t *testing.T) 
 		"",
 		"## Verification",
 		"",
-		"- run story slice coverage",
+		"- run spec execution coverage",
 		"",
-		"## Story Breakdown",
+		"## Execution Plan",
 		"",
 		"- Carry forward recap state",
-		"- Apply first story set",
+		"- Build the first guided execution pass",
 		"",
 	}, "\n")
 	if _, err := manager.UpdateSpec("guided-planning", notes.UpdateInput{
@@ -307,16 +445,23 @@ func TestSpecHandoffAppliesStorySlicesAndAdvancesSessionToStories(t *testing.T) 
 		t.Fatal(err)
 	}
 	session := state.Sessions["brainstorm/guided-planning"]
-	if session.CurrentStage != "stories" {
-		t.Fatalf("expected session to advance to stories stage: %+v", session)
+	if session.CurrentStage != "execution" {
+		t.Fatalf("expected session to advance to execution stage: %+v", session)
 	}
-	if session.StageStatuses["spec"] != "done" || session.StageStatuses["stories"] != "in_progress" {
-		t.Fatalf("expected story-stage handoff statuses: %+v", session)
+	if session.StageStatuses["spec"] != "done" || session.StageStatuses["execution"] != "in_progress" {
+		t.Fatalf("expected execution-stage handoff statuses: %+v", session)
 	}
-	if _, err := notes.Read(filepath.Join(root, ".plan", "stories", "carry-forward-recap-state.md")); err != nil {
-		t.Fatalf("expected first story to be created: %v", err)
+	spec, err := notes.Read(filepath.Join(root, ".plan", "specs", "guided-planning.md"))
+	if err != nil {
+		t.Fatal(err)
 	}
-	if !strings.Contains(output.String(), "story_slice_apply: .plan/specs/guided-planning.md") {
-		t.Fatalf("expected story handoff output:\n%s", output.String())
+	if spec.Metadata["status"] != "implementing" {
+		t.Fatalf("expected handoff to mark spec implementing: %+v", spec.Metadata)
+	}
+	if _, err := notes.Read(filepath.Join(root, ".plan", "stories", "carry-forward-recap-state.md")); !os.IsNotExist(err) {
+		t.Fatalf("expected handoff to avoid creating stories, got %v", err)
+	}
+	if !strings.Contains(output.String(), "spec_execution: .plan/specs/guided-planning.md") || !strings.Contains(output.String(), "branch: feature/guided-planning") {
+		t.Fatalf("expected execution handoff output:\n%s", output.String())
 	}
 }

--- a/cmd/status.go
+++ b/cmd/status.go
@@ -27,35 +27,42 @@ func newStatusCommand() *cobra.Command {
 func printStatus(out io.Writer, status *planning.ProjectStatus) {
 	fmt.Fprintf(out, "project: %s\n", status.Project)
 	fmt.Fprintf(out, "planning_model: %s\n", status.PlanningModel)
-	fmt.Fprintf(out, "stories: %d total, %d done, %d in_progress, %d blocked\n",
-		status.TotalStories,
-		status.DoneStories,
-		status.InProgressStories,
-		status.BlockedStories,
+	fmt.Fprintf(out, "specs: %d total, %d draft, %d approved, %d implementing, %d done\n",
+		status.TotalSpecs,
+		status.DraftSpecs,
+		status.ApprovedSpecs,
+		status.ImplementingSpecs,
+		status.DoneSpecs,
 	)
-	if status.ReadyStories > 0 {
-		fmt.Fprintf(out, "ready_work: %d\n", status.ReadyStories)
-		for _, story := range status.ReadyWork {
-			issueRef := ""
-			if story.IssueNumber > 0 {
-				issueRef = fmt.Sprintf(" issue=#%d", story.IssueNumber)
+	if len(status.ReadySpecs) > 0 {
+		fmt.Fprintf(out, "ready_specs: %d\n", len(status.ReadySpecs))
+		for _, spec := range status.ReadySpecs {
+			initiativeRef := ""
+			if spec.Initiative != "" {
+				initiativeRef = fmt.Sprintf(" initiative=%s", spec.Initiative)
 			}
-			fmt.Fprintf(out, "  - %s%s epic=%s spec=%s\n", story.Title, issueRef, story.Epic, story.Spec)
+			fmt.Fprintf(out, "  - %s%s status=%s\n", spec.Title, initiativeRef, spec.Status)
 		}
 	}
-	if len(status.Epics) == 0 {
-		fmt.Fprintln(out, "epics: none")
-		return
-	}
-	fmt.Fprintln(out, "epics:")
-	for _, epic := range status.Epics {
-		fmt.Fprintf(out, "  - %s [%s] (%d/%d done, %d in progress, %d blocked)\n",
-			epic.Title,
-			epic.SpecStatus,
-			epic.DoneStories,
-			epic.TotalStories,
-			epic.InProgressStories,
-			epic.BlockedStories,
+	if status.TotalStories > 0 {
+		fmt.Fprintf(out, "legacy_stories: %d total, %d done, %d in_progress, %d blocked\n",
+			status.TotalStories,
+			status.DoneStories,
+			status.InProgressStories,
+			status.BlockedStories,
 		)
+	}
+	if len(status.Epics) > 0 {
+		fmt.Fprintln(out, "legacy_epics:")
+		for _, epic := range status.Epics {
+			fmt.Fprintf(out, "  - %s [%s] (%d/%d done, %d in progress, %d blocked)\n",
+				epic.Title,
+				epic.SpecStatus,
+				epic.DoneStories,
+				epic.TotalStories,
+				epic.InProgressStories,
+				epic.BlockedStories,
+			)
+		}
 	}
 }

--- a/cmd/status_test.go
+++ b/cmd/status_test.go
@@ -9,7 +9,7 @@ import (
 	"plan/internal/workspace"
 )
 
-func TestStatusCommandPrintsSimpleEpicProgressCounts(t *testing.T) {
+func TestStatusCommandPrintsSpecQueueSummary(t *testing.T) {
 	root := t.TempDir()
 	ws := workspace.New(root)
 	if _, err := ws.Init(); err != nil {
@@ -47,14 +47,17 @@ func TestStatusCommandPrintsSimpleEpicProgressCounts(t *testing.T) {
 	}
 
 	output := buf.String()
-	if !strings.Contains(output, "stories: 1 total, 0 done, 0 in_progress, 1 blocked") {
-		t.Fatalf("expected story summary in output:\n%s", output)
+	if !strings.Contains(output, "specs: 1 total, 0 draft, 0 approved, 1 implementing, 0 done") {
+		t.Fatalf("expected spec summary in output:\n%s", output)
 	}
 	if strings.Contains(output, "ready_work:") || strings.Contains(output, "versions:") {
-		t.Fatalf("expected status output to drop old power summaries:\n%s", output)
+		t.Fatalf("expected status output to stay on the spec-first queue surface:\n%s", output)
 	}
-	if !strings.Contains(output, "Billing [implementing] (0/1 done, 0 in progress, 1 blocked)") {
-		t.Fatalf("expected epic progress counts in output:\n%s", output)
+	if !strings.Contains(output, "legacy_stories: 1 total, 0 done, 0 in_progress, 1 blocked") {
+		t.Fatalf("expected legacy story summary in output:\n%s", output)
+	}
+	if !strings.Contains(output, "legacy_epics:\n  - Billing [implementing] (0/1 done, 0 in progress, 1 blocked)") {
+		t.Fatalf("expected legacy epic summary in output:\n%s", output)
 	}
 }
 
@@ -110,10 +113,59 @@ func TestStatusCommandShowsMultipleReadyGitHubStories(t *testing.T) {
 	}
 
 	output := buf.String()
-	if !strings.Contains(output, "ready_work: 2") {
-		t.Fatalf("expected ready-work summary in output:\n%s", output)
+	if !strings.Contains(output, "ready_specs: 1") {
+		t.Fatalf("expected ready spec summary in output:\n%s", output)
 	}
-	if !strings.Contains(output, "Seed billing data issue=#101 epic=billing spec=billing") || !strings.Contains(output, "Ship exports issue=#102 epic=billing spec=billing") {
-		t.Fatalf("expected multiple ready GitHub stories in output:\n%s", output)
+	if !strings.Contains(output, "Billing Spec status=approved") {
+		t.Fatalf("expected approved spec in ready queue output:\n%s", output)
+	}
+	if !strings.Contains(output, "legacy_stories: 2 total, 0 done, 0 in_progress, 0 blocked") {
+		t.Fatalf("expected legacy story summary in output:\n%s", output)
+	}
+}
+
+func TestStatusCommandIgnoresArchivedLegacyHierarchy(t *testing.T) {
+	root := t.TempDir()
+	ws := workspace.New(root)
+	if _, err := ws.Init(); err != nil {
+		t.Fatal(err)
+	}
+	manager := planning.New(ws)
+
+	if _, err := manager.CreateEpic("Billing", ""); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := manager.SetSpecStatus("billing", "approved"); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := manager.CreateStory(
+		"billing",
+		"Implement invoices",
+		"Create invoice generation flow",
+		[]string{"Generate invoices from line items"},
+		[]string{"Run focused billing tests"},
+		nil,
+	); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := ws.UpdateWithOptions(workspace.UpdateOptions{ArchiveLegacy: true}); err != nil {
+		t.Fatal(err)
+	}
+
+	var buf bytes.Buffer
+	command := newRootCmd()
+	command.SetOut(&buf)
+	command.SetErr(&buf)
+	command.SetArgs([]string{"--project", root, "status"})
+	if err := command.Execute(); err != nil {
+		t.Fatal(err)
+	}
+
+	output := buf.String()
+	if !strings.Contains(output, "ready_specs: 1") {
+		t.Fatalf("expected ready spec summary in output:\n%s", output)
+	}
+	if strings.Contains(output, "legacy_stories:") || strings.Contains(output, "legacy_epics:") {
+		t.Fatalf("expected archived legacy hierarchy to stay out of active status output:\n%s", output)
 	}
 }

--- a/cmd/story_github_test.go
+++ b/cmd/story_github_test.go
@@ -12,10 +12,10 @@ import (
 )
 
 type stubGitHubStoryClient struct {
-	preflight  *planning.GitHubRepoInfo
-	context    *planning.GitHubContext
-	issues     map[int]*planning.GitHubIssue
-	nextIssue  int
+	preflight *planning.GitHubRepoInfo
+	context   *planning.GitHubContext
+	issues    map[int]*planning.GitHubIssue
+	nextIssue int
 }
 
 func (s *stubGitHubStoryClient) Preflight(projectDir string) (*planning.GitHubRepoInfo, error) {
@@ -58,6 +58,10 @@ func (s *stubGitHubStoryClient) UpdateIssue(projectDir, repo string, issueNumber
 func (s *stubGitHubStoryClient) GetIssue(projectDir, repo string, issueNumber int) (*planning.GitHubIssue, error) {
 	copy := *s.issues[issueNumber]
 	return &copy, nil
+}
+
+func (s *stubGitHubStoryClient) FindMilestone(projectDir, repo, title string) (*planning.GitHubMilestone, error) {
+	return nil, nil
 }
 
 func TestStoryCommandsSupportGitHubBackedStories(t *testing.T) {
@@ -141,7 +145,7 @@ func TestStoryCommandsSupportGitHubBackedStories(t *testing.T) {
 		"",
 	}, "\n")
 	if _, err := manager.UpdateSpec("billing", notes.UpdateInput{
-		Body: &specBody,
+		Body:     &specBody,
 		Metadata: map[string]any{"status": "approved"},
 	}); err != nil {
 		t.Fatal(err)

--- a/cmd/update.go
+++ b/cmd/update.go
@@ -3,15 +3,20 @@ package cmd
 import (
 	"fmt"
 
+	"plan/internal/workspace"
+
 	"github.com/spf13/cobra"
 )
 
 func newUpdateCommand() *cobra.Command {
-	return &cobra.Command{
+	var archiveLegacy bool
+	cmd := &cobra.Command{
 		Use:   "update",
 		Short: "Repair or normalize the local .plan workspace",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			result, err := workspaceManager().Update()
+			result, err := workspaceManager().UpdateWithOptions(workspace.UpdateOptions{
+				ArchiveLegacy: archiveLegacy,
+			})
 			if err != nil {
 				return err
 			}
@@ -22,10 +27,15 @@ func newUpdateCommand() *cobra.Command {
 			for _, item := range result.Updated {
 				fmt.Printf("  updated %s\n", item)
 			}
-			if len(result.Created) == 0 && len(result.Updated) == 0 {
+			for _, move := range result.Archived {
+				fmt.Printf("  archived %s -> %s\n", move.From, move.To)
+			}
+			if len(result.Created) == 0 && len(result.Updated) == 0 && len(result.Archived) == 0 {
 				fmt.Println("  no changes")
 			}
 			return nil
 		},
 	}
+	cmd.Flags().BoolVar(&archiveLegacy, "archive-legacy", false, "move legacy epic/story hierarchy into .plan/archive/ and keep active specs in place")
+	return cmd
 }

--- a/docs/project-workflows.md
+++ b/docs/project-workflows.md
@@ -46,9 +46,10 @@ Use this file for agent operating workflow inside the repo.
 
 - Establish queue with `plan status --project .`.
 - Take the next approved spec, not the next individual issue.
-- Run `plan story slice --project . <epic-slug>` and then `--apply` to materialize the current spec's slices.
+- Run `plan spec execute --project . <spec-slug>` to start execution from the current approved spec.
 - Implement one slice at a time.
 - Review and verify each slice before committing that slice.
 - Repeat until the current spec is done, then move to the next queued spec.
 - Open one PR after the queued specs for the branch are complete.
+- If legacy epic/story material is still active, archive it with `plan update --project . --archive-legacy`.
 - If GitHub story mode is enabled, run `plan update --project .` and `plan github reconcile --project . --update-visible` after merge before taking more queue work.

--- a/docs/using-plan.md
+++ b/docs/using-plan.md
@@ -9,13 +9,15 @@ ideas.
 
 Right now:
 
-- the shipped CLI surface includes the `v4`, `v5`, and `v6` planning passes
-- `story slice` and `story critique` are part of the current workflow
-- `plan check` validates the spec-to-story handoff more aggressively than it
-  did in earlier versions
-- GitHub-backed story execution is available when you enable GitHub story mode
+- the active planning model is spec-first
+- brainstorms stay local and can bloom into idea docs or specs
+- `initiative` is lightweight optional grouping metadata
+- `plan spec execute` is the active execution entry point
+- legacy `epic` and `story` commands still exist during the transition
+- GitHub-backed issue execution remains available when you enable GitHub mode
 
-So this guide covers the current command surface as it exists today.
+The top of this guide reflects the active spec-first model. Some later sections
+still document legacy compatibility commands while the migration is in flight.
 
 ## What `plan` Is
 
@@ -25,30 +27,38 @@ It stores planning material in `.plan/` and focuses on one job:
 
 - turn rough ideas into shaped planning artifacts
 - make specs stronger before implementation starts
-- make stories execution-ready before coding begins
+- guide execution from approved specs without persisting tiny slice artifacts
 
 `plan` does not handle memory, retrieval, or context management.
 
 ## Core Model
 
-Canonical hierarchy:
+Active model:
 
-1. `Epic`
-2. `Spec`
-3. `Story`
+1. `Brainstorm`
+2. `Idea Doc` (optional)
+3. `Spec`
+4. runtime `Slice`
+
+Optional grouping:
+
+- `Initiative` for multi-spec outcomes
+- GitHub milestone mapping when GitHub integration is enabled
+
+Legacy `epic` and `story` objects remain available as compatibility surfaces,
+but they are not the default active model anymore.
 
 Workflow entry:
 
 1. `Brainstorm`
 2. `Refine`
 3. `Challenge`
-4. `Promote to epic`
-5. `Shape the epic`
-6. `Write and approve spec`
-7. `Analyze or checklist the spec`
-8. `Slice stories from the spec`
-9. `Critique stories before execution`
-10. `Create or execute stories`
+4. `Promote or shape into a spec`
+5. `Write and approve spec`
+6. `Analyze or checklist the spec`
+7. `Assign initiative metadata when needed`
+8. `Start spec execution`
+9. `Work slices one commit at a time`
 
 ## Workspace Layout
 
@@ -59,9 +69,9 @@ Workflow entry:
   PROJECT.md
   ROADMAP.md
   brainstorms/
-  epics/
+  ideas/
+  archive/
   specs/
-  stories/
   .meta/
     workspace.json
     migrations.json
@@ -73,9 +83,9 @@ Meaning:
 - `PROJECT.md`: product direction and project rules
 - `ROADMAP.md`: version/phase planning
 - `brainstorms/`: discovery notes
-- `epics/`: outcome boundaries
+- `ideas/`: optional durable idea docs
+- `archive/`: preserved legacy epic/story-era planning material
 - `specs/`: canonical execution contracts
-- `stories/`: execution-ready slices in local story mode
 - `.meta/`: tool-owned state only, including GitHub story metadata when enabled
 
 ## New Repo Setup
@@ -98,6 +108,12 @@ Repair or normalize tool-owned state:
 plan update --project .
 ```
 
+Archive legacy epic/story hierarchy without touching active specs:
+
+```bash
+plan update --project . --archive-legacy
+```
+
 ## Existing Repo Setup
 
 If the repo already exists and you want `plan` to manage it:
@@ -109,8 +125,8 @@ plan doctor --project .
 
 ## Optional: Enable GitHub Story Mode
 
-If you want brainstorms, epics, and specs local but stories stored as GitHub
-Issues:
+If you want local planning but GitHub-backed issue execution during the
+transition:
 
 ```bash
 plan update --project .
@@ -126,9 +142,10 @@ Preconditions:
 
 When GitHub story mode is enabled:
 
-- stories are created as GitHub Issues
+- execution stories are created as GitHub Issues
 - `.plan/.meta/github.json` becomes the local issue-state index
-- `plan status --project .` shows `ready_work` after reconcile
+- initiative metadata can map execution work to GitHub milestones when titles
+  match
 
 ## Step-By-Step Workflow
 

--- a/internal/planning/check.go
+++ b/internal/planning/check.go
@@ -62,10 +62,6 @@ func (m *Manager) Check(input CheckInput) (*CheckReport, error) {
 		return nil, err
 	}
 	report := &CheckReport{Project: info.ProjectName}
-	storyInfos, err := m.ListStories("", "")
-	if err != nil {
-		return nil, err
-	}
 
 	specs, err := m.specNotesForCheck(info, input)
 	if err != nil {
@@ -73,7 +69,6 @@ func (m *Manager) Check(input CheckInput) (*CheckReport, error) {
 	}
 	for _, spec := range specs {
 		report.Findings = append(report.Findings, checkSpecNote(rel(info.ProjectDir, spec.Path), spec)...)
-		report.Findings = append(report.Findings, checkSpecStoryReadiness(info, spec, storyInfos)...)
 	}
 	stories, err := m.storyNotesForCheck(info, input)
 	if err != nil {
@@ -118,11 +113,9 @@ func (m *Manager) storyNotesForCheck(info *workspace.Info, input CheckInput) ([]
 	case strings.TrimSpace(input.SpecSlug) != "":
 		return nil, nil
 	case strings.TrimSpace(input.EpicSlug) != "":
-		return m.readStoriesByFilter(info, func(story StoryInfo) bool {
-			return story.Epic == slugify(input.EpicSlug)
-		})
+		return nil, nil
 	default:
-		return readNotesInDir(info.StoriesDir)
+		return nil, nil
 	}
 }
 
@@ -429,7 +422,7 @@ func checkSpecStoryReadiness(info *workspace.Info, spec *notes.Note, stories []S
 func meaningfulStoryBreakdownCandidates(items []parsedStorySliceCandidate) []parsedStorySliceCandidate {
 	var out []parsedStorySliceCandidate
 	for _, item := range items {
-		if item.Title == "" || strings.EqualFold(item.Title, seededStoryBreakdownPlaceholder) {
+		if item.Title == "" || isSeededExecutionPlaceholder(item.Title) {
 			continue
 		}
 		out = append(out, item)

--- a/internal/planning/github_backend_test.go
+++ b/internal/planning/github_backend_test.go
@@ -16,6 +16,7 @@ type stubGitHubClient struct {
 	preflightErr error
 	context      *GitHubContext
 	issues       map[int]*GitHubIssue
+	milestones   map[string]*GitHubMilestone
 	nextIssue    int
 	lastCreate   GitHubIssueInput
 	lastUpdate   GitHubIssueInput
@@ -54,6 +55,15 @@ func (s *stubGitHubClient) CreateIssue(projectDir, repo string, input GitHubIssu
 	if strings.TrimSpace(input.State) != "" {
 		issue.State = input.State
 	}
+	if input.Milestone != nil {
+		for _, milestone := range s.milestones {
+			if milestone.Number == *input.Milestone {
+				copy := *milestone
+				issue.Milestone = &copy
+				break
+			}
+		}
+	}
 	s.issues[issue.Number] = issue
 	s.nextIssue++
 	return issue, nil
@@ -73,6 +83,16 @@ func (s *stubGitHubClient) UpdateIssue(projectDir, repo string, issueNumber int,
 	if input.Labels != nil {
 		issue.Labels = append([]string(nil), input.Labels...)
 	}
+	if input.Milestone != nil {
+		issue.Milestone = nil
+		for _, milestone := range s.milestones {
+			if milestone.Number == *input.Milestone {
+				copy := *milestone
+				issue.Milestone = &copy
+				break
+			}
+		}
+	}
 	return issue, nil
 }
 
@@ -83,6 +103,18 @@ func (s *stubGitHubClient) GetIssue(projectDir, repo string, issueNumber int) (*
 	}
 	copy := *issue
 	copy.Labels = append([]string(nil), issue.Labels...)
+	return &copy, nil
+}
+
+func (s *stubGitHubClient) FindMilestone(projectDir, repo, title string) (*GitHubMilestone, error) {
+	if s.milestones == nil {
+		return nil, nil
+	}
+	milestone, ok := s.milestones[title]
+	if !ok {
+		return nil, nil
+	}
+	copy := *milestone
 	return &copy, nil
 }
 
@@ -148,6 +180,9 @@ func TestEnableGitHubBackendFailsWhenLocalStoriesAlreadyExist(t *testing.T) {
 	root := t.TempDir()
 	ws := workspace.New(root)
 	if _, err := ws.Init(); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Join(root, ".plan", "stories"), 0o755); err != nil {
 		t.Fatal(err)
 	}
 	if err := os.WriteFile(filepath.Join(root, ".plan", "stories", "existing.md"), []byte("# Existing\n"), 0o644); err != nil {
@@ -257,6 +292,66 @@ func TestCreateStoryUsesGitHubIssueStorageWhenBackendEnabled(t *testing.T) {
 	}
 	if len(items) != 1 || items[0].Backend != "github" || items[0].IssueNumber != 101 {
 		t.Fatalf("unexpected GitHub story list: %+v", items)
+	}
+}
+
+func TestCreateGitHubStoryMapsSpecInitiativeToMilestoneWhenPresent(t *testing.T) {
+	client := &stubGitHubClient{
+		preflight: &GitHubRepoInfo{
+			Repo:          "JimmyMcBride/plan",
+			RepoURL:       "https://github.com/JimmyMcBride/plan",
+			DefaultBranch: "main",
+		},
+		context: &GitHubContext{
+			Repo: GitHubRepoInfo{
+				Repo:          "JimmyMcBride/plan",
+				RepoURL:       "https://github.com/JimmyMcBride/plan",
+				DefaultBranch: "main",
+			},
+			CurrentBranch: "main",
+			CurrentSHA:    "abc123def456",
+		},
+		milestones: map[string]*GitHubMilestone{
+			"Guide Packet Foundation": {Number: 12, Title: "Guide Packet Foundation"},
+		},
+	}
+	reset := SetGitHubClientFactoryForTesting(func() GitHubClient { return client })
+	t.Cleanup(reset)
+
+	root := t.TempDir()
+	ws := workspace.New(root)
+	if _, err := ws.Init(); err != nil {
+		t.Fatal(err)
+	}
+	manager := New(ws)
+	if _, err := manager.EnableGitHubBackend(); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := manager.CreateEpic("Billing", ""); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := manager.SetSpecStatus("billing", "approved"); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := manager.SetSpecInitiative("billing", InitiativeRef{
+		Slug:  "guide-packet-foundation",
+		Title: "Guide Packet Foundation",
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := manager.CreateStory(
+		"billing",
+		"Implement invoices",
+		"Create invoice generation flow",
+		[]string{"Generate invoices from line items"},
+		[]string{"Run focused billing tests"},
+		nil,
+	); err != nil {
+		t.Fatal(err)
+	}
+	if client.lastCreate.Milestone == nil || *client.lastCreate.Milestone != 12 {
+		t.Fatalf("expected GitHub issue create to include initiative milestone: %+v", client.lastCreate)
 	}
 }
 

--- a/internal/planning/github_backend_test.go
+++ b/internal/planning/github_backend_test.go
@@ -12,14 +12,15 @@ import (
 )
 
 type stubGitHubClient struct {
-	preflight    *GitHubRepoInfo
-	preflightErr error
-	context      *GitHubContext
-	issues       map[int]*GitHubIssue
-	milestones   map[string]*GitHubMilestone
-	nextIssue    int
-	lastCreate   GitHubIssueInput
-	lastUpdate   GitHubIssueInput
+	preflight        *GitHubRepoInfo
+	preflightErr     error
+	context          *GitHubContext
+	issues           map[int]*GitHubIssue
+	milestones       map[string]*GitHubMilestone
+	milestoneLookups []string
+	nextIssue        int
+	lastCreate       GitHubIssueInput
+	lastUpdate       GitHubIssueInput
 }
 
 func (s *stubGitHubClient) Preflight(projectDir string) (*GitHubRepoInfo, error) {
@@ -83,6 +84,9 @@ func (s *stubGitHubClient) UpdateIssue(projectDir, repo string, issueNumber int,
 	if input.Labels != nil {
 		issue.Labels = append([]string(nil), input.Labels...)
 	}
+	if input.ClearMilestone {
+		issue.Milestone = nil
+	}
 	if input.Milestone != nil {
 		issue.Milestone = nil
 		for _, milestone := range s.milestones {
@@ -107,6 +111,7 @@ func (s *stubGitHubClient) GetIssue(projectDir, repo string, issueNumber int) (*
 }
 
 func (s *stubGitHubClient) FindMilestone(projectDir, repo, title string) (*GitHubMilestone, error) {
+	s.milestoneLookups = append(s.milestoneLookups, title)
 	if s.milestones == nil {
 		return nil, nil
 	}
@@ -352,6 +357,135 @@ func TestCreateGitHubStoryMapsSpecInitiativeToMilestoneWhenPresent(t *testing.T)
 	}
 	if client.lastCreate.Milestone == nil || *client.lastCreate.Milestone != 12 {
 		t.Fatalf("expected GitHub issue create to include initiative milestone: %+v", client.lastCreate)
+	}
+}
+
+func TestReconcileGitHubStoriesUpdatesMilestoneWhenInitiativeChangesWithoutBodyDiff(t *testing.T) {
+	client := &stubGitHubClient{
+		preflight: &GitHubRepoInfo{
+			Repo:          "JimmyMcBride/plan",
+			RepoURL:       "https://github.com/JimmyMcBride/plan",
+			DefaultBranch: "main",
+		},
+		context: &GitHubContext{
+			Repo: GitHubRepoInfo{
+				Repo:          "JimmyMcBride/plan",
+				RepoURL:       "https://github.com/JimmyMcBride/plan",
+				DefaultBranch: "main",
+			},
+			CurrentBranch: "main",
+			CurrentSHA:    "abc123def456",
+		},
+		milestones: map[string]*GitHubMilestone{
+			"Guide Packet Foundation": {Number: 12, Title: "Guide Packet Foundation"},
+		},
+	}
+	reset := SetGitHubClientFactoryForTesting(func() GitHubClient { return client })
+	t.Cleanup(reset)
+
+	root := t.TempDir()
+	manager := newGitHubStoryManager(t, root)
+	if _, err := manager.EnableGitHubBackend(); err != nil {
+		t.Fatal(err)
+	}
+	seedApprovedGitHubEpic(t, manager)
+	if _, err := manager.CreateStory(
+		"billing",
+		"Implement invoices",
+		"Create invoice generation flow",
+		[]string{"Generate invoices from line items"},
+		[]string{"Run focused billing tests"},
+		nil,
+	); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := manager.SetSpecInitiative("billing", InitiativeRef{
+		Slug:  "guide-packet-foundation",
+		Title: "Guide Packet Foundation",
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	client.lastUpdate = GitHubIssueInput{}
+	client.milestoneLookups = nil
+	result, err := manager.ReconcileGitHubStories(GitHubReconcileOptions{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(result.UpdatedIssues) != 1 {
+		t.Fatalf("expected reconcile to update issue milestone: %+v", result)
+	}
+	if client.lastUpdate.Milestone == nil || *client.lastUpdate.Milestone != 12 {
+		t.Fatalf("expected reconcile to set milestone when initiative metadata appears: %+v", client.lastUpdate)
+	}
+	if client.issues[101].Milestone == nil || client.issues[101].Milestone.Number != 12 {
+		t.Fatalf("expected issue milestone to update: %+v", client.issues[101])
+	}
+}
+
+func TestReconcileGitHubStoriesClearsMilestoneWhenInitiativeRemoved(t *testing.T) {
+	client := &stubGitHubClient{
+		preflight: &GitHubRepoInfo{
+			Repo:          "JimmyMcBride/plan",
+			RepoURL:       "https://github.com/JimmyMcBride/plan",
+			DefaultBranch: "main",
+		},
+		context: &GitHubContext{
+			Repo: GitHubRepoInfo{
+				Repo:          "JimmyMcBride/plan",
+				RepoURL:       "https://github.com/JimmyMcBride/plan",
+				DefaultBranch: "main",
+			},
+			CurrentBranch: "main",
+			CurrentSHA:    "abc123def456",
+		},
+		milestones: map[string]*GitHubMilestone{
+			"Guide Packet Foundation": {Number: 12, Title: "Guide Packet Foundation"},
+		},
+	}
+	reset := SetGitHubClientFactoryForTesting(func() GitHubClient { return client })
+	t.Cleanup(reset)
+
+	root := t.TempDir()
+	manager := newGitHubStoryManager(t, root)
+	if _, err := manager.EnableGitHubBackend(); err != nil {
+		t.Fatal(err)
+	}
+	seedApprovedGitHubEpic(t, manager)
+	if _, err := manager.SetSpecInitiative("billing", InitiativeRef{
+		Slug:  "guide-packet-foundation",
+		Title: "Guide Packet Foundation",
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := manager.CreateStory(
+		"billing",
+		"Implement invoices",
+		"Create invoice generation flow",
+		[]string{"Generate invoices from line items"},
+		[]string{"Run focused billing tests"},
+		nil,
+	); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := manager.ClearSpecInitiative("billing"); err != nil {
+		t.Fatal(err)
+	}
+
+	client.lastUpdate = GitHubIssueInput{}
+	client.milestoneLookups = nil
+	result, err := manager.ReconcileGitHubStories(GitHubReconcileOptions{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(result.UpdatedIssues) != 1 {
+		t.Fatalf("expected reconcile to clear stale milestone: %+v", result)
+	}
+	if !client.lastUpdate.ClearMilestone || client.lastUpdate.Milestone != nil {
+		t.Fatalf("expected reconcile to request milestone clearing: %+v", client.lastUpdate)
+	}
+	if client.issues[101].Milestone != nil {
+		t.Fatalf("expected issue milestone to clear after reconcile: %+v", client.issues[101])
 	}
 }
 
@@ -781,6 +915,57 @@ func TestReconcileGitHubStoriesRefreshesRepoDefaultBranchInState(t *testing.T) {
 	}
 	if !strings.Contains(client.issues[101].Body, "/blob/develop/.plan/specs/billing.md") {
 		t.Fatalf("expected issue body to point at develop after reconcile:\n%s", client.issues[101].Body)
+	}
+}
+
+func TestReconcileGitHubStoriesCachesMilestoneLookupPerInitiative(t *testing.T) {
+	client := &stubGitHubClient{
+		preflight: &GitHubRepoInfo{
+			Repo:          "JimmyMcBride/plan",
+			RepoURL:       "https://github.com/JimmyMcBride/plan",
+			DefaultBranch: "main",
+		},
+		context: &GitHubContext{
+			Repo: GitHubRepoInfo{
+				Repo:          "JimmyMcBride/plan",
+				RepoURL:       "https://github.com/JimmyMcBride/plan",
+				DefaultBranch: "main",
+			},
+			CurrentBranch: "main",
+			CurrentSHA:    "abc123def456",
+		},
+		milestones: map[string]*GitHubMilestone{
+			"Guide Packet Foundation": {Number: 12, Title: "Guide Packet Foundation"},
+		},
+	}
+	reset := SetGitHubClientFactoryForTesting(func() GitHubClient { return client })
+	t.Cleanup(reset)
+
+	root := t.TempDir()
+	manager := newGitHubStoryManager(t, root)
+	if _, err := manager.EnableGitHubBackend(); err != nil {
+		t.Fatal(err)
+	}
+	seedApprovedGitHubEpic(t, manager)
+	if _, err := manager.SetSpecInitiative("billing", InitiativeRef{
+		Slug:  "guide-packet-foundation",
+		Title: "Guide Packet Foundation",
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := manager.CreateStory("billing", "Seed billing data", "Seed data first", []string{"Seed data"}, []string{"Run seed checks"}, nil); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := manager.CreateStory("billing", "Implement invoices", "Create invoice generation flow", []string{"Generate invoices"}, []string{"Run billing tests"}, nil); err != nil {
+		t.Fatal(err)
+	}
+
+	client.milestoneLookups = nil
+	if _, err := manager.ReconcileGitHubStories(GitHubReconcileOptions{}); err != nil {
+		t.Fatal(err)
+	}
+	if len(client.milestoneLookups) != 1 || client.milestoneLookups[0] != "Guide Packet Foundation" {
+		t.Fatalf("expected one cached milestone lookup during reconcile, got %+v", client.milestoneLookups)
 	}
 }
 

--- a/internal/planning/github_client.go
+++ b/internal/planning/github_client.go
@@ -15,6 +15,7 @@ type GitHubClient interface {
 	CreateIssue(projectDir, repo string, input GitHubIssueInput) (*GitHubIssue, error)
 	UpdateIssue(projectDir, repo string, issueNumber int, input GitHubIssueInput) (*GitHubIssue, error)
 	GetIssue(projectDir, repo string, issueNumber int) (*GitHubIssue, error)
+	FindMilestone(projectDir, repo, title string) (*GitHubMilestone, error)
 }
 
 type GitHubRepoInfo struct {
@@ -44,19 +45,26 @@ type GitHubContext struct {
 }
 
 type GitHubIssueInput struct {
-	Title  string
-	Body   string
-	State  string
-	Labels []string
+	Title     string
+	Body      string
+	State     string
+	Labels    []string
+	Milestone *int
 }
 
 type GitHubIssue struct {
+	Number    int
+	URL       string
+	Title     string
+	Body      string
+	State     string
+	Labels    []string
+	Milestone *GitHubMilestone
+}
+
+type GitHubMilestone struct {
 	Number int
-	URL    string
 	Title  string
-	Body   string
-	State  string
-	Labels []string
 }
 
 var newGitHubClient = func() GitHubClient {
@@ -82,9 +90,9 @@ func (c *cliGitHubClient) Preflight(projectDir string) (*GitHubRepoInfo, error) 
 	}
 
 	type repoView struct {
-		NameWithOwner   string `json:"nameWithOwner"`
-		URL             string `json:"url"`
-		HasIssues       bool   `json:"hasIssuesEnabled"`
+		NameWithOwner    string `json:"nameWithOwner"`
+		URL              string `json:"url"`
+		HasIssues        bool   `json:"hasIssuesEnabled"`
 		DefaultBranchRef struct {
 			Name string `json:"name"`
 		} `json:"defaultBranchRef"`
@@ -190,6 +198,9 @@ func (c *cliGitHubClient) upsertIssue(projectDir, apiPath string, input GitHubIs
 	if input.Labels != nil {
 		payload["labels"] = input.Labels
 	}
+	if input.Milestone != nil {
+		payload["milestone"] = *input.Milestone
+	}
 	method := "POST"
 	if strings.Contains(apiPath, "/issues/") {
 		method = "PATCH"
@@ -207,6 +218,27 @@ func (c *cliGitHubClient) GetIssue(projectDir, repo string, issueNumber int) (*G
 		return nil, err
 	}
 	return parseGitHubIssue(out)
+}
+
+func (c *cliGitHubClient) FindMilestone(projectDir, repo, title string) (*GitHubMilestone, error) {
+	type milestonePayload struct {
+		Number int    `json:"number"`
+		Title  string `json:"title"`
+	}
+	out, err := c.api(projectDir, "GET", fmt.Sprintf("repos/%s/milestones?state=all&per_page=100", repo), nil)
+	if err != nil {
+		return nil, err
+	}
+	var milestones []milestonePayload
+	if err := json.Unmarshal(out, &milestones); err != nil {
+		return nil, fmt.Errorf("parse milestones: %w", err)
+	}
+	for _, milestone := range milestones {
+		if strings.EqualFold(strings.TrimSpace(milestone.Title), strings.TrimSpace(title)) {
+			return &GitHubMilestone{Number: milestone.Number, Title: milestone.Title}, nil
+		}
+	}
+	return nil, nil
 }
 
 func (c *cliGitHubClient) api(projectDir, method, apiPath string, payload any) ([]byte, error) {
@@ -249,12 +281,16 @@ func parseGitHubIssue(raw []byte) (*GitHubIssue, error) {
 		Name string `json:"name"`
 	}
 	type payload struct {
-		Number int     `json:"number"`
-		URL    string  `json:"html_url"`
-		Title  string  `json:"title"`
-		Body   string  `json:"body"`
-		State  string  `json:"state"`
-		Labels []label `json:"labels"`
+		Number    int     `json:"number"`
+		URL       string  `json:"html_url"`
+		Title     string  `json:"title"`
+		Body      string  `json:"body"`
+		State     string  `json:"state"`
+		Labels    []label `json:"labels"`
+		Milestone *struct {
+			Number int    `json:"number"`
+			Title  string `json:"title"`
+		} `json:"milestone"`
 	}
 	var item payload
 	if err := json.Unmarshal(raw, &item); err != nil {
@@ -272,6 +308,12 @@ func parseGitHubIssue(raw []byte) (*GitHubIssue, error) {
 			continue
 		}
 		issue.Labels = append(issue.Labels, current.Name)
+	}
+	if item.Milestone != nil {
+		issue.Milestone = &GitHubMilestone{
+			Number: item.Milestone.Number,
+			Title:  item.Milestone.Title,
+		}
 	}
 	return issue, nil
 }

--- a/internal/planning/github_client.go
+++ b/internal/planning/github_client.go
@@ -45,11 +45,12 @@ type GitHubContext struct {
 }
 
 type GitHubIssueInput struct {
-	Title     string
-	Body      string
-	State     string
-	Labels    []string
-	Milestone *int
+	Title          string
+	Body           string
+	State          string
+	Labels         []string
+	Milestone      *int
+	ClearMilestone bool
 }
 
 type GitHubIssue struct {
@@ -188,6 +189,9 @@ func (c *cliGitHubClient) UpdateIssue(projectDir, repo string, issueNumber int, 
 }
 
 func (c *cliGitHubClient) upsertIssue(projectDir, apiPath string, input GitHubIssueInput) (*GitHubIssue, error) {
+	if input.Milestone != nil && input.ClearMilestone {
+		return nil, fmt.Errorf("cannot set and clear a milestone in the same issue request")
+	}
 	payload := map[string]any{
 		"title": input.Title,
 		"body":  input.Body,
@@ -198,7 +202,9 @@ func (c *cliGitHubClient) upsertIssue(projectDir, apiPath string, input GitHubIs
 	if input.Labels != nil {
 		payload["labels"] = input.Labels
 	}
-	if input.Milestone != nil {
+	if input.ClearMilestone {
+		payload["milestone"] = nil
+	} else if input.Milestone != nil {
 		payload["milestone"] = *input.Milestone
 	}
 	method := "POST"

--- a/internal/planning/github_reconcile.go
+++ b/internal/planning/github_reconcile.go
@@ -77,6 +77,7 @@ func (m *Manager) ReconcileGitHubStories(options GitHubReconcileOptions) (*GitHu
 		slugs = append(slugs, slug)
 	}
 	sort.Strings(slugs)
+	milestoneCache := map[string]*int{}
 
 	for _, slug := range slugs {
 		record := state.Stories[slug]
@@ -107,21 +108,23 @@ func (m *Manager) ReconcileGitHubStories(options GitHubReconcileOptions) (*GitHu
 		}
 
 		body := mergeManagedIssueBody(issue.Body, renderGitHubStoryIssueBody(state, &context.Repo, spec, record))
-		milestoneNumber, err := m.resolveSpecInitiativeMilestone(info, state.Repo, spec)
+		milestoneNumber, err := m.resolveSpecInitiativeMilestoneCached(info, state.Repo, spec, milestoneCache)
 		if err != nil {
 			return nil, err
 		}
+		milestoneChanged, desiredMilestone, clearMilestone := milestoneUpdate(issue.Milestone, milestoneNumber)
 		labels := issue.Labels
 		if options.UpdateVisible {
 			labels = applyDerivedReadyLabels(labels, status, ready)
 		}
-		if body != issue.Body || !sameStringSlice(labels, issue.Labels) {
+		if body != issue.Body || !sameStringSlice(labels, issue.Labels) || milestoneChanged {
 			updatedIssue, err := m.github.UpdateIssue(info.ProjectDir, state.Repo, record.IssueNumber, GitHubIssueInput{
-				Title:     record.Title,
-				Body:      body,
-				State:     issue.State,
-				Labels:    labels,
-				Milestone: milestoneNumber,
+				Title:          record.Title,
+				Body:           body,
+				State:          issue.State,
+				Labels:         labels,
+				Milestone:      desiredMilestone,
+				ClearMilestone: clearMilestone,
 			})
 			if err != nil {
 				return nil, err

--- a/internal/planning/github_reconcile.go
+++ b/internal/planning/github_reconcile.go
@@ -81,10 +81,6 @@ func (m *Manager) ReconcileGitHubStories(options GitHubReconcileOptions) (*GitHu
 	for _, slug := range slugs {
 		record := state.Stories[slug]
 		previous := record
-		epic, err := notes.Read(filepath.Join(info.EpicsDir, record.Epic+".md"))
-		if err != nil {
-			return nil, err
-		}
 		spec, err := notes.Read(filepath.Join(info.SpecsDir, record.Spec+".md"))
 		if err != nil {
 			return nil, err
@@ -110,17 +106,22 @@ func (m *Manager) ReconcileGitHubStories(options GitHubReconcileOptions) (*GitHu
 			result.BlockedStories = append(result.BlockedStories, slug)
 		}
 
-		body := mergeManagedIssueBody(issue.Body, renderGitHubStoryIssueBody(state, &context.Repo, epic, spec, record))
+		body := mergeManagedIssueBody(issue.Body, renderGitHubStoryIssueBody(state, &context.Repo, spec, record))
+		milestoneNumber, err := m.resolveSpecInitiativeMilestone(info, state.Repo, spec)
+		if err != nil {
+			return nil, err
+		}
 		labels := issue.Labels
 		if options.UpdateVisible {
 			labels = applyDerivedReadyLabels(labels, status, ready)
 		}
 		if body != issue.Body || !sameStringSlice(labels, issue.Labels) {
 			updatedIssue, err := m.github.UpdateIssue(info.ProjectDir, state.Repo, record.IssueNumber, GitHubIssueInput{
-				Title:  record.Title,
-				Body:   body,
-				State:  issue.State,
-				Labels: labels,
+				Title:     record.Title,
+				Body:      body,
+				State:     issue.State,
+				Labels:    labels,
+				Milestone: milestoneNumber,
 			})
 			if err != nil {
 				return nil, err

--- a/internal/planning/github_story_backend.go
+++ b/internal/planning/github_story_backend.go
@@ -180,17 +180,19 @@ func (m *Manager) updateGitHubStory(info *workspace.Info, storySlug string, chan
 	if err != nil {
 		return nil, err
 	}
+	_, desiredMilestone, clearMilestone := milestoneUpdate(existingIssue.Milestone, milestoneNumber)
 
 	issueState := "open"
 	if record.Status == "done" {
 		issueState = "closed"
 	}
 	updatedIssue, err := m.github.UpdateIssue(info.ProjectDir, state.Repo, record.IssueNumber, GitHubIssueInput{
-		Title:     record.Title,
-		Body:      body,
-		State:     issueState,
-		Labels:    existingIssue.Labels,
-		Milestone: milestoneNumber,
+		Title:          record.Title,
+		Body:           body,
+		State:          issueState,
+		Labels:         existingIssue.Labels,
+		Milestone:      desiredMilestone,
+		ClearMilestone: clearMilestone,
 	})
 	if err != nil {
 		return nil, err
@@ -523,10 +525,7 @@ func mergeManagedIssueBody(existingBody, managedBody string) string {
 }
 
 func (m *Manager) resolveSpecInitiativeMilestone(info *workspace.Info, repo string, spec *notes.Note) (*int, error) {
-	title := strings.TrimSpace(stringValue(spec.Metadata["initiative_title"]))
-	if title == "" {
-		title = strings.TrimSpace(stringValue(spec.Metadata["initiative"]))
-	}
+	title := specInitiativeMilestoneTitle(spec)
 	if title == "" {
 		return nil, nil
 	}
@@ -538,6 +537,52 @@ func (m *Manager) resolveSpecInitiativeMilestone(info *workspace.Info, repo stri
 		return nil, nil
 	}
 	return &milestone.Number, nil
+}
+
+func (m *Manager) resolveSpecInitiativeMilestoneCached(info *workspace.Info, repo string, spec *notes.Note, cache map[string]*int) (*int, error) {
+	title := specInitiativeMilestoneTitle(spec)
+	if title == "" {
+		return nil, nil
+	}
+	key := strings.ToLower(strings.TrimSpace(repo) + "::" + title)
+	if milestone, ok := cache[key]; ok {
+		return cloneIntPointer(milestone), nil
+	}
+	milestone, err := m.resolveSpecInitiativeMilestone(info, repo, spec)
+	if err != nil {
+		return nil, err
+	}
+	cache[key] = cloneIntPointer(milestone)
+	return cloneIntPointer(milestone), nil
+}
+
+func specInitiativeMilestoneTitle(spec *notes.Note) string {
+	title := strings.TrimSpace(stringValue(spec.Metadata["initiative_title"]))
+	if title == "" {
+		title = strings.TrimSpace(stringValue(spec.Metadata["initiative"]))
+	}
+	return title
+}
+
+func milestoneUpdate(existing *GitHubMilestone, desired *int) (changed bool, milestone *int, clear bool) {
+	switch {
+	case desired == nil && existing == nil:
+		return false, nil, false
+	case desired == nil && existing != nil:
+		return true, nil, true
+	case existing != nil && existing.Number == *desired:
+		return false, nil, false
+	default:
+		return true, cloneIntPointer(desired), false
+	}
+}
+
+func cloneIntPointer(value *int) *int {
+	if value == nil {
+		return nil
+	}
+	copy := *value
+	return &copy
 }
 
 func applyDerivedReadyLabels(labels []string, status string, ready bool) []string {

--- a/internal/planning/github_story_backend.go
+++ b/internal/planning/github_story_backend.go
@@ -12,10 +12,10 @@ import (
 )
 
 const (
-	planIssueBlockStart  = "<!-- plan:start -->"
-	planIssueBlockEnd    = "<!-- plan:end -->"
-	planIssueMetaPrefix  = "<!-- plan:meta"
-	planIssueReadyLabel  = "plan:ready"
+	planIssueBlockStart   = "<!-- plan:start -->"
+	planIssueBlockEnd     = "<!-- plan:end -->"
+	planIssueMetaPrefix   = "<!-- plan:meta"
+	planIssueReadyLabel   = "plan:ready"
 	planIssueBlockedLabel = "plan:blocked"
 )
 
@@ -109,11 +109,16 @@ func (m *Manager) createGitHubStory(info *workspace.Info, epicSlug, title, descr
 		record.DocRef = context.Repo.DefaultBranch
 	}
 
-	body := mergeManagedIssueBody("", renderGitHubStoryIssueBody(state, &context.Repo, epic, spec, record))
+	body := mergeManagedIssueBody("", renderGitHubStoryIssueBody(state, &context.Repo, spec, record))
+	milestoneNumber, err := m.resolveSpecInitiativeMilestone(info, state.Repo, spec)
+	if err != nil {
+		return nil, err
+	}
 	issue, err := m.github.CreateIssue(info.ProjectDir, state.Repo, GitHubIssueInput{
-		Title: title,
-		Body:  body,
-		State: "open",
+		Title:     title,
+		Body:      body,
+		State:     "open",
+		Milestone: milestoneNumber,
 	})
 	if err != nil {
 		return nil, err
@@ -160,10 +165,6 @@ func (m *Manager) updateGitHubStory(info *workspace.Info, storySlug string, chan
 	if err != nil {
 		return nil, err
 	}
-	epic, err := notes.Read(filepath.Join(info.EpicsDir, record.Epic+".md"))
-	if err != nil {
-		return nil, err
-	}
 	spec, err := notes.Read(filepath.Join(info.SpecsDir, record.Spec+".md"))
 	if err != nil {
 		return nil, err
@@ -173,18 +174,23 @@ func (m *Manager) updateGitHubStory(info *workspace.Info, storySlug string, chan
 		return nil, err
 	}
 	record.RemoteState = existingIssue.State
-	managedBody := renderGitHubStoryIssueBody(state, &context.Repo, epic, spec, record)
+	managedBody := renderGitHubStoryIssueBody(state, &context.Repo, spec, record)
 	body := mergeManagedIssueBody(existingIssue.Body, managedBody)
+	milestoneNumber, err := m.resolveSpecInitiativeMilestone(info, state.Repo, spec)
+	if err != nil {
+		return nil, err
+	}
 
 	issueState := "open"
 	if record.Status == "done" {
 		issueState = "closed"
 	}
 	updatedIssue, err := m.github.UpdateIssue(info.ProjectDir, state.Repo, record.IssueNumber, GitHubIssueInput{
-		Title:  record.Title,
-		Body:   body,
-		State:  issueState,
-		Labels: existingIssue.Labels,
+		Title:     record.Title,
+		Body:      body,
+		State:     issueState,
+		Labels:    existingIssue.Labels,
+		Milestone: milestoneNumber,
 	})
 	if err != nil {
 		return nil, err
@@ -277,14 +283,14 @@ func (m *Manager) readGitHubStoryFromState(info *workspace.Info, state *workspac
 		Title: record.Title,
 		Type:  "story",
 		Metadata: map[string]any{
-			"slug":     record.Slug,
-			"status":   status,
-			"epic":     record.Epic,
-			"spec":     record.Spec,
-			"backend":  string(workspace.StoryBackendGitHub),
-			"issue":    record.IssueNumber,
+			"slug":      record.Slug,
+			"status":    status,
+			"epic":      record.Epic,
+			"spec":      record.Spec,
+			"backend":   string(workspace.StoryBackendGitHub),
+			"issue":     record.IssueNumber,
 			"issue_url": record.IssueURL,
-			"blockers": append([]string(nil), record.Dependencies...),
+			"blockers":  append([]string(nil), record.Dependencies...),
 		},
 		Content: content,
 	}, nil
@@ -336,14 +342,18 @@ func deriveGitHubStoryState(record workspace.GitHubStoryRecord, state *workspace
 	return status, ready, blockedReasons, blockedByPlan, blockedByDeps
 }
 
-func renderGitHubStoryIssueBody(state *workspace.GitHubState, repo *GitHubRepoInfo, epic, spec *notes.Note, record workspace.GitHubStoryRecord) string {
+func renderGitHubStoryIssueBody(state *workspace.GitHubState, repo *GitHubRepoInfo, spec *notes.Note, record workspace.GitHubStoryRecord) string {
 	content := renderGitHubStoryNoteContent(state, record)
 	status, ready, blockedReasons, _, _ := deriveGitHubStoryState(record, state)
 
-	epicLink, specLink := gitHubPlanningLinks(repo, record)
+	specLink := gitHubPlanningLink(repo, record)
 	planningLines := []string{
-		fmt.Sprintf("- Epic: [%s](%s)", epic.Title, epicLink),
 		fmt.Sprintf("- Spec: [%s](%s)", spec.Title, specLink),
+	}
+	if initiativeTitle := strings.TrimSpace(stringValue(spec.Metadata["initiative_title"])); initiativeTitle != "" {
+		planningLines = append(planningLines, fmt.Sprintf("- Initiative: %s", initiativeTitle))
+	} else if initiative := strings.TrimSpace(stringValue(spec.Metadata["initiative"])); initiative != "" {
+		planningLines = append(planningLines, fmt.Sprintf("- Initiative: %s", initiative))
 	}
 	if record.PlanningPRURL != "" {
 		planningLines = append(planningLines, fmt.Sprintf("- Planning PR: [#%d](%s)", record.PlanningPRNumber, record.PlanningPRURL))
@@ -411,7 +421,7 @@ func renderGitHubStoryNoteContent(state *workspace.GitHubState, record workspace
 	return body.String()
 }
 
-func gitHubPlanningLinks(repo *GitHubRepoInfo, record workspace.GitHubStoryRecord) (string, string) {
+func gitHubPlanningLink(repo *GitHubRepoInfo, record workspace.GitHubStoryRecord) string {
 	ref := repo.DefaultBranch
 	if record.DocRefMode == "sha" && strings.TrimSpace(record.DocRef) != "" {
 		ref = record.DocRef
@@ -420,8 +430,7 @@ func gitHubPlanningLinks(repo *GitHubRepoInfo, record workspace.GitHubStoryRecor
 		ref = record.DocRef
 	}
 	base := strings.TrimSuffix(repo.RepoURL, "/")
-	return fmt.Sprintf("%s/blob/%s/.plan/epics/%s.md", base, ref, record.Epic),
-		fmt.Sprintf("%s/blob/%s/.plan/specs/%s.md", base, ref, record.Spec)
+	return fmt.Sprintf("%s/blob/%s/.plan/specs/%s.md", base, ref, record.Spec)
 }
 
 func renderGitHubDependenciesSection(state *workspace.GitHubState, record workspace.GitHubStoryRecord) string {
@@ -511,6 +520,24 @@ func mergeManagedIssueBody(existingBody, managedBody string) string {
 		return managedBody
 	}
 	return strings.TrimRight(existing, "\n") + "\n\n" + strings.TrimRight(managedBody, "\n") + "\n"
+}
+
+func (m *Manager) resolveSpecInitiativeMilestone(info *workspace.Info, repo string, spec *notes.Note) (*int, error) {
+	title := strings.TrimSpace(stringValue(spec.Metadata["initiative_title"]))
+	if title == "" {
+		title = strings.TrimSpace(stringValue(spec.Metadata["initiative"]))
+	}
+	if title == "" {
+		return nil, nil
+	}
+	milestone, err := m.github.FindMilestone(info.ProjectDir, repo, title)
+	if err != nil {
+		return nil, err
+	}
+	if milestone == nil {
+		return nil, nil
+	}
+	return &milestone.Number, nil
 }
 
 func applyDerivedReadyLabels(labels []string, status string, ready bool) []string {

--- a/internal/planning/guided_session.go
+++ b/internal/planning/guided_session.go
@@ -269,6 +269,21 @@ func (m *Manager) ReadGuidedSessionByEpic(epicSlug string) (*workspace.GuidedSes
 	return nil, fmt.Errorf("no guided session linked to epic %q", epicSlug)
 }
 
+func (m *Manager) ReadGuidedSessionBySpec(specSlug string) (*workspace.GuidedSessionRecord, error) {
+	state, err := m.workspace.ReadGuidedSessionState()
+	if err != nil {
+		return nil, err
+	}
+	needle := slugify(specSlug)
+	for _, record := range state.Sessions {
+		if record.Spec == needle {
+			copy := record
+			return &copy, nil
+		}
+	}
+	return nil, fmt.Errorf("no guided session linked to spec %q", specSlug)
+}
+
 func (m *Manager) AdvanceGuidedSessionToSpec(epicSlug string) (*workspace.GuidedSessionRecord, *notes.Note, error) {
 	session, err := m.ReadGuidedSessionByEpic(epicSlug)
 	if err != nil {
@@ -309,6 +324,18 @@ func (m *Manager) AdvanceGuidedSessionToExecution(epicSlug string) (*workspace.G
 	if err != nil {
 		return nil, err
 	}
+	return m.advanceGuidedSessionToExecutionRecord(session)
+}
+
+func (m *Manager) AdvanceGuidedSessionToExecutionBySpec(specSlug string) (*workspace.GuidedSessionRecord, error) {
+	session, err := m.ReadGuidedSessionBySpec(specSlug)
+	if err != nil {
+		return nil, err
+	}
+	return m.advanceGuidedSessionToExecutionRecord(session)
+}
+
+func (m *Manager) advanceGuidedSessionToExecutionRecord(session *workspace.GuidedSessionRecord) (*workspace.GuidedSessionRecord, error) {
 	updated, err := m.UpdateGuidedSession(session.ChainID, GuidedSessionUpdateInput{
 		CurrentStage: "execution",
 		Summary:      "Spec handoff complete. Continue the planning flow in the execution stage.",

--- a/internal/planning/guided_session.go
+++ b/internal/planning/guided_session.go
@@ -26,7 +26,7 @@ type GuidedSessionUpdateInput struct {
 	StageStatus         string
 }
 
-var guidedStageOrder = []string{"brainstorm", "epic", "spec", "stories"}
+var guidedStageOrder = []string{"brainstorm", "epic", "spec", "execution"}
 
 func (m *Manager) EnsureGuidedBrainstormSession(brainstormSlug string) (*workspace.GuidedSessionRecord, error) {
 	info, err := m.workspace.EnsureInitialized()
@@ -304,15 +304,15 @@ func (m *Manager) AdvanceGuidedSessionToSpec(epicSlug string) (*workspace.Guided
 	return &record, spec, nil
 }
 
-func (m *Manager) AdvanceGuidedSessionToStories(epicSlug string) (*workspace.GuidedSessionRecord, error) {
+func (m *Manager) AdvanceGuidedSessionToExecution(epicSlug string) (*workspace.GuidedSessionRecord, error) {
 	session, err := m.ReadGuidedSessionByEpic(epicSlug)
 	if err != nil {
 		return nil, err
 	}
 	updated, err := m.UpdateGuidedSession(session.ChainID, GuidedSessionUpdateInput{
-		CurrentStage: "stories",
-		Summary:      "Spec handoff complete. Continue the planning flow in the stories stage.",
-		NextAction:   "Start implementation from the created execution-ready story set.",
+		CurrentStage: "execution",
+		Summary:      "Spec handoff complete. Continue the planning flow in the execution stage.",
+		NextAction:   "Work through the execution slices one commit at a time until the spec is delivered.",
 		StageStatus:  "in_progress",
 	})
 	if err != nil {
@@ -324,7 +324,7 @@ func (m *Manager) AdvanceGuidedSessionToStories(epicSlug string) (*workspace.Gui
 	}
 	record := state.Sessions[updated.ChainID]
 	record.StageStatuses["spec"] = "done"
-	record.StageStatuses["stories"] = "in_progress"
+	record.StageStatuses["execution"] = "in_progress"
 	record.UpdatedAt = time.Now().UTC().Format(time.RFC3339)
 	state.LastActiveChain = record.ChainID
 	state.LastUpdatedAt = record.UpdatedAt

--- a/internal/planning/guided_session_test.go
+++ b/internal/planning/guided_session_test.go
@@ -130,7 +130,7 @@ func TestSwitchAndReopenGuidedSessionState(t *testing.T) {
 	if len(downstream) != 3 {
 		t.Fatalf("unexpected downstream stage count: %+v", downstream)
 	}
-	if updated.StageStatuses["epic"] != "needs_review" || updated.StageStatuses["spec"] != "needs_review" || updated.StageStatuses["stories"] != "needs_review" {
+	if updated.StageStatuses["epic"] != "needs_review" || updated.StageStatuses["spec"] != "needs_review" || updated.StageStatuses["execution"] != "needs_review" {
 		t.Fatalf("expected downstream stages to be marked needs_review: %+v", updated)
 	}
 }

--- a/internal/planning/guided_session_test.go
+++ b/internal/planning/guided_session_test.go
@@ -134,3 +134,40 @@ func TestSwitchAndReopenGuidedSessionState(t *testing.T) {
 		t.Fatalf("expected downstream stages to be marked needs_review: %+v", updated)
 	}
 }
+
+func TestReadGuidedSessionBySpecUsesStoredSpecSlug(t *testing.T) {
+	root := t.TempDir()
+	ws := workspace.New(root)
+	if _, err := ws.Init(); err != nil {
+		t.Fatal(err)
+	}
+	manager := New(ws)
+	if _, err := manager.CreateBrainstorm("Guided Flow"); err != nil {
+		t.Fatal(err)
+	}
+	if _, _, err := manager.UpdateGuidedBrainstormIntake("guided-flow", GuidedBrainstormIntakeInput{
+		Vision:             "Guide the user from idea to implementation.",
+		SupportingMaterial: "docs/guided.md",
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	state, err := ws.ReadGuidedSessionState()
+	if err != nil {
+		t.Fatal(err)
+	}
+	record := state.Sessions["brainstorm/guided-flow"]
+	record.Spec = "guided-flow-spec"
+	state.Sessions[record.ChainID] = record
+	if err := ws.WriteGuidedSessionState(*state); err != nil {
+		t.Fatal(err)
+	}
+
+	session, err := manager.ReadGuidedSessionBySpec("guided-flow-spec")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if session.ChainID != "brainstorm/guided-flow" || session.Spec != "guided-flow-spec" {
+		t.Fatalf("expected guided session lookup by spec slug: %+v", session)
+	}
+}

--- a/internal/planning/initiative.go
+++ b/internal/planning/initiative.go
@@ -1,0 +1,25 @@
+package planning
+
+import (
+	"plan/internal/notes"
+)
+
+type InitiativeRef struct {
+	Slug    string
+	Title   string
+	Summary string
+}
+
+func (m *Manager) SetSpecInitiative(specSlug string, initiative InitiativeRef) (*notes.Note, error) {
+	return m.UpdateSpec(specSlug, notes.UpdateInput{
+		Metadata: map[string]any{
+			"initiative":         initiative.Slug,
+			"initiative_title":   initiative.Title,
+			"initiative_summary": initiative.Summary,
+		},
+	})
+}
+
+func (m *Manager) ClearSpecInitiative(specSlug string) (*notes.Note, error) {
+	return m.SetSpecInitiative(specSlug, InitiativeRef{})
+}

--- a/internal/planning/initiative_test.go
+++ b/internal/planning/initiative_test.go
@@ -1,0 +1,53 @@
+package planning
+
+import (
+	"path/filepath"
+	"testing"
+
+	"plan/internal/notes"
+	"plan/internal/workspace"
+)
+
+func TestListIdeasAndSpecsExposeInitiativeMetadata(t *testing.T) {
+	root := t.TempDir()
+	ws := workspace.New(root)
+	if _, err := ws.Init(); err != nil {
+		t.Fatal(err)
+	}
+	manager := New(ws)
+
+	if _, err := notes.Create(filepath.Join(root, ".plan", "ideas", "guide-packet-foundation.md"), "Guide Packet Foundation", "idea", "# Guide Packet Foundation\n", map[string]any{
+		"slug":               "guide-packet-foundation",
+		"initiative":         "guide-packet-foundation",
+		"initiative_title":   "Guide Packet Foundation",
+		"initiative_summary": "Ship the first guide-packet workflow slices.",
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := manager.CreateEpic("Billing", ""); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := manager.SetSpecInitiative("billing", InitiativeRef{
+		Slug:    "guide-packet-foundation",
+		Title:   "Guide Packet Foundation",
+		Summary: "Ship the first guide-packet workflow slices.",
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	ideas, err := manager.ListIdeas()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(ideas) != 1 || ideas[0].Initiative != "guide-packet-foundation" || ideas[0].InitiativeTitle != "Guide Packet Foundation" {
+		t.Fatalf("expected initiative metadata on idea docs: %+v", ideas)
+	}
+
+	specs, err := manager.ListSpecs()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(specs) != 1 || specs[0].Initiative != "guide-packet-foundation" || specs[0].InitiativeTitle != "Guide Packet Foundation" {
+		t.Fatalf("expected initiative metadata on specs: %+v", specs)
+	}
+}

--- a/internal/planning/manager.go
+++ b/internal/planning/manager.go
@@ -32,6 +32,15 @@ type BrainstormInfo struct {
 	Title string
 }
 
+type IdeaInfo struct {
+	Slug              string
+	Path              string
+	Title             string
+	Initiative        string
+	InitiativeTitle   string
+	InitiativeSummary string
+}
+
 type BrainstormCreateInput struct {
 	Topic         string
 	FocusQuestion string
@@ -74,6 +83,19 @@ type StoryInfo struct {
 	Started       bool
 }
 
+type SpecInfo struct {
+	Slug              string
+	Path              string
+	Title             string
+	Status            string
+	SourceBrainstorm  string
+	Initiative        string
+	InitiativeTitle   string
+	InitiativeSummary string
+	TargetVersion     string
+	Ready             bool
+}
+
 type VersionStatus struct {
 	Key               string
 	Title             string
@@ -88,6 +110,13 @@ type VersionStatus struct {
 type ProjectStatus struct {
 	Project           string
 	PlanningModel     string
+	Specs             []SpecInfo
+	TotalSpecs        int
+	DraftSpecs        int
+	ApprovedSpecs     int
+	ImplementingSpecs int
+	DoneSpecs         int
+	ReadySpecs        []SpecInfo
 	RoadmapPath       string
 	Versions          []VersionStatus
 	UnassignedEpics   []EpicInfo
@@ -212,6 +241,9 @@ func (m *Manager) AddBrainstormEntry(brainstormSlug, section, body string) (*not
 func (m *Manager) CreateEpic(title, sourceBrainstorm string) (*EpicBundle, error) {
 	info, err := m.workspace.EnsureInitialized()
 	if err != nil {
+		return nil, err
+	}
+	if err := os.MkdirAll(info.EpicsDir, 0o755); err != nil {
 		return nil, err
 	}
 	epicSlug := slugify(title)
@@ -354,6 +386,66 @@ func (m *Manager) ListEpics() ([]EpicInfo, error) {
 	return out, nil
 }
 
+func (m *Manager) ListSpecs() ([]SpecInfo, error) {
+	info, err := m.workspace.EnsureInitialized()
+	if err != nil {
+		return nil, err
+	}
+	specNotes, err := readNotesInDir(info.SpecsDir)
+	if err != nil {
+		return nil, err
+	}
+	out := make([]SpecInfo, 0, len(specNotes))
+	for _, spec := range specNotes {
+		item := SpecInfo{
+			Slug:              slugFromPath(spec.Path),
+			Path:              rel(info.ProjectDir, spec.Path),
+			Title:             spec.Title,
+			Status:            stringValue(spec.Metadata["status"]),
+			SourceBrainstorm:  stringValue(spec.Metadata["source_brainstorm"]),
+			Initiative:        stringValue(spec.Metadata["initiative"]),
+			InitiativeTitle:   stringValue(spec.Metadata["initiative_title"]),
+			InitiativeSummary: stringValue(spec.Metadata["initiative_summary"]),
+			TargetVersion:     stringValue(spec.Metadata["target_version"]),
+		}
+		if item.Status == "" {
+			item.Status = "draft"
+		}
+		item.Ready = item.Status == "approved"
+		out = append(out, item)
+	}
+	sort.Slice(out, func(i, j int) bool {
+		return out[i].Title < out[j].Title
+	})
+	return out, nil
+}
+
+func (m *Manager) ListIdeas() ([]IdeaInfo, error) {
+	info, err := m.workspace.EnsureInitialized()
+	if err != nil {
+		return nil, err
+	}
+	ideaNotes, err := readNotesInDir(info.IdeasDir)
+	if err != nil {
+		return nil, err
+	}
+	out := make([]IdeaInfo, 0, len(ideaNotes))
+	for _, idea := range ideaNotes {
+		out = append(out, IdeaInfo{
+			Slug:              slugFromPath(idea.Path),
+			Path:              rel(info.ProjectDir, idea.Path),
+			Title:             idea.Title,
+			Initiative:        stringValue(idea.Metadata["initiative"]),
+			InitiativeTitle:   stringValue(idea.Metadata["initiative_title"]),
+			InitiativeSummary: stringValue(idea.Metadata["initiative_summary"]),
+		})
+	}
+	sort.Slice(out, func(i, j int) bool {
+		return out[i].Title < out[j].Title
+	})
+	return out, nil
+}
+
 func (m *Manager) ReadEpic(epicSlug string) (*notes.Note, error) {
 	info, err := m.workspace.EnsureInitialized()
 	if err != nil {
@@ -424,6 +516,9 @@ func (m *Manager) SetSpecStatus(epicSlug, status string) (*notes.Note, error) {
 func (m *Manager) CreateStory(epicSlug, title, description string, criteria, verification, resources []string) (*notes.Note, error) {
 	info, err := m.workspace.EnsureInitialized()
 	if err != nil {
+		return nil, err
+	}
+	if err := os.MkdirAll(info.StoriesDir, 0o755); err != nil {
 		return nil, err
 	}
 	backend, err := m.storyBackendForInfo()
@@ -593,6 +688,10 @@ func (m *Manager) Status() (*ProjectStatus, error) {
 	if err != nil {
 		return nil, err
 	}
+	specs, err := m.ListSpecs()
+	if err != nil {
+		return nil, err
+	}
 	epics, err := m.ListEpics()
 	if err != nil {
 		return nil, err
@@ -604,8 +703,23 @@ func (m *Manager) Status() (*ProjectStatus, error) {
 	status := &ProjectStatus{
 		Project:       info.ProjectName,
 		PlanningModel: workspace.PlanningModel,
+		Specs:         specs,
+		TotalSpecs:    len(specs),
 		Epics:         epics,
 		TotalStories:  len(stories),
+	}
+	for _, spec := range specs {
+		switch spec.Status {
+		case "approved":
+			status.ApprovedSpecs++
+			status.ReadySpecs = append(status.ReadySpecs, spec)
+		case "implementing":
+			status.ImplementingSpecs++
+		case "done":
+			status.DoneSpecs++
+		default:
+			status.DraftSpecs++
+		}
 	}
 	for _, story := range stories {
 		switch story.Status {
@@ -690,7 +804,7 @@ func (m *Manager) seedSpecFromBrainstorm(info *workspace.Info, spec *notes.Note,
 	if questions := notes.ExtractSection(brainstorm.Content, "Open Questions"); questions != "" {
 		body = notes.AppendUnderHeading(body, "Risks / Open Questions", questions)
 	}
-	body = notes.AppendUnderHeading(body, "Story Breakdown", "- [ ] Split approved spec into execution-ready stories")
+	body = notes.AppendUnderHeading(body, "Execution Plan", "- [ ] Define execution slices when implementation begins")
 	body = notes.AppendUnderHeading(body, "Resources", fmt.Sprintf("- [Source Brainstorm](%s)", relativeLinkPath(filepath.Dir(spec.Path), brainstorm.Path)))
 	updated, err := notes.Update(spec.Path, notes.UpdateInput{
 		Body: ptr(body),
@@ -751,6 +865,9 @@ func (m *Manager) relNote(note *notes.Note, projectDir string) *notes.Note {
 func readNotesInDir(dir string) ([]*notes.Note, error) {
 	entries, err := os.ReadDir(dir)
 	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
 		return nil, err
 	}
 	var out []*notes.Note

--- a/internal/planning/spec_execute.go
+++ b/internal/planning/spec_execute.go
@@ -1,0 +1,199 @@
+package planning
+
+import (
+	"fmt"
+	"path/filepath"
+	"strings"
+
+	"plan/internal/notes"
+	"plan/internal/workspace"
+)
+
+type SpecExecutionSlice struct {
+	Title        string
+	Slug         string
+	Goal         string
+	Verification []string
+}
+
+type SpecExecutionPlan struct {
+	Project         string
+	SpecSlug        string
+	SpecPath        string
+	SpecTitle       string
+	Status          string
+	SuggestedBranch string
+	Slices          []SpecExecutionSlice
+}
+
+func (m *Manager) PreviewSpecExecution(specSlug, branchPrefix string) (*SpecExecutionPlan, error) {
+	info, spec, err := m.loadSpecBySlug(specSlug)
+	if err != nil {
+		return nil, err
+	}
+	status := stringValue(spec.Metadata["status"])
+	if status == "" {
+		status = "draft"
+	}
+	switch status {
+	case "approved", "implementing":
+	case "done":
+		return nil, fmt.Errorf("spec %s is already %q; reopen it before starting a new execution pass", rel(info.ProjectDir, spec.Path), status)
+	default:
+		return nil, fmt.Errorf("spec %s is %q; approve the spec before starting execution", rel(info.ProjectDir, spec.Path), status)
+	}
+	return buildSpecExecutionPlan(info, spec, normalizeBranchPrefix(branchPrefix)), nil
+}
+
+func (m *Manager) BeginSpecExecution(specSlug, branchPrefix string) (*SpecExecutionPlan, error) {
+	info, spec, err := m.loadSpecBySlug(specSlug)
+	if err != nil {
+		return nil, err
+	}
+	status := stringValue(spec.Metadata["status"])
+	if status == "" {
+		status = "draft"
+	}
+	switch status {
+	case "approved":
+		spec, err = notes.Update(spec.Path, notes.UpdateInput{
+			Metadata: map[string]any{"status": "implementing"},
+		})
+		if err != nil {
+			return nil, err
+		}
+	case "implementing":
+	case "done":
+		return nil, fmt.Errorf("spec %s is already %q; reopen it before starting a new execution pass", rel(info.ProjectDir, spec.Path), status)
+	default:
+		return nil, fmt.Errorf("spec %s is %q; approve the spec before starting execution", rel(info.ProjectDir, spec.Path), status)
+	}
+	return buildSpecExecutionPlan(info, spec, normalizeBranchPrefix(branchPrefix)), nil
+}
+
+func buildSpecExecutionPlan(info *workspace.Info, spec *notes.Note, branchPrefix string) *SpecExecutionPlan {
+	status := stringValue(spec.Metadata["status"])
+	if status == "" {
+		status = "draft"
+	}
+	return &SpecExecutionPlan{
+		Project:         info.ProjectName,
+		SpecSlug:        slugFromPath(spec.Path),
+		SpecPath:        rel(info.ProjectDir, spec.Path),
+		SpecTitle:       spec.Title,
+		Status:          status,
+		SuggestedBranch: branchPrefix + slugFromPath(spec.Path),
+		Slices:          deriveSpecExecutionSlices(spec),
+	}
+}
+
+func deriveSpecExecutionSlices(spec *notes.Note) []SpecExecutionSlice {
+	if candidates := parseStoryBreakdownCandidates(extractExecutionPlanSection(spec.Content)); len(candidates) > 0 {
+		slices := make([]SpecExecutionSlice, 0, len(candidates))
+		defaultVerification := storySliceVerificationDefaults(spec)
+		for _, candidate := range candidates {
+			if candidate.Title == "" || isSeededExecutionPlaceholder(candidate.Title) {
+				continue
+			}
+			goal := strings.TrimSpace(candidate.Description)
+			if goal == "" {
+				if len(candidate.AcceptanceCriteria) > 0 {
+					goal = strings.TrimSpace(candidate.AcceptanceCriteria[0])
+				} else {
+					goal = fmt.Sprintf("Complete the %q slice of %s.", candidate.Title, spec.Title)
+				}
+			}
+			verification := trimmedItems(candidate.Verification)
+			if len(verification) == 0 {
+				verification = append([]string(nil), defaultVerification...)
+			}
+			slices = append(slices, SpecExecutionSlice{
+				Title:        candidate.Title,
+				Slug:         slugify(candidate.Title),
+				Goal:         goal,
+				Verification: verification,
+			})
+		}
+		if len(slices) > 0 {
+			return slices
+		}
+	}
+
+	if flowSlices := deriveFlowExecutionSlices(spec); len(flowSlices) > 0 {
+		return flowSlices
+	}
+
+	return deriveFallbackExecutionSlices(spec)
+}
+
+func deriveFlowExecutionSlices(spec *notes.Note) []SpecExecutionSlice {
+	defaultVerification := storySliceVerificationDefaults(spec)
+	var slices []SpecExecutionSlice
+	for _, line := range strings.Split(notes.ExtractSection(spec.Content, "Flows"), "\n") {
+		trimmed := normalizeSectionLine(line)
+		if trimmed == "" {
+			continue
+		}
+		slices = append(slices, SpecExecutionSlice{
+			Title:        trimmed,
+			Slug:         slugify(trimmed),
+			Goal:         fmt.Sprintf("Implement and verify the %q flow for %s.", trimmed, spec.Title),
+			Verification: append([]string(nil), defaultVerification...),
+		})
+		if len(slices) == 3 {
+			break
+		}
+	}
+	return slices
+}
+
+func deriveFallbackExecutionSlices(spec *notes.Note) []SpecExecutionSlice {
+	baseTitle := strings.TrimSpace(strings.TrimSuffix(spec.Title, " Spec"))
+	if baseTitle == "" {
+		baseTitle = strings.TrimSpace(spec.Title)
+	}
+	defaultVerification := storySliceVerificationDefaults(spec)
+	return []SpecExecutionSlice{
+		{
+			Title:        "Prepare " + baseTitle,
+			Slug:         slugify("prepare " + baseTitle),
+			Goal:         fmt.Sprintf("Set up the interfaces, constraints, and prerequisites required for %s.", baseTitle),
+			Verification: append([]string(nil), defaultVerification...),
+		},
+		{
+			Title:        "Implement " + baseTitle,
+			Slug:         slugify("implement " + baseTitle),
+			Goal:         fmt.Sprintf("Build the core behavior described by %s.", spec.Title),
+			Verification: append([]string(nil), defaultVerification...),
+		},
+		{
+			Title:        "Verify " + baseTitle,
+			Slug:         slugify("verify " + baseTitle),
+			Goal:         fmt.Sprintf("Run the end-to-end checks for %s and clean up rollout edges.", spec.Title),
+			Verification: append([]string(nil), defaultVerification...),
+		},
+	}
+}
+
+func normalizeBranchPrefix(branchPrefix string) string {
+	branchPrefix = strings.TrimSpace(branchPrefix)
+	if branchPrefix == "" {
+		branchPrefix = "feature/"
+	}
+	if !strings.HasSuffix(branchPrefix, "/") {
+		branchPrefix += "/"
+	}
+	return branchPrefix
+}
+
+func (m *Manager) loadSpecBySlug(specSlug string) (*workspace.Info, *notes.Note, error) {
+	info, err := m.workspace.EnsureInitialized()
+	if err != nil {
+		return nil, nil, err
+	}
+	spec, err := notes.Read(filepath.Join(info.SpecsDir, slugify(specSlug)+".md"))
+	if err != nil {
+		return nil, nil, err
+	}
+	return info, spec, nil
+}

--- a/internal/planning/story_slice.go
+++ b/internal/planning/story_slice.go
@@ -10,7 +10,10 @@ import (
 	"plan/internal/workspace"
 )
 
-const seededStoryBreakdownPlaceholder = "Split approved spec into execution-ready stories"
+const (
+	seededExecutionPlanPlaceholder  = "Define execution slices when implementation begins"
+	legacyStoryBreakdownPlaceholder = "Split approved spec into execution-ready stories"
+)
 
 type StorySliceCandidate struct {
 	Title              string
@@ -56,7 +59,7 @@ func (m *Manager) PreviewStorySlices(epicSlug string) (*StorySlicePreview, error
 		return nil, err
 	}
 	if len(candidates) == 0 {
-		return nil, fmt.Errorf("spec %s has no slice-ready Story Breakdown entries", rel(info.ProjectDir, spec.Path))
+		return nil, fmt.Errorf("spec %s has no slice-ready execution plan entries", rel(info.ProjectDir, spec.Path))
 	}
 	return &StorySlicePreview{
 		Project:    info.ProjectName,
@@ -99,7 +102,7 @@ func (m *Manager) ApplyStorySlices(epicSlug string) (*StorySliceApplyResult, err
 	}
 
 	breakdown := renderStoryBreakdownLinks(info.ProjectDir, spec.Path, result.Candidates)
-	body := notes.SetSection(spec.Content, "Story Breakdown", breakdown)
+	body := notes.SetSection(spec.Content, executionPlanHeading(spec.Content), breakdown)
 	updatedSpec, err := notes.Update(spec.Path, notes.UpdateInput{Body: &body})
 	if err != nil {
 		return nil, err
@@ -109,11 +112,11 @@ func (m *Manager) ApplyStorySlices(epicSlug string) (*StorySliceApplyResult, err
 }
 
 func deriveStorySliceCandidates(info *workspace.Info, epic, spec *notes.Note) ([]StorySliceCandidate, error) {
-	rawCandidates := parseStoryBreakdownCandidates(notes.ExtractSection(spec.Content, "Story Breakdown"))
+	rawCandidates := parseStoryBreakdownCandidates(extractExecutionPlanSection(spec.Content))
 	verificationDefaults := storySliceVerificationDefaults(spec)
 	var candidates []StorySliceCandidate
 	for _, raw := range rawCandidates {
-		if raw.Title == "" || strings.EqualFold(raw.Title, seededStoryBreakdownPlaceholder) {
+		if raw.Title == "" || isSeededExecutionPlaceholder(raw.Title) {
 			continue
 		}
 		candidate := StorySliceCandidate{
@@ -255,6 +258,28 @@ func storySliceVerificationDefaults(spec *notes.Note) []string {
 		return []string{"Validate the slice against the canonical spec."}
 	}
 	return out
+}
+
+func extractExecutionPlanSection(content string) string {
+	if section := notes.ExtractSection(content, "Execution Plan"); strings.TrimSpace(section) != "" {
+		return section
+	}
+	return notes.ExtractSection(content, "Story Breakdown")
+}
+
+func executionPlanHeading(content string) string {
+	if section := notes.ExtractSection(content, "Execution Plan"); strings.TrimSpace(section) != "" {
+		return "Execution Plan"
+	}
+	if section := notes.ExtractSection(content, "Story Breakdown"); strings.TrimSpace(section) != "" {
+		return "Story Breakdown"
+	}
+	return "Execution Plan"
+}
+
+func isSeededExecutionPlaceholder(title string) bool {
+	title = strings.TrimSpace(title)
+	return strings.EqualFold(title, seededExecutionPlanPlaceholder) || strings.EqualFold(title, legacyStoryBreakdownPlaceholder)
 }
 
 func renderStoryBreakdownLinks(projectDir, specPath string, candidates []StorySliceCandidate) string {

--- a/internal/templates/spec.md
+++ b/internal/templates/spec.md
@@ -24,7 +24,7 @@ Created: {{ .Now }}
 
 ## Verification
 
-## Story Breakdown
+## Execution Plan
 
 ## Analysis
 

--- a/internal/workspace/workspace.go
+++ b/internal/workspace/workspace.go
@@ -5,14 +5,17 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 	"time"
 
+	"plan/internal/notes"
 	"plan/internal/templates"
 )
 
 const (
-	CurrentSchemaVersion = 2
-	PlanningModel        = "epic_spec_story_v1"
+	CurrentSchemaVersion = 3
+	PlanningModel        = "spec_first_v1"
+	LegacyPlanningModel  = "epic_spec_story_v1"
 )
 
 type StoryBackend string
@@ -71,6 +74,19 @@ type GitHubStoryRecord struct {
 	UpdatedAt             string   `json:"updated_at,omitempty"`
 }
 
+type ArchivedPath struct {
+	From string `json:"from"`
+	To   string `json:"to"`
+}
+
+type ArchivedSpec struct {
+	Slug             string `json:"slug"`
+	Path             string `json:"path"`
+	Title            string `json:"title,omitempty"`
+	Status           string `json:"status,omitempty"`
+	SourceLegacyEpic string `json:"source_legacy_epic,omitempty"`
+}
+
 type MigrationState struct {
 	SchemaVersion int            `json:"schema_version"`
 	Known         []string       `json:"known"`
@@ -79,15 +95,24 @@ type MigrationState struct {
 	LastOperation string         `json:"last_operation,omitempty"`
 	LastCreated   []string       `json:"last_created,omitempty"`
 	LastUpdated   []string       `json:"last_updated,omitempty"`
+	LastArchived  []ArchivedPath `json:"last_archived,omitempty"`
 	History       []MigrationRun `json:"history,omitempty"`
 }
 
 type MigrationRun struct {
-	Operation string   `json:"operation"`
-	At        string   `json:"at"`
-	Status    string   `json:"status"`
-	Created   []string `json:"created,omitempty"`
-	Updated   []string `json:"updated,omitempty"`
+	Operation string         `json:"operation"`
+	At        string         `json:"at"`
+	Status    string         `json:"status"`
+	Created   []string       `json:"created,omitempty"`
+	Updated   []string       `json:"updated,omitempty"`
+	Archived  []ArchivedPath `json:"archived,omitempty"`
+}
+
+type ArchiveManifest struct {
+	ArchivedAt    string         `json:"archived_at"`
+	PlanningModel string         `json:"planning_model"`
+	Sources       []ArchivedPath `json:"sources"`
+	ActiveSpecs   []ArchivedSpec `json:"active_specs,omitempty"`
 }
 
 type Surface struct {
@@ -111,6 +136,8 @@ type Info struct {
 	ProjectFile    string
 	RoadmapFile    string
 	BrainstormsDir string
+	IdeasDir       string
+	ArchiveDir     string
 	EpicsDir       string
 	SpecsDir       string
 	StoriesDir     string
@@ -127,9 +154,14 @@ type InitResult struct {
 }
 
 type UpdateResult struct {
-	Info    *Info
-	Created []string
-	Updated []string
+	Info     *Info
+	Created  []string
+	Updated  []string
+	Archived []ArchivedPath
+}
+
+type UpdateOptions struct {
+	ArchiveLegacy bool
 }
 
 type DoctorReport struct {
@@ -172,6 +204,8 @@ func (m *Manager) Resolve() (*Info, error) {
 		ProjectFile:    filepath.Join(planDir, "PROJECT.md"),
 		RoadmapFile:    filepath.Join(planDir, "ROADMAP.md"),
 		BrainstormsDir: filepath.Join(planDir, "brainstorms"),
+		IdeasDir:       filepath.Join(planDir, "ideas"),
+		ArchiveDir:     filepath.Join(planDir, "archive"),
 		EpicsDir:       filepath.Join(planDir, "epics"),
 		SpecsDir:       filepath.Join(planDir, "specs"),
 		StoriesDir:     filepath.Join(planDir, "stories"),
@@ -195,9 +229,9 @@ func (i *Info) UserAuthoredSurfaces() []Surface {
 		i.newSurface("PROJECT.md", i.ProjectFile, "user_authored", "file"),
 		i.newSurface("ROADMAP.md", i.RoadmapFile, "user_authored", "file"),
 		i.newSurface("brainstorms/", i.BrainstormsDir, "user_authored", "dir"),
-		i.newSurface("epics/", i.EpicsDir, "user_authored", "dir"),
+		i.newSurface("ideas/", i.IdeasDir, "user_authored", "dir"),
 		i.newSurface("specs/", i.SpecsDir, "user_authored", "dir"),
-		i.newSurface("stories/", i.StoriesDir, "user_authored", "dir"),
+		i.newSurface("archive/", i.ArchiveDir, "user_authored", "dir"),
 	}
 }
 
@@ -282,7 +316,7 @@ func (m *Manager) Init() (*InitResult, error) {
 	} else if created {
 		result.Created = append(result.Created, rel(info.ProjectDir, info.SessionsFile))
 	}
-	if err := recordMigrationRun(info, "init", result.Created, nil, now); err != nil {
+	if err := recordMigrationRun(info, "init", result.Created, nil, nil, now); err != nil {
 		return nil, err
 	}
 
@@ -297,6 +331,10 @@ func (i *Info) directoryPaths() []string {
 		}
 	}
 	return dirs
+}
+
+func (i *Info) legacyDirectoryPaths() []string {
+	return []string{i.EpicsDir, i.StoriesDir}
 }
 
 func (m *Manager) EnsureInitialized() (*Info, error) {
@@ -480,6 +518,10 @@ func (m *Manager) Doctor() (*DoctorReport, error) {
 }
 
 func (m *Manager) Update() (*UpdateResult, error) {
+	return m.UpdateWithOptions(UpdateOptions{})
+}
+
+func (m *Manager) UpdateWithOptions(opts UpdateOptions) (*UpdateResult, error) {
 	info, err := m.Resolve()
 	if err != nil {
 		return nil, err
@@ -490,7 +532,7 @@ func (m *Manager) Update() (*UpdateResult, error) {
 		}
 		return nil, err
 	}
-	return m.repairWorkspace(info, "update")
+	return m.repairWorkspace(info, "update", opts)
 }
 
 func (m *Manager) Adopt() (*UpdateResult, error) {
@@ -498,10 +540,10 @@ func (m *Manager) Adopt() (*UpdateResult, error) {
 	if err != nil {
 		return nil, err
 	}
-	return m.repairWorkspace(info, "adopt")
+	return m.repairWorkspace(info, "adopt", UpdateOptions{})
 }
 
-func (m *Manager) repairWorkspace(info *Info, operation string) (*UpdateResult, error) {
+func (m *Manager) repairWorkspace(info *Info, operation string, opts UpdateOptions) (*UpdateResult, error) {
 	result := &UpdateResult{Info: info}
 	for _, dir := range append([]string{info.PlanDir}, info.directoryPaths()...) {
 		created, err := ensureDir(dir)
@@ -582,7 +624,16 @@ func (m *Manager) repairWorkspace(info *Info, operation string) (*UpdateResult, 
 			result.Updated = append(result.Updated, rel(info.ProjectDir, info.SessionsFile))
 		}
 	}
-	if err := recordMigrationRun(info, operation, result.Created, result.Updated, now); err != nil {
+	if opts.ArchiveLegacy {
+		archiveCreated, archiveUpdated, archived, err := archiveLegacyHierarchy(info, now)
+		if err != nil {
+			return nil, err
+		}
+		result.Created = append(result.Created, archiveCreated...)
+		result.Updated = append(result.Updated, archiveUpdated...)
+		result.Archived = append(result.Archived, archived...)
+	}
+	if err := recordMigrationRun(info, operation, result.Created, result.Updated, result.Archived, now); err != nil {
 		return nil, err
 	}
 
@@ -716,6 +767,122 @@ func reconcileGitHubState(path, now string) (bool, error) {
 	return true, writeJSON(path, normalized)
 }
 
+func archiveLegacyHierarchy(info *Info, now string) ([]string, []string, []ArchivedPath, error) {
+	var created []string
+	var updated []string
+	var archived []ArchivedPath
+	var activeSpecs []ArchivedSpec
+
+	batchName := archiveBatchName(now)
+	batchDir := filepath.Join(info.ArchiveDir, batchName)
+	batchCreated := false
+
+	for _, legacyDir := range info.legacyDirectoryPaths() {
+		entries, err := os.ReadDir(legacyDir)
+		if err != nil {
+			if os.IsNotExist(err) {
+				continue
+			}
+			return nil, nil, nil, err
+		}
+		if len(entries) == 0 {
+			if err := os.Remove(legacyDir); err != nil && !os.IsNotExist(err) {
+				return nil, nil, nil, err
+			}
+			updated = append(updated, rel(info.ProjectDir, legacyDir))
+			continue
+		}
+		if !batchCreated {
+			made, err := ensureDir(batchDir)
+			if err != nil {
+				return nil, nil, nil, err
+			}
+			if made {
+				created = append(created, rel(info.ProjectDir, batchDir))
+			}
+			batchCreated = true
+		}
+		destDir := filepath.Join(batchDir, filepath.Base(legacyDir))
+		if filepath.Base(legacyDir) == "epics" {
+			specs, err := archivedSpecsForLegacyEpics(info, legacyDir, destDir)
+			if err != nil {
+				return nil, nil, nil, err
+			}
+			activeSpecs = append(activeSpecs, specs...)
+		}
+		if err := os.Rename(legacyDir, destDir); err != nil {
+			return nil, nil, nil, err
+		}
+		archived = append(archived, ArchivedPath{
+			From: rel(info.ProjectDir, legacyDir),
+			To:   rel(info.ProjectDir, destDir),
+		})
+	}
+
+	if !batchCreated {
+		return created, updated, archived, nil
+	}
+
+	manifest := ArchiveManifest{
+		ArchivedAt:    now,
+		PlanningModel: PlanningModel,
+		Sources:       append([]ArchivedPath(nil), archived...),
+		ActiveSpecs:   activeSpecs,
+	}
+	manifestPath := filepath.Join(batchDir, "migration.json")
+	if err := writeJSON(manifestPath, manifest); err != nil {
+		return nil, nil, nil, err
+	}
+	created = append(created, rel(info.ProjectDir, manifestPath))
+
+	return created, updated, archived, nil
+}
+
+func archivedSpecsForLegacyEpics(info *Info, legacyDir, destDir string) ([]ArchivedSpec, error) {
+	entries, err := os.ReadDir(legacyDir)
+	if err != nil {
+		return nil, err
+	}
+	specs := make([]ArchivedSpec, 0, len(entries))
+	for _, entry := range entries {
+		if entry.IsDir() || filepath.Ext(entry.Name()) != ".md" {
+			continue
+		}
+		epicPath := filepath.Join(legacyDir, entry.Name())
+		epic, err := notes.Read(epicPath)
+		if err != nil {
+			return nil, err
+		}
+		specSlug := stringValue(epic.Metadata["spec"])
+		if specSlug == "" {
+			specSlug = slugFromPath(epicPath)
+		}
+		specPath := filepath.Join(info.SpecsDir, specSlug+".md")
+		spec := ArchivedSpec{
+			Slug:             specSlug,
+			Path:             rel(info.ProjectDir, specPath),
+			Status:           "draft",
+			SourceLegacyEpic: rel(info.ProjectDir, filepath.Join(destDir, entry.Name())),
+		}
+		if current, err := notes.Read(specPath); err == nil {
+			spec.Title = current.Title
+			if status := stringValue(current.Metadata["status"]); status != "" {
+				spec.Status = status
+			}
+		}
+		specs = append(specs, spec)
+	}
+	return specs, nil
+}
+
+func archiveBatchName(now string) string {
+	parsed, err := time.Parse(time.RFC3339, now)
+	if err != nil {
+		return "legacy-" + strings.NewReplacer(":", "", "-", "", ".", "").Replace(now)
+	}
+	return "legacy-" + parsed.UTC().Format("20060102T150405Z")
+}
+
 func defaultWorkspaceMeta(now string) WorkspaceMeta {
 	return WorkspaceMeta{
 		SchemaVersion: CurrentSchemaVersion,
@@ -746,7 +913,7 @@ func normalizeWorkspaceMeta(meta WorkspaceMeta, now string) (WorkspaceMeta, bool
 	if meta.SchemaVersion > CurrentSchemaVersion {
 		return WorkspaceMeta{}, false, fmt.Errorf("workspace schema version %d is newer than supported version %d", meta.SchemaVersion, CurrentSchemaVersion)
 	}
-	if meta.PlanningModel != "" && meta.PlanningModel != PlanningModel {
+	if meta.PlanningModel != "" && meta.PlanningModel != PlanningModel && meta.PlanningModel != LegacyPlanningModel {
 		return WorkspaceMeta{}, false, fmt.Errorf("workspace planning model %q is not supported by this build", meta.PlanningModel)
 	}
 
@@ -757,6 +924,9 @@ func normalizeWorkspaceMeta(meta WorkspaceMeta, now string) (WorkspaceMeta, bool
 		changed = true
 	}
 	if normalized.PlanningModel == "" {
+		normalized.PlanningModel = PlanningModel
+		changed = true
+	} else if normalized.PlanningModel == LegacyPlanningModel {
 		normalized.PlanningModel = PlanningModel
 		changed = true
 	}
@@ -867,8 +1037,8 @@ func validateMigrationState(state *MigrationState) error {
 	}
 }
 
-func recordMigrationRun(info *Info, operation string, created, updated []string, now string) error {
-	if len(created) == 0 && len(updated) == 0 {
+func recordMigrationRun(info *Info, operation string, created, updated []string, archived []ArchivedPath, now string) error {
+	if len(created) == 0 && len(updated) == 0 && len(archived) == 0 {
 		return nil
 	}
 	state, err := readMigrationStateFile(info.MigrationsFile)
@@ -878,18 +1048,21 @@ func recordMigrationRun(info *Info, operation string, created, updated []string,
 	}
 	created = append([]string(nil), created...)
 	updated = append([]string(nil), updated...)
+	archived = append([]ArchivedPath(nil), archived...)
 	run := MigrationRun{
 		Operation: operation,
 		At:        now,
 		Status:    "current",
 		Created:   created,
 		Updated:   updated,
+		Archived:  archived,
 	}
 	state.LastRunAt = now
 	state.Status = "current"
 	state.LastOperation = operation
 	state.LastCreated = created
 	state.LastUpdated = updated
+	state.LastArchived = archived
 	state.History = append(state.History, run)
 	if len(state.History) > 10 {
 		state.History = append([]MigrationRun(nil), state.History[len(state.History)-10:]...)
@@ -924,6 +1097,16 @@ func rel(root, path string) string {
 		return path
 	}
 	return filepath.ToSlash(r)
+}
+
+func slugFromPath(path string) string {
+	base := filepath.Base(path)
+	return strings.TrimSuffix(base, filepath.Ext(base))
+}
+
+func stringValue(value any) string {
+	text, _ := value.(string)
+	return text
 }
 
 func classifyDoctorWorkspace(missing, broken []string) string {

--- a/internal/workspace/workspace.go
+++ b/internal/workspace/workspace.go
@@ -853,10 +853,7 @@ func archivedSpecsForLegacyEpics(info *Info, legacyDir, destDir string) ([]Archi
 		if err != nil {
 			return nil, err
 		}
-		specSlug := stringValue(epic.Metadata["spec"])
-		if specSlug == "" {
-			specSlug = slugFromPath(epicPath)
-		}
+		specSlug := safeLegacySpecSlug(stringValue(epic.Metadata["spec"]), slugFromPath(epicPath))
 		specPath := filepath.Join(info.SpecsDir, specSlug+".md")
 		spec := ArchivedSpec{
 			Slug:             specSlug,
@@ -873,6 +870,21 @@ func archivedSpecsForLegacyEpics(info *Info, legacyDir, destDir string) ([]Archi
 		specs = append(specs, spec)
 	}
 	return specs, nil
+}
+
+func safeLegacySpecSlug(raw, fallback string) string {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return slugFromPath(fallback)
+	}
+	if strings.ContainsAny(raw, `/\`) {
+		return slugFromPath(fallback)
+	}
+	base := filepath.Base(raw)
+	if base == "." || base == ".." {
+		return slugFromPath(fallback)
+	}
+	return slugFromPath(base)
 }
 
 func archiveBatchName(now string) string {

--- a/internal/workspace/workspace_test.go
+++ b/internal/workspace/workspace_test.go
@@ -1,10 +1,13 @@
 package workspace
 
 import (
+	"encoding/json"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
+
+	"plan/internal/notes"
 )
 
 func TestInitCreatesPlanWorkspace(t *testing.T) {
@@ -21,9 +24,9 @@ func TestInitCreatesPlanWorkspace(t *testing.T) {
 
 	for _, path := range []string{
 		filepath.Join(root, ".plan", "brainstorms"),
-		filepath.Join(root, ".plan", "epics"),
+		filepath.Join(root, ".plan", "ideas"),
+		filepath.Join(root, ".plan", "archive"),
 		filepath.Join(root, ".plan", "specs"),
-		filepath.Join(root, ".plan", "stories"),
 		filepath.Join(root, ".plan", ".meta"),
 		filepath.Join(root, ".plan", "PROJECT.md"),
 		filepath.Join(root, ".plan", "ROADMAP.md"),
@@ -426,9 +429,6 @@ func TestUpdateRecreatesMissingScaffoldingWithoutOverwritingExistingNotes(t *tes
 	if err := os.Remove(filepath.Join(root, ".plan", "ROADMAP.md")); err != nil {
 		t.Fatal(err)
 	}
-	if err := os.RemoveAll(filepath.Join(root, ".plan", "stories")); err != nil {
-		t.Fatal(err)
-	}
 
 	result, err := manager.Update()
 	if err != nil {
@@ -436,9 +436,6 @@ func TestUpdateRecreatesMissingScaffoldingWithoutOverwritingExistingNotes(t *tes
 	}
 	if !contains(result.Created, ".plan/ROADMAP.md") {
 		t.Fatalf("expected roadmap recreation: %+v", result)
-	}
-	if !contains(result.Created, ".plan/stories") {
-		t.Fatalf("expected stories directory recreation: %+v", result)
 	}
 
 	raw, err := os.ReadFile(projectPath)
@@ -471,6 +468,139 @@ func TestUpdateIsIdempotentWhenWorkspaceIsCurrent(t *testing.T) {
 	}
 	if len(second.Created) != 0 || len(second.Updated) != 0 {
 		t.Fatalf("expected second update to stay idempotent: %+v", second)
+	}
+}
+
+func TestUpdateMigratesLegacyWorkspaceMetadataToSpecFirstModel(t *testing.T) {
+	root := t.TempDir()
+	manager := New(root)
+	if _, err := manager.Init(); err != nil {
+		t.Fatal(err)
+	}
+	legacy := `{
+  "schema_version": 1,
+  "planning_model": "epic_spec_story_v1",
+  "story_backend": "local",
+  "created_at": "2026-04-01T00:00:00Z",
+  "updated_at": "2026-04-01T00:00:00Z"
+}
+`
+	if err := os.WriteFile(filepath.Join(root, ".plan", ".meta", "workspace.json"), []byte(legacy), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	result, err := manager.Update()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !contains(result.Updated, ".plan/.meta/workspace.json") {
+		t.Fatalf("expected workspace metadata migration: %+v", result)
+	}
+
+	meta, err := manager.ReadWorkspaceMeta()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if meta.PlanningModel != PlanningModel || meta.SchemaVersion != 1 {
+		t.Fatalf("expected legacy workspace metadata to normalize to spec-first model: %+v", meta)
+	}
+}
+
+func TestUpdateWithArchiveLegacyMovesLegacyHierarchyAndPreservesActiveSpecs(t *testing.T) {
+	root := t.TempDir()
+	manager := New(root)
+	if _, err := manager.Init(); err != nil {
+		t.Fatal(err)
+	}
+
+	epicsDir := filepath.Join(root, ".plan", "epics")
+	storiesDir := filepath.Join(root, ".plan", "stories")
+	if err := os.MkdirAll(epicsDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(storiesDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	specPath := filepath.Join(root, ".plan", "specs", "billing.md")
+	if _, err := notes.Create(specPath, "Billing Spec", "spec", "# Billing Spec\n", map[string]any{
+		"slug":   "billing",
+		"status": "approved",
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := notes.Create(filepath.Join(epicsDir, "billing.md"), "Billing", "epic", "# Billing\n", map[string]any{
+		"slug": "billing",
+		"spec": "billing",
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := notes.Create(filepath.Join(storiesDir, "billing-ui.md"), "Billing UI", "story", "# Billing UI\n", map[string]any{
+		"slug":   "billing-ui",
+		"status": "todo",
+		"epic":   "billing",
+		"spec":   "billing",
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	result, err := manager.UpdateWithOptions(UpdateOptions{ArchiveLegacy: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(result.Archived) != 2 {
+		t.Fatalf("expected both legacy directories to be archived: %+v", result)
+	}
+	if _, err := os.Stat(epicsDir); !os.IsNotExist(err) {
+		t.Fatalf("expected legacy epics dir to be removed, got %v", err)
+	}
+	if _, err := os.Stat(storiesDir); !os.IsNotExist(err) {
+		t.Fatalf("expected legacy stories dir to be removed, got %v", err)
+	}
+	if _, err := os.Stat(specPath); err != nil {
+		t.Fatalf("expected active spec to remain in place: %v", err)
+	}
+
+	var batchDir string
+	for _, move := range result.Archived {
+		if strings.HasSuffix(move.To, "/epics") {
+			batchDir = filepath.Dir(filepath.Join(root, filepath.FromSlash(move.To)))
+			break
+		}
+	}
+	if batchDir == "" {
+		t.Fatalf("expected archived epics destination in result: %+v", result)
+	}
+	if _, err := os.Stat(filepath.Join(batchDir, "epics", "billing.md")); err != nil {
+		t.Fatalf("expected archived epic to exist: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(batchDir, "stories", "billing-ui.md")); err != nil {
+		t.Fatalf("expected archived story to exist: %v", err)
+	}
+
+	manifestPath := filepath.Join(batchDir, "migration.json")
+	raw, err := os.ReadFile(manifestPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var manifest ArchiveManifest
+	if err := json.Unmarshal(raw, &manifest); err != nil {
+		t.Fatal(err)
+	}
+	if len(manifest.ActiveSpecs) != 1 || manifest.ActiveSpecs[0].Path != ".plan/specs/billing.md" {
+		t.Fatalf("expected manifest to describe preserved active spec: %+v", manifest)
+	}
+
+	state, err := manager.ReadMigrationState()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(state.LastArchived) != 2 {
+		t.Fatalf("expected migration state to record archived moves: %+v", state)
+	}
+	last := state.History[len(state.History)-1]
+	if len(last.Archived) != 2 {
+		t.Fatalf("expected migration history to record archived moves: %+v", last)
 	}
 }
 

--- a/internal/workspace/workspace_test.go
+++ b/internal/workspace/workspace_test.go
@@ -618,3 +618,63 @@ func TestEnsureInitializedRejectsInvalidWorkspaceMetadata(t *testing.T) {
 		t.Fatal("expected invalid workspace metadata to fail initialization check")
 	}
 }
+
+func TestArchiveLegacyFallsBackWhenEpicSpecMetadataHasPathTraversal(t *testing.T) {
+	root := t.TempDir()
+	manager := New(root)
+	if _, err := manager.Init(); err != nil {
+		t.Fatal(err)
+	}
+
+	epicsDir := filepath.Join(root, ".plan", "epics")
+	if err := os.MkdirAll(epicsDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	specPath := filepath.Join(root, ".plan", "specs", "billing.md")
+	if _, err := notes.Create(specPath, "Billing Spec", "spec", "# Billing Spec\n", map[string]any{
+		"slug":   "billing",
+		"status": "approved",
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := notes.Create(filepath.Join(epicsDir, "billing.md"), "Billing", "epic", "# Billing\n", map[string]any{
+		"slug": "billing",
+		"spec": "../escape",
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	result, err := manager.UpdateWithOptions(UpdateOptions{ArchiveLegacy: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(result.Archived) != 1 {
+		t.Fatalf("expected archived epics move: %+v", result)
+	}
+
+	var batchDir string
+	for _, move := range result.Archived {
+		if strings.HasSuffix(move.To, "/epics") {
+			batchDir = filepath.Dir(filepath.Join(root, filepath.FromSlash(move.To)))
+			break
+		}
+	}
+	if batchDir == "" {
+		t.Fatalf("expected archive batch dir: %+v", result)
+	}
+
+	raw, err := os.ReadFile(filepath.Join(batchDir, "migration.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	var manifest ArchiveManifest
+	if err := json.Unmarshal(raw, &manifest); err != nil {
+		t.Fatal(err)
+	}
+	if len(manifest.ActiveSpecs) != 1 {
+		t.Fatalf("expected one archived active spec entry: %+v", manifest)
+	}
+	if manifest.ActiveSpecs[0].Slug != "billing" || manifest.ActiveSpecs[0].Path != ".plan/specs/billing.md" {
+		t.Fatalf("expected fallback spec slug/path to stay inside specs dir: %+v", manifest.ActiveSpecs[0])
+	}
+}

--- a/skills/plan/SKILL.md
+++ b/skills/plan/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: plan
-description: Use this skill when working with a project-local `plan` workspace that keeps planning material under `.plan/`. Focus on brainstorms, refinement, epics, specs, stories, and roadmap updates.
+description: Use this skill when working with a project-local `plan` workspace that keeps planning material under `.plan/`. Focus on brainstorms, idea docs, specs, execution slices, legacy compatibility surfaces, and roadmap updates.
 user-invocable: true
 args:
   - name: task
@@ -17,8 +17,8 @@ Use `plan` as the primary interface for repo-local planning.
 - keep planning local to the repo
 - treat specs as the canonical execution contract
 - improve the quality of brainstorms and specs before implementation starts
-- create stories only after spec approval
-- keep stories execution-ready and verification-aware
+- use lightweight initiative metadata when multiple specs belong together
+- guide execution from approved specs without persisting tiny slice artifacts by default
 - avoid sidecar planning systems outside `.plan/`
 
 ## Startup
@@ -27,7 +27,7 @@ When a repo uses `plan`:
 
 1. Read `.plan/PROJECT.md`.
 2. Read `.plan/ROADMAP.md`.
-3. Read the brainstorm, epic, spec, and story notes relevant to the task.
+3. Read the brainstorm, idea, spec, and legacy compatibility notes relevant to the task.
 4. Use the `plan` CLI for durable planning changes.
 
 ## Commands
@@ -36,38 +36,37 @@ When a repo uses `plan`:
 - `plan adopt --project .`
 - `plan doctor --project .`
 - `plan update --project .`
+- `plan update --project . --archive-legacy`
 - `plan check --project .`
 - `plan brainstorm start --project . "<topic>"`
 - `plan brainstorm idea --project . <brainstorm-slug> --body "<idea>"`
 - `plan brainstorm refine --project . <brainstorm-slug>`
 - `plan brainstorm challenge --project . <brainstorm-slug>`
-- `plan epic create --project . "<title>"`
-- `plan epic promote --project . <brainstorm-slug>`
-- `plan epic shape --project . <epic-slug>`
-- `plan spec show --project . <epic-slug>`
-- `plan spec analyze --project . <epic-slug>`
-- `plan spec checklist --project . <epic-slug> --profile general`
-- `plan spec status --project . <epic-slug> --set approved`
-- `plan story slice --project . <epic-slug>`
+- `plan epic create|promote|shape ...` only when a repo still depends on the legacy transition path
+- `plan spec show --project . <spec-slug>`
+- `plan spec analyze --project . <spec-slug>`
+- `plan spec checklist --project . <spec-slug> --profile general`
+- `plan spec status --project . <spec-slug> --set approved`
+- `plan spec initiative --project . <spec-slug> --set <initiative-slug>`
+- `plan spec execute --project . <spec-slug>`
 - `plan story critique --project . <story-slug>`
-- `plan story create --project . <epic-slug> "<title>" --criteria "<criterion>" --verify "<step>"`
-- `plan story update --project . <story-slug> --status in_progress`
+- `plan story create|update|slice ...` only for legacy compatibility during migration
 - `plan roadmap show --project .`
 - `plan status --project .`
 
 ## Rules
 
 - Brainstorms are discovery material, not the canonical hierarchy.
-- Canonical hierarchy is `Epic -> Spec -> Story`.
+- Active model is `Brainstorm -> Idea Doc (optional) -> Spec`, with runtime slices during execution.
 - `brainstorm refine` should reduce ambiguity before promotion.
 - `brainstorm challenge` should pressure-test risk, no-gos, and overengineering before promotion.
-- `epic shape` should turn an epic into a bounded bet with appetite and success signal.
+- `epic shape` is now a legacy compatibility pass, not the preferred active model.
 - `spec analyze` should pressure-test a spec without rewriting its canonical sections.
 - `spec checklist` should add profile-driven rigor without mutating the canonical sections.
-- `story slice` should stay preview-first and derive execution-ready slices from the canonical spec.
+- `spec execute` should derive ephemeral execution slices from the canonical spec and suggest a branch-per-spec path.
 - `story critique` should reject broad or verification-thin stories before implementation starts.
 - Keep roadmap guidance lightweight.
-- Do not add tasks beneath stories as first-class objects unless the project explicitly asks for that system.
+- Do not add a new heavyweight planning layer just to replace epics.
 - Keep planning separate from memory, retrieval, or context management systems.
 
 ## Planning Modes
@@ -76,11 +75,11 @@ Use the smallest pass that resolves the current planning gap:
 
 1. `brainstorm refine` for ambiguity reduction
 2. `brainstorm challenge` for rabbit holes, no-gos, and simplification pressure
-3. `epic shape` for appetite and scope boundaries
+3. `epic shape` only when the repo is still using the legacy transition path
 4. `spec analyze` for general refinement gaps
 5. `spec checklist` for domain-specific review
-6. `story slice` for turning approved spec breakdowns into first-pass story sets
-7. `story critique` for execution-readiness pressure before coding
+6. `spec execute` for starting branch-per-spec execution from an approved spec
+7. `story critique` only for legacy story flows that still need execution-readiness pressure
 
 ## Model Guidance
 
@@ -105,7 +104,7 @@ Use the smallest pass that resolves the current planning gap:
 - shaping passes stay additive
 - optional rigor must not make the default path ceremonial
 - every recommendation should improve clarity, boundedness, verification, or executability
-- spec-to-story handoffs should stay checkable with `plan check`
+- active execution should stay traceable from spec -> slices -> commits -> PR
 
 ## Ambiguity Handling
 


### PR DESCRIPTION
## Summary

- move the active workspace model to spec-first surfaces and add explicit legacy archiving with `plan update --archive-legacy`
- add spec execution entry points, ephemeral slice planning, initiative metadata, and GitHub milestone mapping for initiative-backed execution issues

## Target Branch

- Normal work targets `develop`.
- Release PRs use `release/vX.Y.Z -> main`.
- Hotfix work must be merged back into `develop`.

## Testing

- [x] `go test ./...`
- [x] `go build ./...`
- [x] Other: `brain session run -- go test ./...`, `brain session run -- go build ./...`, `go run . status --project .`, `go run . check --project .`, `git diff --check`

## Release Notes

- User-facing change: `plan` now reports a spec-first active model, supports `plan spec execute` and `plan spec initiative`, and can archive legacy epic/story work into `.plan/archive/`.
- Planning or workflow impact: active execution now flows from approved specs into ephemeral slices and commit-per-slice work, while lightweight initiatives can map to GitHub milestones.
- Follow-up work: remove more legacy epic/story command paths after downstream repo workflows finish migrating.

## Planning

- Related idea/planning documents: #38
- Closes #38
- Closes #42
- Closes #43
- Closes #44
