### PR TITLE
docs: define backend-flexible source-of-truth modes

### DIFF
--- a/.plan/PROJECT.md
+++ b/.plan/PROJECT.md
@@ -4,7 +4,8 @@ Created: 2026-04-16T05:33:06Z
 
 ## Vision
 
-Build the best local-first planning tool for AI-assisted software projects.
+Build the best default-local, backend-flexible planning tool for AI-assisted
+software projects.
 
 `plan` should help indie developers and small teams turn rough ideas into
 shaped, execution-ready specs and stories without PM theater, cloud lock-in, or
@@ -12,7 +13,8 @@ memory/context-management bloat.
 
 ## Principles
 
-- Local-first and markdown-first.
+- Local-first by default, backend-flexible by design.
+- Markdown-first where local planning is the chosen source of truth.
 - Planning only.
 - Specs are the contract.
 - Simple default flow, deeper shaping later.
@@ -20,10 +22,14 @@ memory/context-management bloat.
 
 ## Constraints
 
-- All durable planning material lives in `.plan/`.
+- `.plan/` is the default local planning store, not the only possible durable
+  source of truth.
+- `plan` must support explicit source-of-truth modes: `local`, `github`, and
+  `hybrid`.
 - No hosted dependency is required for core workflows.
 - No issue-tracker clone behavior in the planning core.
-- External sync is later than local refinement quality.
+- Local quality still sets the bar, but external backends may own persistent
+  planning data when configured.
 - This repo uses Gitflow with `develop` as the active integration branch,
   `release/vX.Y.Z` as the release stabilization branch, and `main` as the
   release-only production branch.
@@ -31,13 +37,18 @@ memory/context-management bloat.
 
 ## Planning Rules
 
-- Brainstorm is discovery, not a canonical hierarchy level.
+- Brainstorm is a session, not a canonical hierarchy level.
+- Persistent planning data can live locally or in integrations depending on the
+  configured backend and ownership model.
+- Ownership by planning layer must be explicit when using `github` or `hybrid`
+  mode.
 - Specs are the canonical execution contract.
 - Stories are created only after spec approval.
 - Stories should be execution-ready and verification-aware.
 - New passes should improve clarity, boundedness, and agent executability.
-- If GitHub story mode is enabled, stories live in GitHub Issues rather than
-  local markdown notes.
+- GitHub is the first external planning backend being actively shaped.
+- Current GitHub implementations can be narrower than the target architecture,
+  but the product direction is intentionally backend-flexible.
 - GitHub execution follows a queue loop: establish ready work, grab the next
   issue or issues, ship a PR, review until ready, squash-merge into
   `develop`, refresh local `develop` from `origin/develop`, run `plan update`,
@@ -59,5 +70,6 @@ memory/context-management bloat.
 - v4 focuses on refinement and simplification.
 - v5 focuses on skill quality, shaping, and evals.
 - v6 focuses on story slicing and critique.
-- v7 is GitHub sync only if local planning quality clearly earns the added complexity.
+- v7 expands `plan` beyond local-only assumptions while preserving the local
+  default.
 - v8 focuses on guided co-planning and stage-by-stage execution handoffs.

--- a/.plan/ROADMAP.md
+++ b/.plan/ROADMAP.md
@@ -6,8 +6,8 @@ Created: 2026-04-17T00:00:00Z
 
 `plan` is resetting around planning refinement rather than older power-first
 local workflows. The next few product phases focus on shaping quality, better
-prompts and evals, and stronger execution-readiness before any external sync is
-considered.
+prompts and evals, stronger execution-readiness, and then explicit
+source-of-truth flexibility beyond the default local backend.
 
 ## v4: Planning Refinement Foundation
 
@@ -59,18 +59,21 @@ Summary:
 - add `plan story critique`
 - keep the default path small while making optional story quality passes stronger
 
-## v7: External Sync, Only If Still Needed
+## v7: Backend Flexibility and GitHub Integration
 
-Goal: Connect outward only after the local shaping loop is clearly excellent.
+Goal: Expand beyond local-only assumptions without losing the simple local
+default.
 
-- [ ] GitHub Story Backend and Preflight
-- [ ] Issue Contract and Planning Link Lifecycle
-- [ ] Dependency-Aware Issue Readiness
+- [ ] Source-of-Truth Backends and Ownership Model
+- [ ] GitHub Planning Surfaces and Workflow Modeling
+- [ ] GitHub-Backed Planning and Execution Loops
 
 Summary:
-- keep brainstorms, epics, and specs canonical in `.plan`
-- let GitHub Issues serve as the execution backend for stories when GitHub mode is enabled
-- derive blocked and ready work from planning-merge state plus issue dependencies
+- keep `local` as the default mode, not the only mode
+- support explicit `local`, `github`, and `hybrid` source-of-truth backends
+- make planning-layer ownership explicit instead of assuming `.plan/` always
+  owns every durable artifact
+- use GitHub as the first serious external planning backend
 
 ## v8: Guided Co-Planning System
 
@@ -93,7 +96,8 @@ Summary:
 - fix the product story before adding more product surface
 - benchmark quality improvements before stacking more passes
 - keep the default path simple even as optional shaping modes deepen
-- do not revive older power-first local workflow features without clear eval wins
+- backend flexibility should preserve simple local defaults and explicit
+  ownership boundaries
 
 ## Parking Lot
 

--- a/README.md
+++ b/README.md
@@ -1,17 +1,17 @@
 # plan
 
-`plan` is a local-first planning CLI for AI-assisted software work.
+`plan` is a local-first-by-default, backend-flexible planning CLI for
+AI-assisted software work.
 
-It keeps planning material in `.plan/` and focuses on one job: turning rough
-ideas into shaped, execution-ready plans that agents can follow cleanly.
-
-If GitHub execution mode is enabled, active planning stays local in `.plan/`
-while GitHub Issues can still carry legacy execution stories during the
-transition.
+It focuses on one job: turning rough ideas into shaped, execution-ready plans
+that agents can follow cleanly. `.plan/` is the default local workspace, but
+configured integrations can own persistent planning data in `github` or
+`hybrid` modes.
 
 ## Philosophy
 
 - local-first
+- backend-flexible
 - markdown-first
 - planning only
 - simple default workflow
@@ -62,7 +62,26 @@ Execution loop:
 The default path stays small. New shaping passes should improve the same
 artifacts rather than add new top-level planning objects.
 
-## Workspace
+## Source Of Truth Modes
+
+`plan` now treats source-of-truth choice as an explicit part of the product
+model.
+
+- `local`: durable planning data lives in `.plan/`
+- `github`: durable planning data can live in GitHub issues, projects, and
+  milestones
+- `hybrid`: ownership is split across `.plan/` and integrations
+
+Rules:
+
+- local remains the default
+- brainstorm is a session, not a durable hierarchy layer
+- persistent planning data may live locally or in integrations
+- ownership must be explicit by planning layer
+- today, local is the most complete backend and GitHub is the first external
+  backend being actively shaped
+
+## Default Local Workspace
 
 ```text
 my-project/
@@ -79,7 +98,7 @@ my-project/
       github.json
 ```
 
-User-authored planning material lives in:
+When local owns those planning layers, user-authored material lives in:
 
 - `.plan/PROJECT.md`
 - `.plan/ROADMAP.md`
@@ -88,15 +107,19 @@ User-authored planning material lives in:
 - `.plan/archive/` for preserved legacy material
 - `.plan/specs/`
 
-Tool-owned state lives only in:
+Tool-owned local integration state lives only in:
 
 - `.plan/.meta/workspace.json`
 - `.plan/.meta/migrations.json`
-- `.plan/.meta/github.json` when GitHub story mode is enabled
+- `.plan/.meta/github.json` when GitHub integration is enabled
 
 `plan update` may repair or normalize tool-owned state. Use
 `plan update --archive-legacy` to move legacy `epics/` and `stories/` into
 `.plan/archive/` without mutating the active spec-first surfaces.
+
+In `github` or `hybrid` modes, persistent planning data may also live outside
+the repo while `.plan/.meta/` keeps local integration state and migration
+metadata.
 
 ## Quick Start
 
@@ -168,7 +191,7 @@ Rules:
 - in this repo, normal work targets `develop`
 - work on a feature branch, not on `develop`, `release/*`, or `main`
 - open one PR after the queued specs for that branch are complete
-- if GitHub story mode is enabled, run
+- if GitHub integration is enabled, run
   `./scripts/refresh-plan-develop-context.sh` after merge before taking more
   queue work
 
@@ -248,8 +271,9 @@ That script:
 - installs the repo-local Brain skill for Codex at `.codex/skills/brain`
 - leaves Brain optional when the repo does not contain a `.brain/` workspace
 
-`plan` remains the planning source of truth. Brain is only for context,
-retrieval, and session hygiene when present.
+`plan` remains the planning control plane. Depending on the configured backend,
+durable planning truth may live in `.plan/`, GitHub, or both. Brain is only
+for context, retrieval, and session hygiene when present.
 
 ## Evaluating Prompt And Workflow Changes
 

--- a/docs/project-workflows.md
+++ b/docs/project-workflows.md
@@ -44,6 +44,8 @@ Use this file for agent operating workflow inside the repo.
 
 ### Project Override: Spec Queue Loop
 
+- Respect the configured source-of-truth backend. `.plan/` is the default local
+  store, but `github` or `hybrid` mode may own some persistent planning data.
 - Establish queue with `plan status --project .`.
 - Take the next approved spec, not the next individual issue.
 - Run `plan spec execute --project . <spec-slug>` to start execution from the current approved spec.

--- a/docs/using-plan.md
+++ b/docs/using-plan.md
@@ -10,24 +10,29 @@ ideas.
 Right now:
 
 - the active planning model is spec-first
+- source-of-truth backends can be `local`, `github`, or `hybrid`
 - brainstorms stay local and can bloom into idea docs or specs
 - `initiative` is lightweight optional grouping metadata
 - `plan spec execute` is the active execution entry point
 - legacy `epic` and `story` commands still exist during the transition
-- GitHub-backed issue execution remains available when you enable GitHub mode
+- GitHub integration is the first external backend being actively shaped
 
 The top of this guide reflects the active spec-first model. Some later sections
 still document legacy compatibility commands while the migration is in flight.
 
 ## What `plan` Is
 
-`plan` is a local-first planning CLI for software projects.
+`plan` is a local-first-by-default, backend-flexible planning CLI for software
+projects.
 
-It stores planning material in `.plan/` and focuses on one job:
+It focuses on one job:
 
 - turn rough ideas into shaped planning artifacts
 - make specs stronger before implementation starts
 - guide execution from approved specs without persisting tiny slice artifacts
+
+`.plan/` is the default local workspace, but configured integrations can own
+persistent planning data in `github` or `hybrid` modes.
 
 `plan` does not handle memory, retrieval, or context management.
 
@@ -60,9 +65,28 @@ Workflow entry:
 8. `Start spec execution`
 9. `Work slices one commit at a time`
 
-## Workspace Layout
+## Source Of Truth Modes
 
-`plan` keeps its durable planning material under `.plan/`:
+`plan` now supports three source-of-truth modes:
+
+- `local`: durable planning data lives in `.plan/`
+- `github`: durable planning data can live in GitHub issues, projects, and
+  milestones
+- `hybrid`: ownership is split across `.plan/` and integrations
+
+Rules:
+
+- local is still the default
+- brainstorm is a session, not a durable hierarchy layer
+- persistent planning data may live locally or in integrations
+- ownership must be explicit by planning layer
+- today, local is the most complete shipped backend and GitHub is the first
+  external backend being actively shaped
+
+## Default Local Workspace Layout
+
+When local owns those planning layers, `plan` keeps durable material under
+`.plan/`:
 
 ```text
 .plan/
@@ -87,6 +111,10 @@ Meaning:
 - `archive/`: preserved legacy epic/story-era planning material
 - `specs/`: canonical execution contracts
 - `.meta/`: tool-owned state only, including GitHub story metadata when enabled
+
+In `github` or `hybrid` modes, persistent planning data may also live outside
+the repo while `.plan/.meta/` keeps local integration state and migration
+metadata.
 
 ## New Repo Setup
 
@@ -123,10 +151,9 @@ plan adopt --project .
 plan doctor --project .
 ```
 
-## Optional: Enable GitHub Story Mode
+## Optional: Enable GitHub Integration
 
-If you want local planning but GitHub-backed issue execution during the
-transition:
+If you want to shape work with GitHub as part of the source-of-truth model:
 
 ```bash
 plan update --project .
@@ -140,7 +167,11 @@ Preconditions:
 - the repo has GitHub Issues enabled
 - local story notes are not still active in `.plan/stories/`
 
-When GitHub story mode is enabled:
+Current shipped GitHub support is still strongest around issue-backed execution
+stories and milestone mapping. Broader GitHub ownership is an active design
+direction, not a fully finished backend yet.
+
+When the current GitHub backend is enabled:
 
 - execution stories are created as GitHub Issues
 - `.plan/.meta/github.json` becomes the local issue-state index

--- a/skills/plan/SKILL.md
+++ b/skills/plan/SKILL.md
@@ -10,11 +10,13 @@ args:
 
 # Plan
 
-Use `plan` as the primary interface for repo-local planning.
+Use `plan` as the primary interface for project planning, while respecting the
+configured source-of-truth backend.
 
 ## Goals
 
-- keep planning local to the repo
+- keep local planning as the default while respecting `github` and `hybrid`
+  source-of-truth modes when configured
 - treat specs as the canonical execution contract
 - improve the quality of brainstorms and specs before implementation starts
 - use lightweight initiative metadata when multiple specs belong together
@@ -28,7 +30,8 @@ When a repo uses `plan`:
 1. Read `.plan/PROJECT.md`.
 2. Read `.plan/ROADMAP.md`.
 3. Read the brainstorm, idea, spec, and legacy compatibility notes relevant to the task.
-4. Use the `plan` CLI for durable planning changes.
+4. If the project is using `github` or `hybrid` ownership for durable planning data, inspect the linked GitHub issue, project, or milestone state too.
+5. Use the `plan` CLI for durable planning changes and keep backend ownership explicit.
 
 ## Commands
 
@@ -58,6 +61,8 @@ When a repo uses `plan`:
 
 - Brainstorms are discovery material, not the canonical hierarchy.
 - Active model is `Brainstorm -> Idea Doc (optional) -> Spec`, with runtime slices during execution.
+- Local is the default backend, not the only backend.
+- Do not assume every durable planning artifact lives in `.plan/`; respect explicit ownership by planning layer.
 - `brainstorm refine` should reduce ambiguity before promotion.
 - `brainstorm challenge` should pressure-test risk, no-gos, and overengineering before promotion.
 - `epic shape` is now a legacy compatibility pass, not the preferred active model.
@@ -105,9 +110,11 @@ Use the smallest pass that resolves the current planning gap:
 - optional rigor must not make the default path ceremonial
 - every recommendation should improve clarity, boundedness, verification, or executability
 - active execution should stay traceable from spec -> slices -> commits -> PR
+- when backend ownership is split, the agent should preserve that split instead of silently moving truth back into `.plan/`
 
 ## Ambiguity Handling
 
 - if the next shaping pass is obvious, run it
 - if two passes could apply, choose the lighter one first
+- if backend ownership is unclear, inspect project rules and current GitHub state before editing durable planning artifacts
 - do not turn `plan` into memory, context, or execution orchestration


### PR DESCRIPTION
## Summary
- update the repo contract from local-only planning assumptions to explicit `local`, `github`, and `hybrid` source-of-truth modes
- keep local as the default while making GitHub the first serious external backend being actively shaped
- clarify across docs and skill guidance that ownership must be explicit by planning layer instead of assuming `.plan/` always owns every durable artifact

## Testing
- `git diff --check`
- `go test ./...`
- `go build ./...`

## Release Notes
Docs: clarify that `plan` is local-first by default, but now intentionally backend-flexible with explicit `local`, `github`, and `hybrid` source-of-truth modes.

## Planning
Related idea/planning documents: #38, #39, #40
