### PR TITLE
chore: refresh github planning metadata

### DIFF
--- a/.brain/context/current-state.md
+++ b/.brain/context/current-state.md
@@ -1,3 +1,6 @@
+---
+updated: "2026-04-22T20:01:22Z"
+---
 # Current State
 
 <!-- brain:begin context-current-state -->
@@ -27,3 +30,5 @@ This file is a deterministic snapshot of the repository state at the last refres
 ## Local Notes
 
 Add repo-specific notes here. `brain context refresh` preserves content outside managed blocks.
+
+- On April 22, 2026, `./scripts/refresh-plan-develop-context.sh` reconciled checked-in GitHub planning metadata on `develop` and updated `.plan/.meta/github.json` so guide packet issues `#34`-`#36` are recorded as closed/merged with doc refs normalized to `develop`.

--- a/.plan/.meta/github.json
+++ b/.plan/.meta/github.json
@@ -3,8 +3,8 @@
   "repo_url": "https://github.com/JimmyMcBride/plan",
   "default_branch": "develop",
   "last_enabled_at": "2026-04-20T03:04:26Z",
-  "last_updated_at": "2026-04-20T06:12:21Z",
-  "last_reconciled_at": "2026-04-20T06:12:21Z",
+  "last_updated_at": "2026-04-22T19:49:22Z",
+  "last_reconciled_at": "2026-04-22T19:49:22Z",
   "stories": {
     "add-brainstorm-stage-recap-and-stop-flow": {
       "slug": "add-brainstorm-stage-recap-and-stop-flow",
@@ -87,12 +87,13 @@
       ],
       "issue_number": 34,
       "issue_url": "https://github.com/JimmyMcBride/plan/issues/34",
-      "remote_state": "open",
+      "remote_state": "closed",
       "planning_pr_number": 33,
       "planning_pr_url": "https://github.com/JimmyMcBride/plan/pull/33",
-      "doc_ref_mode": "sha",
-      "doc_ref": "d3edd3f752a39d558133ae979313ff7012cc9c10",
-      "updated_at": "2026-04-21T14:08:07Z"
+      "planning_pr_merged": true,
+      "doc_ref_mode": "main",
+      "doc_ref": "develop",
+      "updated_at": "2026-04-22T19:49:22Z"
     },
     "add-guided-session-state-model": {
       "slug": "add-guided-session-state-model",
@@ -171,12 +172,13 @@
       ],
       "issue_number": 35,
       "issue_url": "https://github.com/JimmyMcBride/plan/issues/35",
-      "remote_state": "open",
+      "remote_state": "closed",
       "planning_pr_number": 33,
       "planning_pr_url": "https://github.com/JimmyMcBride/plan/pull/33",
-      "doc_ref_mode": "sha",
-      "doc_ref": "d3edd3f752a39d558133ae979313ff7012cc9c10",
-      "updated_at": "2026-04-21T14:08:09Z"
+      "planning_pr_merged": true,
+      "doc_ref_mode": "main",
+      "doc_ref": "develop",
+      "updated_at": "2026-04-22T19:49:22Z"
     },
     "add-plan-guide-show-json-command": {
       "slug": "add-plan-guide-show-json-command",
@@ -200,12 +202,13 @@
       ],
       "issue_number": 36,
       "issue_url": "https://github.com/JimmyMcBride/plan/issues/36",
-      "remote_state": "open",
+      "remote_state": "closed",
       "planning_pr_number": 33,
       "planning_pr_url": "https://github.com/JimmyMcBride/plan/pull/33",
-      "doc_ref_mode": "sha",
-      "doc_ref": "d3edd3f752a39d558133ae979313ff7012cc9c10",
-      "updated_at": "2026-04-21T14:08:11Z"
+      "planning_pr_merged": true,
+      "doc_ref_mode": "main",
+      "doc_ref": "develop",
+      "updated_at": "2026-04-22T19:49:22Z"
     },
     "add-reopen-impact-summary-and-needs-review-markers": {
       "slug": "add-reopen-impact-summary-and-needs-review-markers",


### PR DESCRIPTION
## Summary

- Refresh tracked `.plan/.meta/github.json` after reconciling against current `develop`
- Record guide packet issues `#34`-`#36` as closed/merged and normalize their doc refs to `develop`

## Target Branch

- Normal work targets `develop`.
- Release PRs use `release/vX.Y.Z -> main`.
- Hotfix work must be merged back into `develop`.

## Testing

- [x] `go test ./...`
- [x] `go build ./...`
- [x] Other: `git diff --check`

## Release Notes

- User-facing change: none
- Planning or workflow impact: checked-in GitHub planning metadata now matches the current remote state on `develop`
- Follow-up work: none

## Planning

- Related epic/spec/story: n/a (metadata refresh only)
