### PR TITLE
feat: ship guide packet v1

### DIFF
--- a/.plan/research/guide-packet-schema-and-cli-design.md
+++ b/.plan/research/guide-packet-schema-and-cli-design.md
@@ -43,7 +43,8 @@ The right split is:
 ## Terms
 
 - guide packet: machine-readable stage contract emitted by `plan`
-- stage: one of `brainstorm`, `epic`, `spec`, `stories`
+- stage: runtime planning step, with brainstorm shipped first and later stages
+  extending toward initiative/spec/execution guidance
 - checkpoint: stage-local step such as `vision-intake` or
   `clarify-constraints-appetite`
 - family overlay: optional style layer such as `gpt_style` or
@@ -78,15 +79,13 @@ Behavior:
 - reads `.plan/.meta/guided_sessions.json`
 - resolves `last_active_chain`
 - builds a packet from current stage, checkpoint, session summary, linked
-  artifact, workspace rules, and optional family overlay
+  artifact, and workspace rules
 - does not mutate session state
 
 Flags:
 
-- `--format json|md|text`
+- `--format json`
   - default: `json`
-- `--family base|gpt_style|reasoning_heavy`
-  - default: `base`
 
 Errors:
 
@@ -117,23 +116,20 @@ plan guide show \
 Behavior:
 
 - reads the requested chain
-- uses explicit stage/checkpoint if provided
-- otherwise falls back to session current stage/checkpoint
-- supports previewing a packet even when the caller wants a stage other than the
-  current active stage
+- uses explicit checkpoint if provided
+- falls back to session current stage/checkpoint when omitted
+- currently supports brainstorm-stage preview only
 
 Flags:
 
 - `--chain <chain-id>`
   - required
-- `--stage brainstorm|epic|spec|stories`
-  - optional if session already has a current stage
+- `--stage brainstorm`
+  - optional today; any non-brainstorm value is rejected in v1
 - `--checkpoint <label>`
   - optional
-- `--format json|md|text`
+- `--format json`
   - default: `json`
-- `--family base|gpt_style|reasoning_heavy`
-  - default: `base`
 
 Errors:
 
@@ -149,28 +145,11 @@ Exit codes:
 ### `plan guide schema`
 
 Purpose:
-- emit the JSON Schema for the guide packet
+- future follow-up for emitting the JSON Schema for the guide packet
 
-Command:
+Status:
 
-```bash
-plan guide schema --format json
-```
-
-Behavior:
-
-- emits the current packet schema definition
-- intended for tests, external integrations, and agent-runtime validation
-
-Flags:
-
-- `--format json`
-  - default and only supported value in v1
-
-Exit codes:
-
-- `0` success
-- `2` usage errors
+- intentionally deferred from the shipped v1 slice
 
 ## Packet Schema V1
 
@@ -183,7 +162,7 @@ Canonical packet shape:
   "generated_at": "2026-04-21T12:00:00Z",
   "builder": {
     "command": "plan guide current",
-    "family": "gpt_style"
+    "format": "json"
   },
   "workspace": {
     "project_root": "/home/jimmy/Projects/plan",
@@ -200,7 +179,7 @@ Canonical packet shape:
       "brainstorm": "in_progress",
       "epic": "todo",
       "spec": "todo",
-      "stories": "todo"
+      "execution": "todo"
     },
     "summary": "Vision captured. Supporting material recorded.",
     "next_action": "Continue with open questions and candidate approaches."
@@ -255,7 +234,7 @@ Canonical packet shape:
       ],
       "preserve_rules": [
         "User input first",
-        "Do not draft epic/spec/story content during brainstorm stage"
+        "Do not draft spec content or execution slices during brainstorm stage"
       ]
     },
     "do": [
@@ -274,7 +253,7 @@ Canonical packet shape:
       "Open questions are blocker-shaped, not vague brainstorming sprawl."
     ],
     "completion_gate": [
-      "The brainstorm can promote into an epic without hidden assumptions.",
+      "The brainstorm can move into the next durable planning step without hidden assumptions.",
       "The recommended next stage is clear."
     ],
     "command_hints": [
@@ -331,8 +310,8 @@ Canonical packet shape:
 
 - `command`
   - source command such as `plan guide current`
-- `family`
-  - `base`, `gpt_style`, or `reasoning_heavy`
+- `format`
+  - currently `json`
 
 ### `workspace`
 
@@ -373,7 +352,8 @@ This should map cleanly onto current fields in
 ### `mode`
 
 - `stage`
-  - `brainstorm`, `epic`, `spec`, `stories`
+  - `brainstorm` today; later follow-up work may add initiative/spec/execution
+    stages
 - `checkpoint`
   - stage-local checkpoint label
 - `pass`
@@ -381,12 +361,9 @@ This should map cleanly onto current fields in
     - `brainstorm_start`
     - `brainstorm_refine`
     - `brainstorm_challenge`
-    - `epic_shape`
-    - `spec_analyze`
-    - `spec_checklist`
-    - `story_slice`
-    - `story_critique`
-    - `handoff`
+    - `brainstorm_intake`
+    - `brainstorm_refine`
+    - `brainstorm_handoff`
 
 ### `contract`
 
@@ -433,6 +410,9 @@ For brainstorm v1:
 - `clarify-constraints-appetite`
 - `clarify-open-approaches`
 - `handoff-epic`
+  - legacy checkpoint id retained for compatibility; semantically this is the
+    handoff where guide packet guidance decides whether the work should stay one
+    bounded spec or split into multiple specs under one initiative
 
 For later stages:
 
@@ -441,6 +421,8 @@ For later stages:
 - prefer descriptive ids over display text
 
 ## Markdown Rendering Contract
+
+Deferred follow-up, not part of the shipped v1 slice.
 
 `--format md` should render:
 
@@ -457,6 +439,8 @@ For later stages:
 This keeps one human-debug view without inventing a second schema.
 
 ## Text Rendering Contract
+
+Deferred follow-up, not part of the shipped v1 slice.
 
 `--format text` should be concise and terminal-friendly:
 
@@ -491,11 +475,10 @@ plan guide show \
   --chain brainstorm/billing-export \
   --stage brainstorm \
   --checkpoint clarify-open-approaches \
-  --family reasoning_heavy \
-  --format md
+  --format json
 ```
 
-Schema export:
+Deferred schema export:
 
 ```bash
 plan guide schema --format json
@@ -509,11 +492,6 @@ JSON mode:
 - emit no partial JSON to stdout
 - return exit code `2`
 
-Markdown and text mode:
-
-- print concise error
-- print one next-best-action hint when possible
-
 Examples:
 
 - no active session:
@@ -521,7 +499,7 @@ Examples:
 - unknown chain:
   - `Guided session "brainstorm/foo" not found.`
 - unsupported stage:
-  - `Unsupported guide stage "release". Expected brainstorm, epic, spec, or stories.`
+  - `Unsupported guide stage "release". Expected brainstorm, initiative, spec, or execution.`
 
 ## Integration With Existing Skill
 
@@ -559,5 +537,5 @@ If this direction holds:
 
 1. add `plan guide current|show|schema`
 2. build brainstorm-stage packet first
-3. convert `skills/plan/agents/*.yaml` into family overlays for packet building
+3. decide whether model-family overlays are worth adding later
 4. update installed `plan` skill to use guide packets instead of static stage prose

--- a/.plan/research/guide-packet-schema-and-cli-design.md
+++ b/.plan/research/guide-packet-schema-and-cli-design.md
@@ -499,7 +499,7 @@ Examples:
 - unknown chain:
   - `Guided session "brainstorm/foo" not found.`
 - unsupported stage:
-  - `Unsupported guide stage "release". Expected brainstorm, initiative, spec, or execution.`
+  - `Unsupported guide stage "release". Expected brainstorm.`
 
 ## Integration With Existing Skill
 

--- a/.plan/specs/guide-packet-and-cli-foundation.md
+++ b/.plan/specs/guide-packet-and-cli-foundation.md
@@ -1,6 +1,5 @@
 ---
 created_at: "2026-04-21T06:36:20Z"
-epic: guide-packet-and-cli-foundation
 project: plan
 slug: guide-packet-and-cli-foundation
 status: approved
@@ -39,7 +38,7 @@ planning state.
 
 - direct model API calls from `plan`
 - installed per-agent personas as the primary runtime interface
-- full guide coverage for epic, spec, or story stages
+- full guide coverage for initiative, spec, or execution stages
 - markdown or text guide rendering in the first slice
 - automatic consumption by Codex, Claude, or other runtimes in the same scope
 - schema export command in the first slice
@@ -55,6 +54,8 @@ planning state.
 - actionable error text should exist when there is no active guided session
 - the brainstorm note remains the durable artifact; guide packets are runtime
   contracts, not new planning documents
+- the brainstorm handoff checkpoint must allow either a single-spec next step or
+  a multi-spec initiative when the work is larger
 
 ## Solution Shape
 
@@ -83,7 +84,9 @@ planning state.
   - `clarify-problem-user-value`
   - `clarify-constraints-appetite`
   - `clarify-open-approaches`
-  - `handoff-epic`
+  - `handoff-epic` (legacy checkpoint id retained for compatibility while the
+    decision itself now chooses between a single-spec path and a larger
+    multi-spec initiative)
 
 ## Flows
 
@@ -92,9 +95,11 @@ planning state.
 3. `plan` reads the last-active guided session and linked brainstorm note.
 4. `plan` returns a JSON guide packet for the current brainstorm checkpoint.
 5. The agent uses the packet contract to guide the next user interaction.
-6. If the runtime needs an explicit preview instead of the active session, it
+6. At the brainstorm handoff checkpoint, the packet guidance makes the
+   single-spec vs multi-spec decision explicit based on the size of the work.
+7. If the runtime needs an explicit preview instead of the active session, it
    calls `plan guide show --chain ... --stage brainstorm --checkpoint ...`.
-7. `plan` returns the requested packet without mutating the session.
+8. `plan` returns the requested packet without mutating the session.
 
 ## Data / Interfaces
 
@@ -111,8 +116,8 @@ planning state.
   - `artifact`: type, slug, title, path, status
   - `mode`: stage, checkpoint, pass
   - `sources`: supporting local files used to shape the packet
-  - `contract`: role, goal, question strategy, artifact strategy, do, avoid,
-    quality bar, completion gate, command hints
+  - `contract`: role, stance, goal, question strategy, artifact strategy, do,
+    avoid, quality bar, completion gate, command hints
   - `rendered_prompt`: derived prompt string
 - initial supported format:
   - `json`
@@ -161,7 +166,7 @@ Reference design source:
 - brainstorm checkpoint ids in the packet match current guided brainstorm
   cluster labels
 
-## Story Breakdown
+## Implementation Slices
 
 - Add guide packet types and brainstorm-stage packet builder
 - Add `plan guide current` JSON command
@@ -204,7 +209,6 @@ guidance_findings: 0
 - [ok] No findings.
 ## Resources
 
-- [Epic](../epics/guide-packet-and-cli-foundation.md)
 - [Research: Guide Packet Schema and CLI Design](../research/guide-packet-schema-and-cli-design.md)
 - [Guided Session Engine and Resume Spec](../specs/guided-session-engine-and-resume.md)
 - [Vision Intake and Brainstorm Co-Planning Spec](../specs/vision-intake-and-brainstorm-co-planning.md)
@@ -216,3 +220,7 @@ guidance_findings: 0
 Recommendation locked during planning: use installed skills as bootstrap only,
 and make live guide packets the runtime source of truth for guided agent
 behavior.
+
+Current implementation choice: guide packet shipped as one bounded spec on one
+branch. If the feature grows later, a multi-spec initiative remains valid, but
+it is not required for the current slice.

--- a/README.md
+++ b/README.md
@@ -151,6 +151,7 @@ Full guide:
 - `plan update`
 - `plan brainstorm start|idea|show|refine`
 - `plan brainstorm challenge`
+- `plan guide current|show`
 - `plan epic create|promote|list|show|shape` for legacy compatibility during migration
 - `plan spec show|edit|status|analyze|checklist|initiative|execute|handoff`
 - `plan story create|update|list|show|slice|critique` for legacy compatibility during migration

--- a/cmd/guide.go
+++ b/cmd/guide.go
@@ -1,0 +1,67 @@
+package cmd
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/spf13/cobra"
+)
+
+func newGuideCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "guide",
+		Short: "Render live guide packets for guided planning stages",
+	}
+
+	var currentFormat string
+	current := &cobra.Command{
+		Use:   "current",
+		Short: "Render the guide packet for the last-active guided session",
+		Args:  cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			packet, err := planningManager().CurrentGuidePacket()
+			if err != nil {
+				return err
+			}
+			return writeGuidePacket(cmd, currentFormat, packet)
+		},
+	}
+	current.Flags().StringVar(&currentFormat, "format", "json", "output format: json")
+
+	var (
+		showFormat     string
+		showChain      string
+		showStage      string
+		showCheckpoint string
+	)
+	show := &cobra.Command{
+		Use:   "show",
+		Short: "Render the guide packet for an explicit guided session chain",
+		Args:  cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			packet, err := planningManager().GuidePacketForChain(showChain, showStage, showCheckpoint)
+			if err != nil {
+				return err
+			}
+			return writeGuidePacket(cmd, showFormat, packet)
+		},
+	}
+	show.Flags().StringVar(&showChain, "chain", "", "guided session chain id, such as brainstorm/my-topic")
+	show.Flags().StringVar(&showStage, "stage", "", "explicit stage override")
+	show.Flags().StringVar(&showCheckpoint, "checkpoint", "", "explicit checkpoint override")
+	show.Flags().StringVar(&showFormat, "format", "json", "output format: json")
+	_ = show.MarkFlagRequired("chain")
+
+	cmd.AddCommand(current, show)
+	return cmd
+}
+
+func writeGuidePacket(cmd *cobra.Command, format string, packet any) error {
+	if strings.TrimSpace(format) != "json" {
+		return fmt.Errorf("unsupported guide output format %q; only json is supported in v1", format)
+	}
+	encoder := json.NewEncoder(cmd.OutOrStdout())
+	encoder.SetIndent("", "  ")
+	return encoder.Encode(packet)
+}

--- a/cmd/guide_test.go
+++ b/cmd/guide_test.go
@@ -32,11 +32,17 @@ func TestGuideCurrentCommandEmitsJSONForActiveSession(t *testing.T) {
 	if packet["kind"] != "guide_packet" {
 		t.Fatalf("expected guide packet kind, got %#v", packet["kind"])
 	}
-	session := packet["session"].(map[string]any)
+	session, ok := packet["session"].(map[string]any)
+	if !ok {
+		t.Fatalf("expected packet.session to be an object, got %#v", packet["session"])
+	}
 	if session["chain_id"] != "brainstorm/guide-packet-foundation" {
 		t.Fatalf("unexpected chain id in packet: %#v", session)
 	}
-	mode := packet["mode"].(map[string]any)
+	mode, ok := packet["mode"].(map[string]any)
+	if !ok {
+		t.Fatalf("expected packet.mode to be an object, got %#v", packet["mode"])
+	}
 	if mode["stage"] != "brainstorm" {
 		t.Fatalf("expected brainstorm stage: %#v", mode)
 	}
@@ -87,9 +93,19 @@ func TestGuideShowCommandEmitsJSONForExplicitChainAndCheckpoint(t *testing.T) {
 	if err := json.Unmarshal(output.Bytes(), &packet); err != nil {
 		t.Fatalf("expected valid JSON output: %v\n%s", err, output.String())
 	}
-	mode := packet["mode"].(map[string]any)
+	mode, ok := packet["mode"].(map[string]any)
+	if !ok {
+		t.Fatalf("expected packet.mode to be an object, got %#v", packet["mode"])
+	}
 	if mode["checkpoint"] != "clarify-open-approaches" {
 		t.Fatalf("expected explicit checkpoint override, got %#v", mode)
+	}
+	session, ok := packet["session"].(map[string]any)
+	if !ok {
+		t.Fatalf("expected packet.session to be an object, got %#v", packet["session"])
+	}
+	if session["current_cluster_label"] != "clarify-open-approaches" {
+		t.Fatalf("expected session checkpoint to match preview override, got %#v", session)
 	}
 }
 

--- a/cmd/guide_test.go
+++ b/cmd/guide_test.go
@@ -1,0 +1,204 @@
+package cmd
+
+import (
+	"bytes"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"plan/internal/planning"
+	"plan/internal/workspace"
+)
+
+func TestGuideCurrentCommandEmitsJSONForActiveSession(t *testing.T) {
+	root := t.TempDir()
+	setupGuidePacketFixture(t, root)
+
+	var output bytes.Buffer
+	command := newRootCmd()
+	command.SetOut(&output)
+	command.SetErr(&output)
+	command.SetArgs([]string{"--project", root, "guide", "current", "--format", "json"})
+	if err := command.Execute(); err != nil {
+		t.Fatalf("expected guide current to succeed: %v", err)
+	}
+
+	var packet map[string]any
+	if err := json.Unmarshal(output.Bytes(), &packet); err != nil {
+		t.Fatalf("expected valid JSON output: %v\n%s", err, output.String())
+	}
+	if packet["kind"] != "guide_packet" {
+		t.Fatalf("expected guide packet kind, got %#v", packet["kind"])
+	}
+	session := packet["session"].(map[string]any)
+	if session["chain_id"] != "brainstorm/guide-packet-foundation" {
+		t.Fatalf("unexpected chain id in packet: %#v", session)
+	}
+	mode := packet["mode"].(map[string]any)
+	if mode["stage"] != "brainstorm" {
+		t.Fatalf("expected brainstorm stage: %#v", mode)
+	}
+}
+
+func TestGuideCurrentCommandReturnsActionableErrorWithoutActiveSession(t *testing.T) {
+	root := t.TempDir()
+	ws := workspace.New(root)
+	if _, err := ws.Init(); err != nil {
+		t.Fatal(err)
+	}
+
+	var output bytes.Buffer
+	command := newRootCmd()
+	command.SetOut(&output)
+	command.SetErr(&output)
+	command.SetArgs([]string{"--project", root, "guide", "current", "--format", "json"})
+	err := command.Execute()
+	if err == nil {
+		t.Fatal("expected guide current to fail without an active session")
+	}
+	if !strings.Contains(err.Error(), "no active guided session") {
+		t.Fatalf("expected actionable missing-session error, got %v", err)
+	}
+}
+
+func TestGuideShowCommandEmitsJSONForExplicitChainAndCheckpoint(t *testing.T) {
+	root := t.TempDir()
+	setupGuidePacketFixture(t, root)
+
+	var output bytes.Buffer
+	command := newRootCmd()
+	command.SetOut(&output)
+	command.SetErr(&output)
+	command.SetArgs([]string{
+		"--project", root,
+		"guide", "show",
+		"--chain", "brainstorm/guide-packet-foundation",
+		"--stage", "brainstorm",
+		"--checkpoint", "clarify-open-approaches",
+		"--format", "json",
+	})
+	if err := command.Execute(); err != nil {
+		t.Fatalf("expected guide show to succeed: %v", err)
+	}
+
+	var packet map[string]any
+	if err := json.Unmarshal(output.Bytes(), &packet); err != nil {
+		t.Fatalf("expected valid JSON output: %v\n%s", err, output.String())
+	}
+	mode := packet["mode"].(map[string]any)
+	if mode["checkpoint"] != "clarify-open-approaches" {
+		t.Fatalf("expected explicit checkpoint override, got %#v", mode)
+	}
+}
+
+func TestGuideShowCommandRejectsUnsupportedStage(t *testing.T) {
+	root := t.TempDir()
+	setupGuidePacketFixture(t, root)
+
+	command := newRootCmd()
+	command.SetArgs([]string{
+		"--project", root,
+		"guide", "show",
+		"--chain", "brainstorm/guide-packet-foundation",
+		"--stage", "execution",
+		"--format", "json",
+	})
+	err := command.Execute()
+	if err == nil {
+		t.Fatal("expected guide show to fail for unsupported stage")
+	}
+	if !strings.Contains(err.Error(), "only support the brainstorm stage") {
+		t.Fatalf("expected unsupported-stage error, got %v", err)
+	}
+}
+
+func TestGuideShowCommandFailsForUnknownChain(t *testing.T) {
+	root := t.TempDir()
+	setupGuidePacketFixture(t, root)
+
+	command := newRootCmd()
+	command.SetArgs([]string{
+		"--project", root,
+		"guide", "show",
+		"--chain", "brainstorm/missing",
+		"--format", "json",
+	})
+	err := command.Execute()
+	if err == nil {
+		t.Fatal("expected guide show to fail for an unknown chain")
+	}
+	if !strings.Contains(err.Error(), "not found") {
+		t.Fatalf("expected unknown-chain error, got %v", err)
+	}
+}
+
+func TestGuideShowCommandRejectsUnsupportedCheckpoint(t *testing.T) {
+	root := t.TempDir()
+	setupGuidePacketFixture(t, root)
+
+	command := newRootCmd()
+	command.SetArgs([]string{
+		"--project", root,
+		"guide", "show",
+		"--chain", "brainstorm/guide-packet-foundation",
+		"--stage", "brainstorm",
+		"--checkpoint", "unknown",
+		"--format", "json",
+	})
+	err := command.Execute()
+	if err == nil {
+		t.Fatal("expected guide show to fail for unsupported checkpoint")
+	}
+	if !strings.Contains(err.Error(), "unsupported brainstorm checkpoint") {
+		t.Fatalf("expected unsupported-checkpoint error, got %v", err)
+	}
+}
+
+func TestGuideCurrentCommandRejectsNonJSONFormat(t *testing.T) {
+	root := t.TempDir()
+	setupGuidePacketFixture(t, root)
+
+	command := newRootCmd()
+	command.SetArgs([]string{"--project", root, "guide", "current", "--format", "md"})
+	err := command.Execute()
+	if err == nil {
+		t.Fatal("expected guide current to reject non-json formats")
+	}
+	if !strings.Contains(err.Error(), "only json is supported in v1") {
+		t.Fatalf("expected format error, got %v", err)
+	}
+}
+
+func setupGuidePacketFixture(t *testing.T, root string) {
+	t.Helper()
+	ws := workspace.New(root)
+	if _, err := ws.Init(); err != nil {
+		t.Fatal(err)
+	}
+	state, err := ws.ReadGitHubState()
+	if err != nil {
+		t.Fatal(err)
+	}
+	state.DefaultBranch = "develop"
+	if err := ws.WriteGitHubState(*state); err != nil {
+		t.Fatal(err)
+	}
+
+	manager := planning.New(ws)
+	if _, err := manager.CreateBrainstorm("Guide Packet Foundation"); err != nil {
+		t.Fatal(err)
+	}
+	if _, _, err := manager.UpdateGuidedBrainstormIntake("guide-packet-foundation", planning.GuidedBrainstormIntakeInput{
+		Vision:             "Give agents live guide packets instead of static stage prose.",
+		SupportingMaterial: "docs/guide-packet.md",
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	sessionsPath := filepath.Join(root, ".plan", ".meta", "guided_sessions.json")
+	if _, err := os.Stat(sessionsPath); err != nil {
+		t.Fatalf("expected guided sessions state to exist: %v", err)
+	}
+}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -22,6 +22,7 @@ func newRootCmd() *cobra.Command {
 		newDoctorCommand(),
 		newUpdateCommand(),
 		newBrainstormCommand(),
+		newGuideCommand(),
 		newEpicCommand(),
 		newSpecCommand(),
 		newStoryCommand(),

--- a/docs/using-plan.md
+++ b/docs/using-plan.md
@@ -14,6 +14,7 @@ Right now:
 - brainstorms stay local and can bloom into idea docs or specs
 - `initiative` is lightweight optional grouping metadata
 - `plan spec execute` is the active execution entry point
+- `plan guide current|show` emits live brainstorm-stage guide packets for agent runtimes
 - legacy `epic` and `story` commands still exist during the transition
 - GitHub integration is the first external backend being actively shaped
 
@@ -200,6 +201,13 @@ Show the brainstorm:
 
 ```bash
 plan brainstorm show --project . newsletter-system
+```
+
+If you are using an external agent during a guided brainstorm, ask `plan` for
+the live stage contract:
+
+```bash
+plan guide current --project . --format json
 ```
 
 ### 2. Refine the Brainstorm

--- a/internal/planning/guide_packet.go
+++ b/internal/planning/guide_packet.go
@@ -1,6 +1,7 @@
 package planning
 
 import (
+	"errors"
 	"fmt"
 	"path/filepath"
 	"sort"
@@ -112,8 +113,8 @@ type GuidePacketCommandHint struct {
 func (m *Manager) CurrentGuidePacket() (*GuidePacket, error) {
 	session, err := m.ReadLastActiveGuidedSession()
 	if err != nil {
-		if strings.Contains(err.Error(), "no active guided session") {
-			return nil, fmt.Errorf("no active guided session. Start one with `plan brainstorm start --project . \"<topic>\"`")
+		if errors.Is(err, ErrNoActiveGuidedSession) {
+			return nil, fmt.Errorf("no active guided session. Start one with `plan brainstorm start --project . \"<topic>\"`: %w", ErrNoActiveGuidedSession)
 		}
 		return nil, err
 	}
@@ -198,9 +199,9 @@ func (m *Manager) buildGuidePacket(command string, session *workspace.GuidedSess
 		},
 		Session: GuidePacketSession{
 			ChainID:             session.ChainID,
-			CurrentStage:        defaultString(session.CurrentStage, "brainstorm"),
-			CurrentCluster:      session.CurrentCluster,
-			CurrentClusterLabel: defaultString(session.CurrentClusterLabel, "vision-intake"),
+			CurrentStage:        effectiveStage,
+			CurrentCluster:      brainstormGuideCheckpointIndex(effectiveCheckpoint, session.CurrentCluster),
+			CurrentClusterLabel: effectiveCheckpoint,
 			StageStatuses:       copyStringMap(session.StageStatuses),
 			Summary:             strings.TrimSpace(session.Summary),
 			NextAction:          strings.TrimSpace(session.NextAction),
@@ -238,6 +239,26 @@ func brainstormGuidePass(checkpoint string) string {
 		return "brainstorm_handoff"
 	default:
 		return "brainstorm_refine"
+	}
+}
+
+func brainstormGuideCheckpointIndex(checkpoint string, fallback int) int {
+	switch checkpoint {
+	case "vision-intake":
+		return 1
+	case "clarify-problem-user-value":
+		return 2
+	case "clarify-constraints-appetite":
+		return 3
+	case "clarify-open-approaches":
+		return 4
+	case "handoff-epic":
+		return 5
+	default:
+		if fallback > 0 {
+			return fallback
+		}
+		return 1
 	}
 }
 

--- a/internal/planning/guide_packet.go
+++ b/internal/planning/guide_packet.go
@@ -1,0 +1,392 @@
+package planning
+
+import (
+	"fmt"
+	"path/filepath"
+	"sort"
+	"strings"
+	"time"
+
+	"plan/internal/notes"
+	"plan/internal/workspace"
+)
+
+const (
+	GuidePacketSchemaVersion = 1
+	guidePacketKind          = "guide_packet"
+	guidePlanningMode        = "guided"
+)
+
+var brainstormGuideCheckpoints = map[string]struct{}{
+	"vision-intake":                {},
+	"clarify-problem-user-value":   {},
+	"clarify-constraints-appetite": {},
+	"clarify-open-approaches":      {},
+	"handoff-epic":                 {},
+}
+
+type GuidePacket struct {
+	SchemaVersion  int                    `json:"schema_version"`
+	Kind           string                 `json:"kind"`
+	GeneratedAt    string                 `json:"generated_at"`
+	Builder        GuidePacketBuilderMeta `json:"builder"`
+	Workspace      GuidePacketWorkspace   `json:"workspace"`
+	Session        GuidePacketSession     `json:"session"`
+	Artifact       GuidePacketArtifact    `json:"artifact"`
+	Mode           GuidePacketMode        `json:"mode"`
+	Sources        []string               `json:"sources"`
+	Contract       GuidePacketContract    `json:"contract"`
+	RenderedPrompt string                 `json:"rendered_prompt"`
+}
+
+type GuidePacketBuilderMeta struct {
+	Command string `json:"command"`
+	Format  string `json:"format"`
+}
+
+type GuidePacketWorkspace struct {
+	ProjectRoot       string `json:"project_root"`
+	PlanningMode      string `json:"planning_mode"`
+	PlanningModel     string `json:"planning_model"`
+	StoryBackend      string `json:"story_backend"`
+	IntegrationBranch string `json:"integration_branch,omitempty"`
+}
+
+type GuidePacketSession struct {
+	ChainID             string            `json:"chain_id"`
+	CurrentStage        string            `json:"current_stage"`
+	CurrentCluster      int               `json:"current_cluster,omitempty"`
+	CurrentClusterLabel string            `json:"current_cluster_label,omitempty"`
+	StageStatuses       map[string]string `json:"stage_statuses,omitempty"`
+	Summary             string            `json:"summary,omitempty"`
+	NextAction          string            `json:"next_action,omitempty"`
+}
+
+type GuidePacketArtifact struct {
+	Type   string `json:"type"`
+	Slug   string `json:"slug"`
+	Title  string `json:"title"`
+	Path   string `json:"path"`
+	Status string `json:"status,omitempty"`
+}
+
+type GuidePacketMode struct {
+	Stage      string `json:"stage"`
+	Checkpoint string `json:"checkpoint"`
+	Pass       string `json:"pass"`
+}
+
+type GuidePacketContract struct {
+	Role             string                      `json:"role"`
+	Stance           []string                    `json:"stance"`
+	Goal             string                      `json:"goal"`
+	QuestionStrategy GuidePacketQuestionStrategy `json:"question_strategy"`
+	ArtifactStrategy GuidePacketArtifactStrategy `json:"artifact_strategy"`
+	Do               []string                    `json:"do"`
+	Avoid            []string                    `json:"avoid"`
+	QualityBar       []string                    `json:"quality_bar"`
+	CompletionGate   []string                    `json:"completion_gate"`
+	CommandHints     []GuidePacketCommandHint    `json:"command_hints"`
+}
+
+type GuidePacketQuestionStrategy struct {
+	ClusterSizeMin        int      `json:"cluster_size_min"`
+	ClusterSizeMax        int      `json:"cluster_size_max"`
+	ReflectOncePerCluster bool     `json:"reflect_once_per_cluster"`
+	GapGuidance           string   `json:"gap_guidance,omitempty"`
+	MenuActions           []string `json:"menu_actions"`
+}
+
+type GuidePacketArtifactStrategy struct {
+	WriteMode          string   `json:"write_mode"`
+	DurableArtifact    string   `json:"durable_artifact"`
+	StrengthenSections []string `json:"strengthen_sections"`
+	PreserveRules      []string `json:"preserve_rules"`
+}
+
+type GuidePacketCommandHint struct {
+	Purpose string `json:"purpose"`
+	Command string `json:"command"`
+}
+
+func (m *Manager) CurrentGuidePacket() (*GuidePacket, error) {
+	session, err := m.ReadLastActiveGuidedSession()
+	if err != nil {
+		if strings.Contains(err.Error(), "no active guided session") {
+			return nil, fmt.Errorf("no active guided session. Start one with `plan brainstorm start --project . \"<topic>\"`")
+		}
+		return nil, err
+	}
+	return m.buildGuidePacket("plan guide current", session, "", "")
+}
+
+func (m *Manager) GuidePacketForChain(chainID, stage, checkpoint string) (*GuidePacket, error) {
+	session, err := m.ReadGuidedSession(strings.TrimSpace(chainID))
+	if err != nil {
+		return nil, err
+	}
+	return m.buildGuidePacket("plan guide show", session, stage, checkpoint)
+}
+
+func (m *Manager) buildGuidePacket(command string, session *workspace.GuidedSessionRecord, stageOverride, checkpointOverride string) (*GuidePacket, error) {
+	if session == nil {
+		return nil, fmt.Errorf("guided session is required")
+	}
+	info, err := m.workspace.EnsureInitialized()
+	if err != nil {
+		return nil, err
+	}
+	meta, err := m.workspace.ReadWorkspaceMeta()
+	if err != nil {
+		return nil, err
+	}
+	branch := ""
+	if githubState, err := m.workspace.ReadGitHubState(); err == nil {
+		branch = strings.TrimSpace(githubState.DefaultBranch)
+	}
+	if strings.TrimSpace(session.Brainstorm) == "" {
+		return nil, fmt.Errorf("guided session %q is not linked to a brainstorm artifact", session.ChainID)
+	}
+
+	effectiveStage := strings.TrimSpace(stageOverride)
+	if effectiveStage == "" {
+		effectiveStage = strings.TrimSpace(session.CurrentStage)
+	}
+	if effectiveStage == "" {
+		effectiveStage = "brainstorm"
+	}
+	if effectiveStage != "brainstorm" {
+		return nil, fmt.Errorf("guide packets currently only support the brainstorm stage; use `--stage brainstorm` or switch back to a brainstorm session")
+	}
+
+	effectiveCheckpoint := strings.TrimSpace(checkpointOverride)
+	if effectiveCheckpoint == "" {
+		effectiveCheckpoint = strings.TrimSpace(session.CurrentClusterLabel)
+	}
+	if effectiveCheckpoint == "" {
+		effectiveCheckpoint = "vision-intake"
+	}
+	if _, ok := brainstormGuideCheckpoints[effectiveCheckpoint]; !ok {
+		return nil, fmt.Errorf("unsupported brainstorm checkpoint %q", effectiveCheckpoint)
+	}
+
+	brainstormPath := filepath.Join(info.BrainstormsDir, slugify(session.Brainstorm)+".md")
+	brainstorm, err := notes.Read(brainstormPath)
+	if err != nil {
+		return nil, fmt.Errorf("read brainstorm artifact for guided session %q: %w", session.ChainID, err)
+	}
+	if brainstorm.Type != "brainstorm" {
+		return nil, fmt.Errorf("%s is not a brainstorm artifact", rel(info.ProjectDir, brainstorm.Path))
+	}
+
+	artifactPath := rel(info.ProjectDir, brainstorm.Path)
+	contract := brainstormGuideContract(session, effectiveCheckpoint, artifactPath)
+	packet := &GuidePacket{
+		SchemaVersion: GuidePacketSchemaVersion,
+		Kind:          guidePacketKind,
+		GeneratedAt:   time.Now().UTC().Format(time.RFC3339),
+		Builder: GuidePacketBuilderMeta{
+			Command: command,
+			Format:  "json",
+		},
+		Workspace: GuidePacketWorkspace{
+			ProjectRoot:       info.ProjectDir,
+			PlanningMode:      guidePlanningMode,
+			PlanningModel:     meta.PlanningModel,
+			StoryBackend:      string(meta.StoryBackend),
+			IntegrationBranch: branch,
+		},
+		Session: GuidePacketSession{
+			ChainID:             session.ChainID,
+			CurrentStage:        defaultString(session.CurrentStage, "brainstorm"),
+			CurrentCluster:      session.CurrentCluster,
+			CurrentClusterLabel: defaultString(session.CurrentClusterLabel, "vision-intake"),
+			StageStatuses:       copyStringMap(session.StageStatuses),
+			Summary:             strings.TrimSpace(session.Summary),
+			NextAction:          strings.TrimSpace(session.NextAction),
+		},
+		Artifact: GuidePacketArtifact{
+			Type:   brainstorm.Type,
+			Slug:   session.Brainstorm,
+			Title:  brainstorm.Title,
+			Path:   artifactPath,
+			Status: defaultString(stringValue(brainstorm.Metadata["status"]), "active"),
+		},
+		Mode: GuidePacketMode{
+			Stage:      effectiveStage,
+			Checkpoint: effectiveCheckpoint,
+			Pass:       brainstormGuidePass(effectiveCheckpoint),
+		},
+		Sources: []string{
+			rel(info.ProjectDir, info.ProjectFile),
+			rel(info.ProjectDir, info.RoadmapFile),
+			rel(info.ProjectDir, info.SessionsFile),
+			artifactPath,
+		},
+		Contract: contract,
+	}
+	sort.Strings(packet.Sources)
+	packet.RenderedPrompt = renderGuidePrompt(packet)
+	return packet, nil
+}
+
+func brainstormGuidePass(checkpoint string) string {
+	switch checkpoint {
+	case "vision-intake":
+		return "brainstorm_intake"
+	case "handoff-epic":
+		return "brainstorm_handoff"
+	default:
+		return "brainstorm_refine"
+	}
+}
+
+func brainstormGuideContract(session *workspace.GuidedSessionRecord, checkpoint, artifactPath string) GuidePacketContract {
+	questionStrategy := GuidePacketQuestionStrategy{
+		ClusterSizeMin:        2,
+		ClusterSizeMax:        4,
+		ReflectOncePerCluster: true,
+		GapGuidance:           "one_recommended_plus_up_to_two_alternatives",
+		MenuActions:           []string{"continue", "refine", "stop_for_now"},
+	}
+	artifactStrategy := GuidePacketArtifactStrategy{
+		WriteMode:       "additive",
+		DurableArtifact: artifactPath,
+		PreserveRules: []string{
+			"Use the user's own language when it clarifies intent.",
+			"Do not invent a new durable planning layer during brainstorm guidance.",
+			"Do not draft implementation slices during brainstorm guidance.",
+		},
+		StrengthenSections: brainstormStrengthenSections(checkpoint),
+	}
+
+	goal := "Turn the brainstorm into a clearer, promotable planning artifact."
+	do := []string{
+		"Ask small clusters of focused questions instead of dumping a long form.",
+		"Reflect back what changed before moving to the next checkpoint.",
+		"Keep scope bounded and surface simpler alternatives when the work sprawls.",
+	}
+	avoid := []string{
+		"Do not call model APIs from `plan`.",
+		"Do not mutate guided session state while rendering the packet.",
+		"Do not jump into execution slices during brainstorm guidance.",
+	}
+	quality := []string{
+		"The user should leave this checkpoint with clearer scope and fewer hidden assumptions.",
+		"The brainstorm note should be stronger than it was before the checkpoint started.",
+	}
+	completion := []string{
+		"The checkpoint-specific sections are strong enough to keep moving without guessing.",
+		"The recap and next action are specific enough for the next guided move.",
+	}
+	commands := []GuidePacketCommandHint{
+		{
+			Purpose: "resume_current_stage",
+			Command: "plan brainstorm resume " + session.Brainstorm + " --project .",
+		},
+		{
+			Purpose: "preview_current_checkpoint",
+			Command: "plan guide show --project . --chain " + session.ChainID + " --stage brainstorm --checkpoint " + checkpoint + " --format json",
+		},
+	}
+
+	switch checkpoint {
+	case "vision-intake":
+		goal = "Capture the vision and supporting material before deeper shaping starts."
+		do = append(do,
+			"Start from the outcome the user sees in their head.",
+			"Capture any supporting docs, links, or references that should shape later refinement.",
+		)
+		completion = []string{
+			"The Vision section describes the outcome in plain language.",
+			"Supporting Material captures any docs, links, or references the user wants to carry forward.",
+		}
+	case "clarify-problem-user-value":
+		goal = "Clarify the problem and the user value so the brainstorm has a concrete center of gravity."
+	case "clarify-constraints-appetite":
+		goal = "Set the hard boundaries and appetite that keep the work honest."
+		do = append(do, "Push for at least one hard boundary the work will not cross.")
+	case "clarify-open-approaches":
+		goal = "Trim the open questions down to the real blockers and identify the best candidate approaches."
+		do = append(do, "Prefer one recommended path plus up to two alternatives.")
+	case "handoff-epic":
+		goal = "Prepare the brainstorm for the next durable planning step."
+		do = append(do, "Call out whether the work is small enough for one spec or broad enough to justify multiple specs under one initiative.")
+		avoid = append(avoid, "Do not force a multi-spec initiative when the work is still one bounded spec.")
+		completion = []string{
+			"It is clear whether the work should stay one spec or split into multiple specs.",
+			"The recap is strong enough to hand the work into the next planning step without re-interviewing the user.",
+		}
+	}
+
+	return GuidePacketContract{
+		Role:             "co_planning_facilitator",
+		Stance:           []string{"collaborative", "direct", "skeptical_when_needed", "keep_scope_small"},
+		Goal:             goal,
+		QuestionStrategy: questionStrategy,
+		ArtifactStrategy: artifactStrategy,
+		Do:               do,
+		Avoid:            avoid,
+		QualityBar:       quality,
+		CompletionGate:   completion,
+		CommandHints:     commands,
+	}
+}
+
+func brainstormStrengthenSections(checkpoint string) []string {
+	switch checkpoint {
+	case "vision-intake":
+		return []string{"Vision", "Supporting Material"}
+	case "clarify-problem-user-value":
+		return []string{"Problem", "User / Value"}
+	case "clarify-constraints-appetite":
+		return []string{"Constraints", "Appetite"}
+	case "clarify-open-approaches":
+		return []string{"Remaining Open Questions", "Candidate Approaches"}
+	case "handoff-epic":
+		return []string{"Decision Snapshot", "Problem", "User / Value", "Constraints"}
+	default:
+		return []string{"Vision"}
+	}
+}
+
+func renderGuidePrompt(packet *GuidePacket) string {
+	var lines []string
+	lines = append(lines, "You are guiding the brainstorm stage for `plan`.")
+	lines = append(lines, "Goal: "+packet.Contract.Goal)
+	lines = append(lines, "Current summary: "+defaultString(packet.Session.Summary, "No recap saved yet."))
+	lines = append(lines, "Next action: "+defaultString(packet.Session.NextAction, "Continue guided clarification."))
+	lines = append(lines, "Durable artifact: "+packet.Contract.ArtifactStrategy.DurableArtifact)
+	lines = append(lines, "Checkpoint: "+packet.Mode.Checkpoint)
+	lines = append(lines, "Do:")
+	for _, item := range packet.Contract.Do {
+		lines = append(lines, "- "+item)
+	}
+	lines = append(lines, "Avoid:")
+	for _, item := range packet.Contract.Avoid {
+		lines = append(lines, "- "+item)
+	}
+	lines = append(lines, "Completion gate:")
+	for _, item := range packet.Contract.CompletionGate {
+		lines = append(lines, "- "+item)
+	}
+	return strings.Join(lines, "\n")
+}
+
+func copyStringMap(in map[string]string) map[string]string {
+	if len(in) == 0 {
+		return map[string]string{}
+	}
+	out := make(map[string]string, len(in))
+	for key, value := range in {
+		out[key] = value
+	}
+	return out
+}
+
+func defaultString(value, fallback string) string {
+	if strings.TrimSpace(value) == "" {
+		return fallback
+	}
+	return value
+}

--- a/internal/planning/guide_packet_test.go
+++ b/internal/planning/guide_packet_test.go
@@ -1,0 +1,128 @@
+package planning
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"plan/internal/workspace"
+)
+
+func TestCurrentGuidePacketBuildsBrainstormPacketWithoutMutatingSessionState(t *testing.T) {
+	root := t.TempDir()
+	ws := workspace.New(root)
+	if _, err := ws.Init(); err != nil {
+		t.Fatal(err)
+	}
+
+	githubState, err := ws.ReadGitHubState()
+	if err != nil {
+		t.Fatal(err)
+	}
+	githubState.DefaultBranch = "develop"
+	if err := ws.WriteGitHubState(*githubState); err != nil {
+		t.Fatal(err)
+	}
+
+	manager := New(ws)
+	if _, err := manager.CreateBrainstorm("Guide Packet Foundation"); err != nil {
+		t.Fatal(err)
+	}
+	if _, _, err := manager.UpdateGuidedBrainstormIntake("guide-packet-foundation", GuidedBrainstormIntakeInput{
+		Vision:             "Guide the user from idea to a live planning contract.",
+		SupportingMaterial: "docs/guide-packet.md",
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	sessionsPath := filepath.Join(root, ".plan", ".meta", "guided_sessions.json")
+	before, err := os.ReadFile(sessionsPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	packet, err := manager.CurrentGuidePacket()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if packet.Kind != guidePacketKind || packet.SchemaVersion != GuidePacketSchemaVersion {
+		t.Fatalf("unexpected packet identity: %+v", packet)
+	}
+	if packet.Workspace.IntegrationBranch != "develop" {
+		t.Fatalf("expected integration branch from github state: %+v", packet.Workspace)
+	}
+	if packet.Session.ChainID != "brainstorm/guide-packet-foundation" {
+		t.Fatalf("unexpected chain id: %+v", packet.Session)
+	}
+	if packet.Artifact.Path != ".plan/brainstorms/guide-packet-foundation.md" {
+		t.Fatalf("unexpected artifact path: %+v", packet.Artifact)
+	}
+	if len(packet.Contract.Stance) == 0 || packet.Contract.QuestionStrategy.GapGuidance == "" {
+		t.Fatalf("expected richer contract guidance: %+v", packet.Contract)
+	}
+	if len(packet.Contract.CommandHints) != 2 {
+		t.Fatalf("expected command hints: %+v", packet.Contract.CommandHints)
+	}
+	if !strings.Contains(packet.Contract.CommandHints[1].Command, "--chain brainstorm/guide-packet-foundation") {
+		t.Fatalf("expected explicit chain in command hints: %+v", packet.Contract.CommandHints)
+	}
+	if !strings.Contains(packet.RenderedPrompt, "Goal: ") {
+		t.Fatalf("expected rendered prompt to be derived from the contract: %s", packet.RenderedPrompt)
+	}
+
+	after, err := os.ReadFile(sessionsPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(before) != string(after) {
+		t.Fatalf("guide packet generation should not mutate guided sessions state\nbefore:\n%s\nafter:\n%s", string(before), string(after))
+	}
+}
+
+func TestCurrentGuidePacketFailsWithoutActiveSession(t *testing.T) {
+	root := t.TempDir()
+	ws := workspace.New(root)
+	if _, err := ws.Init(); err != nil {
+		t.Fatal(err)
+	}
+	manager := New(ws)
+
+	_, err := manager.CurrentGuidePacket()
+	if err == nil {
+		t.Fatal("expected missing active session error")
+	}
+	if !strings.Contains(err.Error(), "no active guided session") {
+		t.Fatalf("expected actionable missing-session error, got %v", err)
+	}
+}
+
+func TestGuidePacketForChainFailsWhenArtifactIsMissing(t *testing.T) {
+	root := t.TempDir()
+	ws := workspace.New(root)
+	if _, err := ws.Init(); err != nil {
+		t.Fatal(err)
+	}
+	manager := New(ws)
+	if _, err := manager.CreateBrainstorm("Guide Packet Foundation"); err != nil {
+		t.Fatal(err)
+	}
+	if _, _, err := manager.UpdateGuidedBrainstormIntake("guide-packet-foundation", GuidedBrainstormIntakeInput{
+		Vision:             "Guide packet planning should be runtime-driven.",
+		SupportingMaterial: "docs/guide-packet.md",
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := os.Remove(filepath.Join(root, ".plan", "brainstorms", "guide-packet-foundation.md")); err != nil {
+		t.Fatal(err)
+	}
+
+	_, err := manager.GuidePacketForChain("brainstorm/guide-packet-foundation", "brainstorm", "")
+	if err == nil {
+		t.Fatal("expected missing artifact error")
+	}
+	if !strings.Contains(err.Error(), "read brainstorm artifact") {
+		t.Fatalf("expected missing-artifact error, got %v", err)
+	}
+}

--- a/internal/planning/guide_packet_test.go
+++ b/internal/planning/guide_packet_test.go
@@ -1,6 +1,7 @@
 package planning
 
 import (
+	"errors"
 	"os"
 	"path/filepath"
 	"strings"
@@ -94,6 +95,9 @@ func TestCurrentGuidePacketFailsWithoutActiveSession(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "no active guided session") {
 		t.Fatalf("expected actionable missing-session error, got %v", err)
+	}
+	if !errors.Is(err, ErrNoActiveGuidedSession) {
+		t.Fatalf("expected missing-session error to wrap ErrNoActiveGuidedSession, got %v", err)
 	}
 }
 

--- a/internal/planning/guided_session.go
+++ b/internal/planning/guided_session.go
@@ -1,6 +1,7 @@
 package planning
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -11,6 +12,8 @@ import (
 	"plan/internal/notes"
 	"plan/internal/workspace"
 )
+
+var ErrNoActiveGuidedSession = errors.New("no active guided session")
 
 type GuidedBrainstormIntakeInput struct {
 	Vision             string
@@ -95,7 +98,7 @@ func (m *Manager) ReadLastActiveGuidedSession() (*workspace.GuidedSessionRecord,
 		return nil, err
 	}
 	if strings.TrimSpace(state.LastActiveChain) == "" {
-		return nil, fmt.Errorf("no active guided session")
+		return nil, ErrNoActiveGuidedSession
 	}
 	return m.ReadGuidedSession(state.LastActiveChain)
 }

--- a/skills/plan/SKILL.md
+++ b/skills/plan/SKILL.md
@@ -45,6 +45,8 @@ When a repo uses `plan`:
 - `plan brainstorm idea --project . <brainstorm-slug> --body "<idea>"`
 - `plan brainstorm refine --project . <brainstorm-slug>`
 - `plan brainstorm challenge --project . <brainstorm-slug>`
+- `plan guide current --project . --format json` when a guided brainstorm session is active
+- `plan guide show --project . --chain <chain-id> --stage brainstorm --checkpoint <checkpoint> --format json` for explicit preview/debug use
 - `plan epic create|promote|shape ...` only when a repo still depends on the legacy transition path
 - `plan spec show --project . <spec-slug>`
 - `plan spec analyze --project . <spec-slug>`
@@ -65,6 +67,7 @@ When a repo uses `plan`:
 - Do not assume every durable planning artifact lives in `.plan/`; respect explicit ownership by planning layer.
 - `brainstorm refine` should reduce ambiguity before promotion.
 - `brainstorm challenge` should pressure-test risk, no-gos, and overengineering before promotion.
+- When a guided brainstorm session is active, prefer live guide packets over static stage prose.
 - `epic shape` is now a legacy compatibility pass, not the preferred active model.
 - `spec analyze` should pressure-test a spec without rewriting its canonical sections.
 - `spec checklist` should add profile-driven rigor without mutating the canonical sections.


### PR DESCRIPTION
## Summary

- add the guide packet builder, `plan guide current`, and `plan guide show` for brainstorm-stage JSON packets
- keep guide packet rendering read-only against guided session state and expose the single-spec vs multi-spec handoff decision explicitly at the brainstorm handoff checkpoint
- update the plan skill, user docs, and local guide-packet background docs so the shipped v1 command surface matches the current spec-first model

## Target Branch

- Normal work targets `develop`.
- Release PRs use `release/vX.Y.Z -> main`.
- Hotfix work must be merged back into `develop`.

## Testing

- [x] `go test ./...`
- [x] `go build ./...`
- [x] Other: `git diff --check`

## Release Notes

- User-facing change: `plan guide current --format json` and `plan guide show --chain ... --stage brainstorm --checkpoint ... --format json` now emit live brainstorm-stage guide packets.
- Planning or workflow impact: guided agent flows can pull live prompt contracts from `plan` instead of relying on static stage prose; the brainstorm handoff now explicitly supports both single-spec and multi-spec initiative paths.
- Follow-up work: later-stage packets, non-JSON renderers, and optional schema/family overlays remain follow-up scope.

## Planning

- Related idea/planning documents: #40, .plan/specs/guide-packet-and-cli-foundation.md, .plan/research/guide-packet-schema-and-cli-design.md
- Closes #34
- Closes #35
- Closes #36
- Closes #40
