### PR TITLE
feat: add collaboration-stage guide packets

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,7 +168,7 @@ Full guide:
 - `plan brainstorm start|idea|show|refine`
 - `plan brainstorm challenge`
 - `plan discuss assess|promote`
-- `plan guide current|show`
+- `plan guide current|show` for brainstorm and collaboration guide packets
 - `plan epic create|promote|list|show|shape` for legacy compatibility during migration
 - `plan spec show|edit|status|analyze|checklist|initiative|execute|handoff`
 - `plan story create|update|list|show|slice|critique` for legacy compatibility during migration

--- a/cmd/guide.go
+++ b/cmd/guide.go
@@ -32,26 +32,43 @@ func newGuideCommand() *cobra.Command {
 	var (
 		showFormat     string
 		showChain      string
+		showBrainstorm string
+		showDiscussion string
 		showStage      string
 		showCheckpoint string
 	)
 	show := &cobra.Command{
 		Use:   "show",
-		Short: "Render the guide packet for an explicit guided session chain",
+		Short: "Render a guide packet for a guided brainstorm chain or collaboration source",
 		Args:  cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			packet, err := planningManager().GuidePacketForChain(showChain, showStage, showCheckpoint)
-			if err != nil {
-				return err
+			switch {
+			case strings.TrimSpace(showChain) != "":
+				if strings.TrimSpace(showBrainstorm) != "" || strings.TrimSpace(showDiscussion) != "" {
+					return fmt.Errorf("choose either --chain or one collaboration source flag")
+				}
+				packet, err := planningManager().GuidePacketForChain(showChain, showStage, showCheckpoint)
+				if err != nil {
+					return err
+				}
+				return writeGuidePacket(cmd, showFormat, packet)
+			case strings.TrimSpace(showBrainstorm) != "" || strings.TrimSpace(showDiscussion) != "":
+				packet, err := planningManager().GuidePacketForCollaborationSource(showBrainstorm, showDiscussion, showStage)
+				if err != nil {
+					return err
+				}
+				return writeGuidePacket(cmd, showFormat, packet)
+			default:
+				return fmt.Errorf("guide show requires --chain, --brainstorm, or --discussion")
 			}
-			return writeGuidePacket(cmd, showFormat, packet)
 		},
 	}
 	show.Flags().StringVar(&showChain, "chain", "", "guided session chain id, such as brainstorm/my-topic")
+	show.Flags().StringVar(&showBrainstorm, "brainstorm", "", "local brainstorm slug for collaboration-stage guide packets")
+	show.Flags().StringVar(&showDiscussion, "discussion", "", "GitHub Discussion number or URL for collaboration-stage guide packets")
 	show.Flags().StringVar(&showStage, "stage", "", "explicit stage override")
 	show.Flags().StringVar(&showCheckpoint, "checkpoint", "", "explicit checkpoint override")
 	show.Flags().StringVar(&showFormat, "format", "json", "output format: json")
-	_ = show.MarkFlagRequired("chain")
 
 	cmd.AddCommand(current, show)
 	return cmd
@@ -59,7 +76,7 @@ func newGuideCommand() *cobra.Command {
 
 func writeGuidePacket(cmd *cobra.Command, format string, packet any) error {
 	if strings.TrimSpace(format) != "json" {
-		return fmt.Errorf("unsupported guide output format %q; only json is supported in v1", format)
+		return fmt.Errorf("unsupported guide output format %q; only json is supported", format)
 	}
 	encoder := json.NewEncoder(cmd.OutOrStdout())
 	encoder.SetIndent("", "  ")

--- a/cmd/guide.go
+++ b/cmd/guide.go
@@ -53,6 +53,9 @@ func newGuideCommand() *cobra.Command {
 				}
 				return writeGuidePacket(cmd, showFormat, packet)
 			case strings.TrimSpace(showBrainstorm) != "" || strings.TrimSpace(showDiscussion) != "":
+				if strings.TrimSpace(showCheckpoint) != "" {
+					return fmt.Errorf("--checkpoint only applies to --chain guide previews")
+				}
 				packet, err := planningManager().GuidePacketForCollaborationSource(showBrainstorm, showDiscussion, showStage)
 				if err != nil {
 					return err
@@ -67,7 +70,7 @@ func newGuideCommand() *cobra.Command {
 	show.Flags().StringVar(&showBrainstorm, "brainstorm", "", "local brainstorm slug for collaboration-stage guide packets")
 	show.Flags().StringVar(&showDiscussion, "discussion", "", "GitHub Discussion number or URL for collaboration-stage guide packets")
 	show.Flags().StringVar(&showStage, "stage", "", "explicit stage override")
-	show.Flags().StringVar(&showCheckpoint, "checkpoint", "", "explicit checkpoint override")
+	show.Flags().StringVar(&showCheckpoint, "checkpoint", "", "explicit checkpoint override for --chain previews")
 	show.Flags().StringVar(&showFormat, "format", "json", "output format: json")
 
 	cmd.AddCommand(current, show)

--- a/cmd/guide_test.go
+++ b/cmd/guide_test.go
@@ -281,6 +281,28 @@ func TestGuideShowCommandRejectsMixedChainAndCollaborationSourceFlags(t *testing
 	}
 }
 
+func TestGuideShowCommandRejectsCheckpointForCollaborationSource(t *testing.T) {
+	root := t.TempDir()
+	setupCollaborationGuideBrainstormFixture(t, root)
+
+	command := newRootCmd()
+	command.SetArgs([]string{
+		"--project", root,
+		"guide", "show",
+		"--brainstorm", "guide-packet-collaboration",
+		"--stage", "promotion_review",
+		"--checkpoint", "clarify-open-approaches",
+		"--format", "json",
+	})
+	err := command.Execute()
+	if err == nil {
+		t.Fatal("expected guide show to reject --checkpoint for collaboration sources")
+	}
+	if !strings.Contains(err.Error(), "--checkpoint only applies to --chain guide previews") {
+		t.Fatalf("expected collaboration checkpoint error, got %v", err)
+	}
+}
+
 func setupGuidePacketFixture(t *testing.T, root string) {
 	t.Helper()
 	ws := workspace.New(root)

--- a/cmd/guide_test.go
+++ b/cmd/guide_test.go
@@ -125,7 +125,7 @@ func TestGuideShowCommandRejectsUnsupportedStage(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected guide show to fail for unsupported stage")
 	}
-	if !strings.Contains(err.Error(), "only support the brainstorm stage") {
+	if !strings.Contains(err.Error(), "guided session chain packets only support the brainstorm stage") {
 		t.Fatalf("expected unsupported-stage error, got %v", err)
 	}
 }
@@ -182,8 +182,102 @@ func TestGuideCurrentCommandRejectsNonJSONFormat(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected guide current to reject non-json formats")
 	}
-	if !strings.Contains(err.Error(), "only json is supported in v1") {
+	if !strings.Contains(err.Error(), "only json is supported") {
 		t.Fatalf("expected format error, got %v", err)
+	}
+}
+
+func TestGuideShowCommandEmitsCollaborationPacketForBrainstormSource(t *testing.T) {
+	root := t.TempDir()
+	setupCollaborationGuideBrainstormFixture(t, root)
+
+	var output bytes.Buffer
+	command := newRootCmd()
+	command.SetOut(&output)
+	command.SetErr(&output)
+	command.SetArgs([]string{
+		"--project", root,
+		"guide", "show",
+		"--brainstorm", "guide-packet-collaboration",
+		"--stage", "promotion_review",
+		"--format", "json",
+	})
+	if err := command.Execute(); err != nil {
+		t.Fatalf("expected collaboration guide show to succeed: %v", err)
+	}
+
+	var packet map[string]any
+	if err := json.Unmarshal(output.Bytes(), &packet); err != nil {
+		t.Fatalf("expected valid JSON output: %v\n%s", err, output.String())
+	}
+	if packet["kind"] != "guide_packet" {
+		t.Fatalf("expected guide packet kind, got %#v", packet["kind"])
+	}
+	mode := packet["mode"].(map[string]any)
+	if mode["stage"] != "promotion_review" {
+		t.Fatalf("expected collaboration stage in packet: %#v", mode)
+	}
+	collaboration, ok := packet["collaboration"].(map[string]any)
+	if !ok {
+		t.Fatalf("expected collaboration payload in packet: %#v", packet["collaboration"])
+	}
+	if _, ok := collaboration["promotion_draft"]; !ok {
+		t.Fatalf("expected embedded promotion draft: %#v", collaboration)
+	}
+}
+
+func TestGuideShowCommandEmitsCollaborationPacketForDiscussionSource(t *testing.T) {
+	root := t.TempDir()
+	setupCollaborationGuideDiscussionFixture(t, root)
+
+	var output bytes.Buffer
+	command := newRootCmd()
+	command.SetOut(&output)
+	command.SetErr(&output)
+	command.SetArgs([]string{
+		"--project", root,
+		"guide", "show",
+		"--discussion", "49",
+		"--stage", "initiative_draft",
+		"--format", "json",
+	})
+	if err := command.Execute(); err != nil {
+		t.Fatalf("expected discussion guide show to succeed: %v", err)
+	}
+
+	var packet map[string]any
+	if err := json.Unmarshal(output.Bytes(), &packet); err != nil {
+		t.Fatalf("expected valid JSON output: %v\n%s", err, output.String())
+	}
+	artifact := packet["artifact"].(map[string]any)
+	if artifact["type"] != "github_discussion" {
+		t.Fatalf("expected discussion artifact, got %#v", artifact)
+	}
+	rendered, ok := packet["rendered_drafts"].([]any)
+	if !ok || len(rendered) != 1 {
+		t.Fatalf("expected rendered initiative draft, got %#v", packet["rendered_drafts"])
+	}
+}
+
+func TestGuideShowCommandRejectsMixedChainAndCollaborationSourceFlags(t *testing.T) {
+	root := t.TempDir()
+	setupGuidePacketFixture(t, root)
+
+	command := newRootCmd()
+	command.SetArgs([]string{
+		"--project", root,
+		"guide", "show",
+		"--chain", "brainstorm/guide-packet-foundation",
+		"--brainstorm", "guide-packet-foundation",
+		"--stage", "brainstorm",
+		"--format", "json",
+	})
+	err := command.Execute()
+	if err == nil {
+		t.Fatal("expected guide show to reject mixed chain and collaboration flags")
+	}
+	if !strings.Contains(err.Error(), "choose either --chain or one collaboration source flag") {
+		t.Fatalf("expected mixed-source error, got %v", err)
 	}
 }
 
@@ -217,4 +311,139 @@ func setupGuidePacketFixture(t *testing.T, root string) {
 	if _, err := os.Stat(sessionsPath); err != nil {
 		t.Fatalf("expected guided sessions state to exist: %v", err)
 	}
+}
+
+func setupCollaborationGuideBrainstormFixture(t *testing.T, root string) {
+	t.Helper()
+	ws := workspace.New(root)
+	if _, err := ws.Init(); err != nil {
+		t.Fatal(err)
+	}
+	manager := planning.New(ws)
+	if _, err := manager.CreateBrainstorm("Guide Packet Collaboration"); err != nil {
+		t.Fatal(err)
+	}
+	if _, _, err := manager.UpdateGuidedBrainstormIntake("guide-packet-collaboration", planning.GuidedBrainstormIntakeInput{
+		Vision: "Wrap collaboration shaping in live guide packets.",
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := manager.UpdateBrainstormRefinement("guide-packet-collaboration", planning.BrainstormRefinementInput{
+		Problem:             "Collaboration guidance is missing from guide packets.",
+		UserValue:           "Agents can review promotion-ready payloads without guessing.",
+		Constraints:         "Keep JSON canonical.\nDo not replace discuss payloads.",
+		Appetite:            "One bounded collaboration slice.",
+		CandidateApproaches: "Wrap assessment.\nWrap promotion draft.",
+		DecisionSnapshot:    "Promote directly into one spec.",
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := manager.UpdateBrainstormChallenge("guide-packet-collaboration", planning.BrainstormChallengeInput{
+		NoGos:              "No custom review UI.",
+		SimplerAlternative: "Embed canonical collaboration payloads in the guide packet.",
+	}); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func setupCollaborationGuideDiscussionFixture(t *testing.T, root string) {
+	t.Helper()
+	client := &stubGuideGitHubClient{
+		preflight: &planning.GitHubRepoInfo{
+			Repo:          "JimmyMcBride/plan",
+			RepoURL:       "https://github.com/JimmyMcBride/plan",
+			DefaultBranch: "develop",
+		},
+		context: &planning.GitHubContext{
+			Repo: planning.GitHubRepoInfo{
+				Repo:          "JimmyMcBride/plan",
+				RepoURL:       "https://github.com/JimmyMcBride/plan",
+				DefaultBranch: "develop",
+			},
+			CurrentBranch: "develop",
+			CurrentSHA:    "abc123",
+		},
+		discussions: map[int]*planning.GitHubDiscussion{
+			49: {
+				Number: 49,
+				URL:    "https://github.com/JimmyMcBride/plan/discussions/49",
+				Title:  "Guide packet collaboration",
+				Body: strings.Join([]string{
+					"## Problem",
+					"Guide packets need collaboration-stage coverage.",
+					"",
+					"## Goals",
+					"Review promotion drafts in runtime packets.",
+					"",
+					"## Non-Goals",
+					"Do not replace canonical discuss contracts.",
+					"",
+					"## Constraints",
+					"Keep JSON canonical.",
+					"",
+					"## Proposed Shape",
+					"Use one initiative issue plus two spec issues.",
+					"",
+					"## Spec Split",
+					"- Guide packet v2 schema",
+					"- Guide packet v2 CLI",
+					"",
+					"Guide packet v2 CLI depends on Guide packet v2 schema.",
+				}, "\n"),
+			},
+		},
+	}
+	reset := planning.SetGitHubClientFactoryForTesting(func() planning.GitHubClient { return client })
+	t.Cleanup(reset)
+
+	ws := workspace.New(root)
+	if _, err := ws.Init(); err != nil {
+		t.Fatal(err)
+	}
+}
+
+type stubGuideGitHubClient struct {
+	preflight   *planning.GitHubRepoInfo
+	context     *planning.GitHubContext
+	discussions map[int]*planning.GitHubDiscussion
+}
+
+func (s *stubGuideGitHubClient) Preflight(projectDir string) (*planning.GitHubRepoInfo, error) {
+	return s.preflight, nil
+}
+
+func (s *stubGuideGitHubClient) CurrentContext(projectDir string) (*planning.GitHubContext, error) {
+	return s.context, nil
+}
+
+func (s *stubGuideGitHubClient) CreateIssue(projectDir, repo string, input planning.GitHubIssueInput) (*planning.GitHubIssue, error) {
+	return nil, nil
+}
+
+func (s *stubGuideGitHubClient) UpdateIssue(projectDir, repo string, issueNumber int, input planning.GitHubIssueInput) (*planning.GitHubIssue, error) {
+	return nil, nil
+}
+
+func (s *stubGuideGitHubClient) GetIssue(projectDir, repo string, issueNumber int) (*planning.GitHubIssue, error) {
+	return nil, nil
+}
+
+func (s *stubGuideGitHubClient) FindMilestone(projectDir, repo, title string) (*planning.GitHubMilestone, error) {
+	return nil, nil
+}
+
+func (s *stubGuideGitHubClient) CreateMilestone(projectDir, repo string, input planning.GitHubMilestoneInput) (*planning.GitHubMilestone, error) {
+	return nil, nil
+}
+
+func (s *stubGuideGitHubClient) GetDiscussion(projectDir, repo string, number int) (*planning.GitHubDiscussion, error) {
+	return s.discussions[number], nil
+}
+
+func (s *stubGuideGitHubClient) AddSubIssue(projectDir, repo string, issueNumber, subIssueNumber int) error {
+	return nil
+}
+
+func (s *stubGuideGitHubClient) AddBlockedBy(projectDir, repo string, issueNumber, blockingIssueNumber int) error {
+	return nil
 }

--- a/docs/using-plan.md
+++ b/docs/using-plan.md
@@ -14,7 +14,7 @@ Right now:
 - brainstorms can start locally or in GitHub Discussions
 - `initiative` is lightweight optional grouping metadata
 - `plan spec execute` is the active execution entry point
-- `plan guide current|show` emits live brainstorm-stage guide packets for agent runtimes
+- `plan guide current|show` emits live brainstorm and collaboration guide packets for agent runtimes
 - `plan discuss assess|promote` ships the GitHub collaboration foundation
 - `plan source show|set` makes backend ownership explicit
 - legacy `epic` and `story` commands still exist during the transition
@@ -387,7 +387,56 @@ When a multi-spec promotion is applied, `plan` will:
 By default, new spec issues are `ready`. A spec starts as `needs-refinement`
 only when the draft identified a concrete execution gap.
 
-### 8. Work The Spec
+### 8. Preview Collaboration Guide Packets
+
+`plan guide current` remains the guided brainstorm packet entry point:
+
+```bash
+plan guide current --project . --format json
+```
+
+Use `plan guide show` when you want an explicit preview of either:
+
+- a brainstorm checkpoint from a guided session chain
+- a collaboration stage driven by a brainstorm or GitHub Discussion source
+
+Examples:
+
+```bash
+plan guide show --project . \
+  --chain brainstorm/newsletter-system \
+  --stage brainstorm \
+  --checkpoint clarify-open-approaches \
+  --format json
+
+plan guide show --project . \
+  --brainstorm newsletter-system \
+  --stage promotion_review \
+  --format json
+
+plan guide show --project . \
+  --discussion 49 \
+  --stage initiative_draft \
+  --format json
+```
+
+Current collaboration packet stages:
+
+- `discussion_assess`
+- `promotion_review`
+- `initiative_draft`
+- `spec_draft`
+- `needs_refinement`
+
+Current collaboration packet behavior:
+
+- embeds the canonical `maturity_assessment` and `promotion_draft` payloads
+- includes rendered initiative/spec draft markdown when the stage needs it
+- emits explicit review and confirmation action objects for agent runtimes
+- keeps JSON as the canonical output format
+- does not mutate the source material while rendering the packet
+
+### 9. Work The Spec
 
 After promotion, the canonical execution contract may live in different places
 depending on ownership:

--- a/internal/planning/collaboration.go
+++ b/internal/planning/collaboration.go
@@ -67,10 +67,11 @@ const (
 type ReadinessState string
 
 const (
-	ReadinessClarifying ReadinessState = "clarifying"
-	ReadinessReady      ReadinessState = "ready"
-	ReadinessBlocked    ReadinessState = "blocked"
-	ReadinessDone       ReadinessState = "done"
+	ReadinessClarifying      ReadinessState = "clarifying"
+	ReadinessReady           ReadinessState = "ready"
+	ReadinessBlocked         ReadinessState = "blocked"
+	ReadinessNeedsRefinement ReadinessState = "needs-refinement"
+	ReadinessDone            ReadinessState = "done"
 )
 
 type CollaborationSourceRef struct {
@@ -266,7 +267,11 @@ func (m *Manager) BuildPromotionDraft(input PromotionDraftInput) (*PromotionDraf
 		specTitles = []string{fallbackSpecTitle(data.title)}
 	}
 	if draft.PromotionDecision == PromotionSingleSpec {
-		specDraft := buildPromotionSpecDraft(data, specTitles[0], nil)
+		refinementExceptions := buildRefinementExceptions(data, specTitles)
+		specDraft := buildPromotionSpecDraft(data, specTitles[0], nil, refinementExceptions[specTitles[0]])
+		if exception, ok := refinementExceptions[specTitles[0]]; ok {
+			draft.NeedsRefinementExceptions = append(draft.NeedsRefinementExceptions, exception)
+		}
 		draft.ProposedSpecIssues = []PromotionIssueDraft{specDraft}
 		return draft, nil
 	}
@@ -286,10 +291,14 @@ func (m *Manager) BuildPromotionDraft(input PromotionDraftInput) (*PromotionDraf
 			BlockedBy:  append([]string(nil), dep.BlockedBy...),
 		})
 	}
+	refinementExceptions := buildRefinementExceptions(data, specTitles)
 	for _, title := range specTitles {
 		blockedBy := findBlockedByForTitle(decision.DependencyGuess, title)
-		specDraft := buildPromotionSpecDraft(data, title, blockedBy)
+		specDraft := buildPromotionSpecDraft(data, title, blockedBy, refinementExceptions[title])
 		draft.ProposedSpecIssues = append(draft.ProposedSpecIssues, specDraft)
+		if exception, ok := refinementExceptions[title]; ok {
+			draft.NeedsRefinementExceptions = append(draft.NeedsRefinementExceptions, exception)
+		}
 	}
 	draft.MilestonePlan = &PromotionMilestonePlan{
 		Create: true,
@@ -742,11 +751,18 @@ func buildPromotionInitiativeDraft(data *collaborationSourceData, title string, 
 	}
 }
 
-func buildPromotionSpecDraft(data *collaborationSourceData, title string, blockedBy []string) PromotionIssueDraft {
-	body := renderPromotionSpecBody(title, data, blockedBy, nil)
+func buildPromotionSpecDraft(data *collaborationSourceData, title string, blockedBy []string, exception PromotionRefinementException) PromotionIssueDraft {
+	var exceptionPtr *PromotionRefinementException
+	if strings.TrimSpace(exception.IssueTitle) != "" {
+		exceptionPtr = &exception
+	}
+	body := renderPromotionSpecBody(title, data, blockedBy, exceptionPtr)
 	readiness := ReadinessReady
 	labels := []string{"enhancement", planIssueReadyLabel}
-	if len(blockedBy) > 0 {
+	if exceptionPtr != nil {
+		readiness = ReadinessNeedsRefinement
+		labels = []string{"enhancement"}
+	} else if len(blockedBy) > 0 {
 		readiness = ReadinessBlocked
 		labels = []string{"enhancement", planIssueBlockedLabel}
 	}
@@ -759,8 +775,47 @@ func buildPromotionSpecDraft(data *collaborationSourceData, title string, blocke
 		Labels:         labels,
 		SourceLinks:    append([]string(nil), data.source.SourceLinks...),
 		BlockedBy:      append([]string(nil), blockedBy...),
-		ReadyByDefault: len(blockedBy) == 0,
+		ReadyByDefault: len(blockedBy) == 0 && exceptionPtr == nil,
 	}
+}
+
+func buildRefinementExceptions(data *collaborationSourceData, specTitles []string) map[string]PromotionRefinementException {
+	out := map[string]PromotionRefinementException{}
+	raw := strings.TrimSpace(data.openQs)
+	if raw == "" {
+		return out
+	}
+	lower := strings.ToLower(raw)
+	if !strings.Contains(lower, "needs-refinement") && !strings.Contains(lower, "refinement gap") {
+		return out
+	}
+	lines := bulletItems(raw)
+	if len(specTitles) == 1 {
+		out[specTitles[0]] = PromotionRefinementException{
+			IssueTitle:               specTitles[0],
+			Gap:                      strings.TrimSpace(raw),
+			WhyNotReady:              "The source still carries an explicit refinement gap that would force execution to guess.",
+			RecommendedClarification: "Resolve the explicit refinement gap before treating this spec as ready.",
+			ExitCriteria:             []string{"The remaining refinement gap is resolved or explicitly deferred."},
+		}
+		return out
+	}
+	for _, title := range specTitles {
+		for _, line := range lines {
+			if !strings.Contains(strings.ToLower(line), strings.ToLower(title)) {
+				continue
+			}
+			out[title] = PromotionRefinementException{
+				IssueTitle:               title,
+				Gap:                      strings.TrimSpace(line),
+				WhyNotReady:              "The source calls out a spec-specific refinement gap that still needs resolution.",
+				RecommendedClarification: "Resolve the explicit refinement note for this spec before execution starts.",
+				ExitCriteria:             []string{"The spec-specific refinement gap is resolved or removed from the source."},
+			}
+			break
+		}
+	}
+	return out
 }
 
 func renderPromotionSpecBody(title string, data *collaborationSourceData, blockedBy []string, exception *PromotionRefinementException) string {

--- a/internal/planning/guide_packet.go
+++ b/internal/planning/guide_packet.go
@@ -286,6 +286,8 @@ func (m *Manager) buildCollaborationGuidePacket(command, brainstormSlug, discuss
 	if err != nil {
 		return nil, err
 	}
+	brainstormSlug = strings.TrimSpace(brainstormSlug)
+	discussionRef = strings.TrimSpace(discussionRef)
 	meta, err := m.workspace.ReadWorkspaceMeta()
 	if err != nil {
 		return nil, err
@@ -786,7 +788,9 @@ func collaborationApplyActions(mode SourceOfTruthMode, sourceArg string, draft *
 }
 
 func collaborationSourceCommand(brainstormSlug, discussionRef string) (string, string) {
-	if strings.TrimSpace(brainstormSlug) != "" {
+	brainstormSlug = strings.TrimSpace(brainstormSlug)
+	discussionRef = strings.TrimSpace(discussionRef)
+	if brainstormSlug != "" {
 		return "--brainstorm " + brainstormSlug, "local brainstorm " + brainstormSlug
 	}
 	return "--discussion " + discussionRef, "GitHub Discussion " + discussionRef

--- a/internal/planning/guide_packet.go
+++ b/internal/planning/guide_packet.go
@@ -13,9 +13,10 @@ import (
 )
 
 const (
-	GuidePacketSchemaVersion = 1
+	GuidePacketSchemaVersion = 2
 	guidePacketKind          = "guide_packet"
-	guidePlanningMode        = "guided"
+	guidePlanningModeGuided  = "guided"
+	guidePlanningModeCollab  = "collaboration"
 )
 
 var brainstormGuideCheckpoints = map[string]struct{}{
@@ -26,19 +27,36 @@ var brainstormGuideCheckpoints = map[string]struct{}{
 	"handoff-epic":                 {},
 }
 
+var collaborationGuideStages = map[string]struct{}{
+	"discussion_assess": {},
+	"promotion_review":  {},
+	"initiative_draft":  {},
+	"spec_draft":        {},
+	"needs_refinement":  {},
+}
+
 type GuidePacket struct {
-	SchemaVersion  int                    `json:"schema_version"`
-	Kind           string                 `json:"kind"`
-	GeneratedAt    string                 `json:"generated_at"`
-	Builder        GuidePacketBuilderMeta `json:"builder"`
-	Workspace      GuidePacketWorkspace   `json:"workspace"`
-	Ownership      CollaborationOwnership `json:"ownership"`
-	Session        GuidePacketSession     `json:"session"`
-	Artifact       GuidePacketArtifact    `json:"artifact"`
-	Mode           GuidePacketMode        `json:"mode"`
-	Sources        []string               `json:"sources"`
-	Contract       GuidePacketContract    `json:"contract"`
-	RenderedPrompt string                 `json:"rendered_prompt"`
+	SchemaVersion  int                        `json:"schema_version"`
+	Kind           string                     `json:"kind"`
+	GeneratedAt    string                     `json:"generated_at"`
+	Builder        GuidePacketBuilderMeta     `json:"builder"`
+	Workspace      GuidePacketWorkspace       `json:"workspace"`
+	Ownership      CollaborationOwnership     `json:"ownership"`
+	Session        GuidePacketSession         `json:"session"`
+	Artifact       GuidePacketArtifact        `json:"artifact"`
+	Mode           GuidePacketMode            `json:"mode"`
+	Sources        []string                   `json:"sources"`
+	Collaboration  *GuidePacketCollaboration  `json:"collaboration,omitempty"`
+	Contract       GuidePacketContract        `json:"contract"`
+	RenderedDrafts []GuidePacketRenderedDraft `json:"rendered_drafts,omitempty"`
+	Actions        []GuidePacketAction        `json:"actions,omitempty"`
+	RenderedPrompt string                     `json:"rendered_prompt"`
+}
+
+type GuidePacketCollaboration struct {
+	Source         CollaborationSourceRef   `json:"source"`
+	Assessment     *CollaborationAssessment `json:"assessment,omitempty"`
+	PromotionDraft *PromotionDraft          `json:"promotion_draft,omitempty"`
 }
 
 type GuidePacketBuilderMeta struct {
@@ -79,6 +97,14 @@ type GuidePacketMode struct {
 	Pass       string `json:"pass"`
 }
 
+type GuidePacketRenderedDraft struct {
+	Kind      string `json:"kind"`
+	Title     string `json:"title"`
+	Body      string `json:"body"`
+	Slug      string `json:"slug,omitempty"`
+	Readiness string `json:"readiness,omitempty"`
+}
+
 type GuidePacketContract struct {
 	Role             string                      `json:"role"`
 	Stance           []string                    `json:"stance"`
@@ -112,6 +138,18 @@ type GuidePacketCommandHint struct {
 	Command string `json:"command"`
 }
 
+type GuidePacketAction struct {
+	ID                   string `json:"id"`
+	Kind                 string `json:"kind"`
+	Label                string `json:"label"`
+	Description          string `json:"description,omitempty"`
+	Command              string `json:"command,omitempty"`
+	Target               string `json:"target,omitempty"`
+	RequiresConfirmation bool   `json:"requires_confirmation,omitempty"`
+	Available            bool   `json:"available"`
+	BlockedReason        string `json:"blocked_reason,omitempty"`
+}
+
 func (m *Manager) CurrentGuidePacket() (*GuidePacket, error) {
 	session, err := m.ReadLastActiveGuidedSession()
 	if err != nil {
@@ -120,7 +158,7 @@ func (m *Manager) CurrentGuidePacket() (*GuidePacket, error) {
 		}
 		return nil, err
 	}
-	return m.buildGuidePacket("plan guide current", session, "", "")
+	return m.buildBrainstormGuidePacket("plan guide current", session, "", "")
 }
 
 func (m *Manager) GuidePacketForChain(chainID, stage, checkpoint string) (*GuidePacket, error) {
@@ -128,10 +166,14 @@ func (m *Manager) GuidePacketForChain(chainID, stage, checkpoint string) (*Guide
 	if err != nil {
 		return nil, err
 	}
-	return m.buildGuidePacket("plan guide show", session, stage, checkpoint)
+	return m.buildBrainstormGuidePacket("plan guide show", session, stage, checkpoint)
 }
 
-func (m *Manager) buildGuidePacket(command string, session *workspace.GuidedSessionRecord, stageOverride, checkpointOverride string) (*GuidePacket, error) {
+func (m *Manager) GuidePacketForCollaborationSource(brainstormSlug, discussionRef, stage string) (*GuidePacket, error) {
+	return m.buildCollaborationGuidePacket("plan guide show", brainstormSlug, discussionRef, stage)
+}
+
+func (m *Manager) buildBrainstormGuidePacket(command string, session *workspace.GuidedSessionRecord, stageOverride, checkpointOverride string) (*GuidePacket, error) {
 	if session == nil {
 		return nil, fmt.Errorf("guided session is required")
 	}
@@ -159,7 +201,7 @@ func (m *Manager) buildGuidePacket(command string, session *workspace.GuidedSess
 		effectiveStage = "brainstorm"
 	}
 	if effectiveStage != "brainstorm" {
-		return nil, fmt.Errorf("guide packets currently only support the brainstorm stage; use `--stage brainstorm` or switch back to a brainstorm session")
+		return nil, fmt.Errorf("guided session chain packets only support the brainstorm stage; use `--stage brainstorm` or a collaboration source")
 	}
 
 	effectiveCheckpoint := strings.TrimSpace(checkpointOverride)
@@ -198,7 +240,7 @@ func (m *Manager) buildGuidePacket(command string, session *workspace.GuidedSess
 		},
 		Workspace: GuidePacketWorkspace{
 			ProjectRoot:       info.ProjectDir,
-			PlanningMode:      guidePlanningMode,
+			PlanningMode:      guidePlanningModeGuided,
 			PlanningModel:     meta.PlanningModel,
 			SourceMode:        string(sourceMode),
 			StoryBackend:      string(meta.StoryBackend),
@@ -239,6 +281,108 @@ func (m *Manager) buildGuidePacket(command string, session *workspace.GuidedSess
 	return packet, nil
 }
 
+func (m *Manager) buildCollaborationGuidePacket(command, brainstormSlug, discussionRef, stage string) (*GuidePacket, error) {
+	info, err := m.workspace.EnsureInitialized()
+	if err != nil {
+		return nil, err
+	}
+	meta, err := m.workspace.ReadWorkspaceMeta()
+	if err != nil {
+		return nil, err
+	}
+	branch := ""
+	if githubState, err := m.workspace.ReadGitHubState(); err == nil {
+		branch = strings.TrimSpace(githubState.DefaultBranch)
+	}
+	sourceMode, err := m.SourceMode()
+	if err != nil {
+		return nil, err
+	}
+	data, ownership, err := m.loadCollaborationSourceData(brainstormSlug, discussionRef)
+	if err != nil {
+		return nil, err
+	}
+
+	effectiveStage := strings.TrimSpace(stage)
+	if effectiveStage == "" {
+		effectiveStage = "discussion_assess"
+	}
+	if _, ok := collaborationGuideStages[effectiveStage]; !ok {
+		return nil, fmt.Errorf("unsupported collaboration stage %q", effectiveStage)
+	}
+
+	assessment, err := m.AssessCollaborationSource(CollaborationAssessInput{
+		BrainstormSlug: brainstormSlug,
+		DiscussionRef:  discussionRef,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	var draft *PromotionDraft
+	if effectiveStage != "discussion_assess" {
+		draft, err = m.BuildPromotionDraft(PromotionDraftInput{
+			BrainstormSlug: brainstormSlug,
+			DiscussionRef:  discussionRef,
+		})
+		if err != nil {
+			return nil, err
+		}
+	}
+	if effectiveStage == "initiative_draft" && (draft == nil || draft.ProposedInitiativeIssue == nil) {
+		return nil, fmt.Errorf("guide packets for %q require a multi-spec promotion draft with an initiative issue", effectiveStage)
+	}
+	if effectiveStage == "spec_draft" && (draft == nil || len(draft.ProposedSpecIssues) == 0) {
+		return nil, fmt.Errorf("guide packets for %q require at least one promoted spec draft", effectiveStage)
+	}
+
+	artifact := buildCollaborationArtifact(data)
+	contract := collaborationGuideContract(effectiveStage, artifact.Path)
+	packet := &GuidePacket{
+		SchemaVersion: GuidePacketSchemaVersion,
+		Kind:          guidePacketKind,
+		GeneratedAt:   time.Now().UTC().Format(time.RFC3339),
+		Builder: GuidePacketBuilderMeta{
+			Command: command,
+			Format:  "json",
+		},
+		Workspace: GuidePacketWorkspace{
+			ProjectRoot:       info.ProjectDir,
+			PlanningMode:      guidePlanningModeCollab,
+			PlanningModel:     meta.PlanningModel,
+			SourceMode:        string(sourceMode),
+			StoryBackend:      string(meta.StoryBackend),
+			IntegrationBranch: branch,
+		},
+		Ownership: ownership,
+		Session: GuidePacketSession{
+			CurrentStage: effectiveStage,
+			Summary:      collaborationStageSummary(effectiveStage, assessment, draft),
+			NextAction:   collaborationNextAction(effectiveStage, ownership.Mode, assessment, draft),
+		},
+		Artifact: artifact,
+		Mode: GuidePacketMode{
+			Stage: effectiveStage,
+			Pass:  collaborationGuidePass(effectiveStage),
+		},
+		Sources: append([]string{
+			rel(info.ProjectDir, info.ProjectFile),
+			rel(info.ProjectDir, info.RoadmapFile),
+		}, data.source.SourceLinks...),
+		Collaboration: &GuidePacketCollaboration{
+			Source:         data.source,
+			Assessment:     assessment,
+			PromotionDraft: draft,
+		},
+		Contract:       contract,
+		RenderedDrafts: buildCollaborationRenderedDrafts(effectiveStage, draft),
+		Actions:        buildCollaborationActions(effectiveStage, ownership.Mode, brainstormSlug, discussionRef, assessment, draft),
+	}
+	sort.Strings(packet.Sources)
+	packet.RenderedPrompt = renderGuidePrompt(packet)
+	return packet, nil
+}
+
 func brainstormGuidePass(checkpoint string) string {
 	switch checkpoint {
 	case "vision-intake":
@@ -268,6 +412,418 @@ func brainstormGuideCheckpointIndex(checkpoint string, fallback int) int {
 		}
 		return 1
 	}
+}
+
+func collaborationGuidePass(stage string) string {
+	switch stage {
+	case "discussion_assess":
+		return "collaboration_assess"
+	case "promotion_review":
+		return "collaboration_review"
+	case "initiative_draft":
+		return "initiative_review"
+	case "spec_draft":
+		return "spec_review"
+	case "needs_refinement":
+		return "refinement_review"
+	default:
+		return "collaboration"
+	}
+}
+
+func buildCollaborationArtifact(data *collaborationSourceData) GuidePacketArtifact {
+	switch data.source.Mode {
+	case CollaborationSourceGitHubDiscussion:
+		title := data.title
+		if data.source.Discussion != nil && strings.TrimSpace(data.source.Discussion.Title) != "" {
+			title = data.source.Discussion.Title
+		}
+		path := firstNonEmpty(discussionURL(data.source.Discussion), firstNonEmpty(data.source.SourceLinks...))
+		return GuidePacketArtifact{
+			Type:   "github_discussion",
+			Slug:   fmt.Sprintf("discussion-%d", discussionNumber(data.source.Discussion)),
+			Title:  title,
+			Path:   path,
+			Status: "active",
+		}
+	default:
+		return GuidePacketArtifact{
+			Type:   "brainstorm",
+			Slug:   data.source.BrainstormSlug,
+			Title:  data.title,
+			Path:   data.source.BrainstormPath,
+			Status: "active",
+		}
+	}
+}
+
+func collaborationGuideContract(stage, artifactPath string) GuidePacketContract {
+	questionStrategy := GuidePacketQuestionStrategy{
+		ClusterSizeMin:        1,
+		ClusterSizeMax:        3,
+		ReflectOncePerCluster: true,
+		GapGuidance:           "keep_feedback_specific_and_execution_relevant",
+		MenuActions:           []string{"accept", "refine", "stop_for_now"},
+	}
+	artifactStrategy := GuidePacketArtifactStrategy{
+		WriteMode:       "review_only",
+		DurableArtifact: artifactPath,
+		PreserveRules: []string{
+			"Do not replace the canonical discuss payloads with ad hoc packet-only data.",
+			"Do not mutate the collaboration source while rendering the packet.",
+			"Do not invent execution-state automation during collaboration shaping.",
+		},
+		StrengthenSections: collaborationStrengthenSections(stage),
+	}
+
+	return GuidePacketContract{
+		Role:             "collaboration_shaping_facilitator",
+		Stance:           []string{"direct", "review_focused", "skeptical_when_needed", "preserve_canonical_contracts"},
+		Goal:             collaborationGuideGoal(stage),
+		QuestionStrategy: questionStrategy,
+		ArtifactStrategy: artifactStrategy,
+		Do:               collaborationGuideDo(stage),
+		Avoid: []string{
+			"Do not treat the guide packet as the canonical collaboration record.",
+			"Do not bypass the explicit review and confirmation flow.",
+			"Do not mutate GitHub or local planning state while previewing the packet.",
+		},
+		QualityBar: []string{
+			"The packet should make the next collaboration decision obvious without re-deriving the discuss payloads.",
+			"The rendered drafts and action objects should be specific enough for an agent runtime to follow directly.",
+		},
+		CompletionGate: collaborationCompletionGate(stage),
+		CommandHints:   collaborationCommandHints(stage),
+	}
+}
+
+func collaborationGuideGoal(stage string) string {
+	switch stage {
+	case "discussion_assess":
+		return "Assess whether the current collaboration source is mature enough for promotion."
+	case "promotion_review":
+		return "Review the promotion draft before any apply step can mutate GitHub or local planning state."
+	case "initiative_draft":
+		return "Pressure-test the proposed initiative issue body and milestone-backed multi-spec wrapper."
+	case "spec_draft":
+		return "Pressure-test the proposed spec issue bodies, readiness states, and dependency shape."
+	case "needs_refinement":
+		return "Review any explicit refinement exceptions before promotion continues."
+	default:
+		return "Guide the collaboration shaping flow."
+	}
+}
+
+func collaborationGuideDo(stage string) []string {
+	items := []string{
+		"Use the embedded collaboration payloads as the canonical source of truth.",
+		"Keep feedback specific to the current stage instead of reopening the whole planning flow.",
+	}
+	switch stage {
+	case "discussion_assess":
+		return append(items,
+			"Focus on whether the source is not ready, single-spec ready, or multi-spec ready.",
+			"Call out concrete missing inputs rather than generic uncertainty.",
+		)
+	case "promotion_review":
+		return append(items,
+			"Review the draft issue set, dependency plan, and milestone/project guidance before any apply action.",
+			"Prefer specific corrections to titles, bodies, and dependencies over vague approval.",
+		)
+	case "initiative_draft":
+		return append(items,
+			"Review whether the initiative body explains outcome, scope boundary, specs, and milestone clearly.",
+			"Make sure the initiative stays lightweight and does not become a second execution layer.",
+		)
+	case "spec_draft":
+		return append(items,
+			"Check that proposed spec bodies are bounded, verifiable, and correctly marked ready or blocked.",
+			"Preserve the distinction between parent/sub-issue grouping and blocked-by ordering.",
+		)
+	case "needs_refinement":
+		return append(items,
+			"Review only the specs that have explicit refinement exceptions.",
+			"Translate each exception into a concrete next clarification instead of letting it stay vague.",
+		)
+	default:
+		return items
+	}
+}
+
+func collaborationCompletionGate(stage string) []string {
+	switch stage {
+	case "discussion_assess":
+		return []string{
+			"It is clear whether the source is not ready, ready for one spec, or ready for multiple specs.",
+			"The next collaboration move is obvious from the packet actions.",
+		}
+	case "promotion_review":
+		return []string{
+			"The proposed issue set is concrete enough to confirm or refine.",
+			"Any apply action is gated behind explicit confirmation.",
+		}
+	case "initiative_draft":
+		return []string{
+			"The initiative wrapper is specific enough to anchor the multi-spec set without redefining the work.",
+			"The milestone-backed grouping is clear.",
+		}
+	case "spec_draft":
+		return []string{
+			"Each spec draft has an acceptable body, readiness state, and dependency shape.",
+			"The packet makes clear which specs are ready, blocked, or need refinement.",
+		}
+	case "needs_refinement":
+		return []string{
+			"Each refinement exception names a concrete gap, why it blocks execution, and what would resolve it.",
+			"If no refinement exceptions exist, the packet says so explicitly.",
+		}
+	default:
+		return []string{"The current collaboration stage is specific enough to continue without guessing."}
+	}
+}
+
+func collaborationCommandHints(stage string) []GuidePacketCommandHint {
+	hints := []GuidePacketCommandHint{
+		{
+			Purpose: "refresh_assessment",
+			Command: "plan discuss assess --project . <source> --format json",
+		},
+		{
+			Purpose: "refresh_promotion_draft",
+			Command: "plan discuss promote --project . <source> --format json",
+		},
+	}
+	switch stage {
+	case "promotion_review", "initiative_draft", "spec_draft", "needs_refinement":
+		hints = append(hints, GuidePacketCommandHint{
+			Purpose: "apply_confirmed_promotion",
+			Command: "plan discuss promote --project . <source> --apply --confirm --target <github|hybrid> --format json",
+		})
+	}
+	return hints
+}
+
+func collaborationStrengthenSections(stage string) []string {
+	switch stage {
+	case "discussion_assess":
+		return []string{"Problem", "Goals", "Constraints", "Non-Goals", "Proposed Shape"}
+	case "promotion_review":
+		return []string{"Promotion Decision", "Dependency Plan", "Milestone Plan", "Project Prompt"}
+	case "initiative_draft":
+		return []string{"Initiative", "Outcome", "Scope Boundary", "Specs", "Milestone"}
+	case "spec_draft":
+		return []string{"Spec", "Goals", "Constraints", "Verification", "Dependencies", "Readiness"}
+	case "needs_refinement":
+		return []string{"Refinement Gap", "Why Not Ready", "Recommended Clarification", "Exit Criteria"}
+	default:
+		return []string{"Problem", "Goals"}
+	}
+}
+
+func collaborationStageSummary(stage string, assessment *CollaborationAssessment, draft *PromotionDraft) string {
+	switch stage {
+	case "discussion_assess":
+		if assessment != nil {
+			return defaultString(assessment.Decision.Reason, "Assess the collaboration source for promotion readiness.")
+		}
+	case "promotion_review", "initiative_draft", "spec_draft", "needs_refinement":
+		if draft != nil {
+			return defaultString(draft.WhyThisPath, "Review the promotion draft before any write step.")
+		}
+	}
+	return "Review the collaboration shaping packet."
+}
+
+func collaborationNextAction(stage string, mode SourceOfTruthMode, assessment *CollaborationAssessment, draft *PromotionDraft) string {
+	switch stage {
+	case "discussion_assess":
+		if assessment != nil && assessment.Decision.State == MaturityNotReady {
+			return "Refine the source material until the missing gaps are resolved, then reassess."
+		}
+		return "Review the promotion draft before any apply action."
+	case "promotion_review":
+		return nextApplyAction(mode, draft)
+	case "initiative_draft":
+		return "Finalize the initiative wrapper details, then return to the promotion review or apply step."
+	case "spec_draft":
+		return "Finalize the spec drafts and dependency shape, then confirm the promotion."
+	case "needs_refinement":
+		if draft != nil && len(draft.NeedsRefinementExceptions) == 0 {
+			return "No spec starts in needs-refinement right now; return to promotion review."
+		}
+		return "Resolve the refinement exceptions or accept them before applying the promotion."
+	default:
+		return "Continue collaboration shaping."
+	}
+}
+
+func buildCollaborationRenderedDrafts(stage string, draft *PromotionDraft) []GuidePacketRenderedDraft {
+	if draft == nil {
+		return nil
+	}
+	rendered := []GuidePacketRenderedDraft{}
+	switch stage {
+	case "initiative_draft":
+		if draft.ProposedInitiativeIssue != nil {
+			rendered = append(rendered, GuidePacketRenderedDraft{
+				Kind:      "initiative_issue",
+				Title:     draft.ProposedInitiativeIssue.Title,
+				Body:      draft.ProposedInitiativeIssue.Body,
+				Slug:      draft.ProposedInitiativeIssue.Slug,
+				Readiness: string(draft.ProposedInitiativeIssue.Readiness),
+			})
+		}
+	case "spec_draft", "promotion_review":
+		for _, item := range draft.ProposedSpecIssues {
+			rendered = append(rendered, GuidePacketRenderedDraft{
+				Kind:      "spec_issue",
+				Title:     item.Title,
+				Body:      item.Body,
+				Slug:      item.Slug,
+				Readiness: string(item.Readiness),
+			})
+		}
+		if stage == "promotion_review" && draft.ProposedInitiativeIssue != nil {
+			rendered = append([]GuidePacketRenderedDraft{{
+				Kind:      "initiative_issue",
+				Title:     draft.ProposedInitiativeIssue.Title,
+				Body:      draft.ProposedInitiativeIssue.Body,
+				Slug:      draft.ProposedInitiativeIssue.Slug,
+				Readiness: string(draft.ProposedInitiativeIssue.Readiness),
+			}}, rendered...)
+		}
+	case "needs_refinement":
+		if len(draft.NeedsRefinementExceptions) == 0 {
+			rendered = append(rendered, GuidePacketRenderedDraft{
+				Kind:  "refinement_summary",
+				Title: "No specs currently need refinement",
+				Body:  "The promotion draft does not currently mark any spec as `needs-refinement`.",
+			})
+			return rendered
+		}
+		for _, item := range draft.NeedsRefinementExceptions {
+			rendered = append(rendered, GuidePacketRenderedDraft{
+				Kind:      "refinement_exception",
+				Title:     item.IssueTitle,
+				Body:      renderRefinementException(item),
+				Slug:      slugify(item.IssueTitle),
+				Readiness: "needs-refinement",
+			})
+		}
+	}
+	return rendered
+}
+
+func buildCollaborationActions(stage string, mode SourceOfTruthMode, brainstormSlug, discussionRef string, assessment *CollaborationAssessment, draft *PromotionDraft) []GuidePacketAction {
+	sourceArg, display := collaborationSourceCommand(brainstormSlug, discussionRef)
+	actions := []GuidePacketAction{
+		{
+			ID:        "refresh_assessment",
+			Kind:      "refresh",
+			Label:     "Refresh assessment",
+			Command:   "plan discuss assess --project . " + sourceArg + " --format json",
+			Target:    "assessment",
+			Available: true,
+		},
+	}
+	if stage != "discussion_assess" {
+		actions = append(actions, GuidePacketAction{
+			ID:          "refresh_promotion_draft",
+			Kind:        "review",
+			Label:       "Refresh promotion draft",
+			Description: "Rebuild the current promotion draft from " + display + ".",
+			Command:     "plan discuss promote --project . " + sourceArg + " --format json",
+			Target:      "promotion_draft",
+			Available:   true,
+		})
+	}
+	if stage == "promotion_review" || stage == "initiative_draft" || stage == "spec_draft" || stage == "needs_refinement" {
+		actions = append(actions, collaborationApplyActions(mode, sourceArg, draft)...)
+	}
+	if stage == "discussion_assess" && assessment != nil && assessment.Decision.State != MaturityNotReady {
+		actions = append(actions, GuidePacketAction{
+			ID:          "build_promotion_draft",
+			Kind:        "review",
+			Label:       "Build promotion draft",
+			Description: "Move from maturity assessment into the promotion draft review.",
+			Command:     "plan discuss promote --project . " + sourceArg + " --format json",
+			Target:      "promotion_draft",
+			Available:   true,
+		})
+	}
+	return actions
+}
+
+func collaborationApplyActions(mode SourceOfTruthMode, sourceArg string, draft *PromotionDraft) []GuidePacketAction {
+	if draft == nil {
+		return nil
+	}
+	makeAction := func(id, label, target string, targetMode SourceOfTruthMode, available bool, blockedReason string) GuidePacketAction {
+		return GuidePacketAction{
+			ID:                   id,
+			Kind:                 "apply",
+			Label:                label,
+			Description:          "Apply the reviewed promotion draft to " + string(targetMode) + ".",
+			Command:              "plan discuss promote --project . " + sourceArg + " --apply --confirm --target " + string(targetMode) + " --format json",
+			Target:               target,
+			RequiresConfirmation: true,
+			Available:            available,
+			BlockedReason:        blockedReason,
+		}
+	}
+
+	switch mode {
+	case SourceOfTruthGitHub:
+		return []GuidePacketAction{makeAction("apply_github", "Apply to GitHub", "promotion_apply", SourceOfTruthGitHub, true, "")}
+	case SourceOfTruthHybrid:
+		return []GuidePacketAction{makeAction("apply_hybrid", "Apply to Hybrid", "promotion_apply", SourceOfTruthHybrid, true, "")}
+	default:
+		return []GuidePacketAction{
+			makeAction("apply_github", "Apply to GitHub", "promotion_apply", SourceOfTruthGitHub, true, ""),
+			makeAction("apply_hybrid", "Apply to Hybrid", "promotion_apply", SourceOfTruthHybrid, true, ""),
+		}
+	}
+}
+
+func collaborationSourceCommand(brainstormSlug, discussionRef string) (string, string) {
+	if strings.TrimSpace(brainstormSlug) != "" {
+		return "--brainstorm " + brainstormSlug, "local brainstorm " + brainstormSlug
+	}
+	return "--discussion " + discussionRef, "GitHub Discussion " + discussionRef
+}
+
+func nextApplyAction(mode SourceOfTruthMode, draft *PromotionDraft) string {
+	if draft == nil {
+		return "Refresh the promotion draft before applying it."
+	}
+	switch mode {
+	case SourceOfTruthGitHub:
+		return "Review the draft and confirm `plan discuss promote --apply --confirm --target github` when it is ready."
+	case SourceOfTruthHybrid:
+		return "Review the draft and confirm `plan discuss promote --apply --confirm --target hybrid` when it is ready."
+	default:
+		return "Review the draft and choose whether to apply it to `github` or `hybrid` ownership."
+	}
+}
+
+func renderRefinementException(item PromotionRefinementException) string {
+	lines := []string{
+		"## Refinement Gap",
+		defaultString(item.Gap, "-"),
+		"",
+		"## Why Not Ready",
+		defaultString(item.WhyNotReady, "-"),
+		"",
+		"## Recommended Clarification",
+		defaultString(item.RecommendedClarification, "-"),
+	}
+	if len(item.ExitCriteria) > 0 {
+		lines = append(lines, "", "## Exit Criteria")
+		for _, criterion := range item.ExitCriteria {
+			lines = append(lines, "- "+criterion)
+		}
+	}
+	return strings.TrimSpace(strings.Join(lines, "\n"))
 }
 
 func brainstormGuideContract(session *workspace.GuidedSessionRecord, checkpoint, artifactPath string) GuidePacketContract {
@@ -380,6 +936,13 @@ func brainstormStrengthenSections(checkpoint string) []string {
 }
 
 func renderGuidePrompt(packet *GuidePacket) string {
+	if packet.Collaboration != nil {
+		return renderCollaborationGuidePrompt(packet)
+	}
+	return renderBrainstormGuidePrompt(packet)
+}
+
+func renderBrainstormGuidePrompt(packet *GuidePacket) string {
 	var lines []string
 	lines = append(lines, "You are guiding the brainstorm stage for `plan`.")
 	lines = append(lines, "Goal: "+packet.Contract.Goal)
@@ -398,6 +961,54 @@ func renderGuidePrompt(packet *GuidePacket) string {
 	lines = append(lines, "Completion gate:")
 	for _, item := range packet.Contract.CompletionGate {
 		lines = append(lines, "- "+item)
+	}
+	return strings.Join(lines, "\n")
+}
+
+func renderCollaborationGuidePrompt(packet *GuidePacket) string {
+	var lines []string
+	source := packet.Collaboration.Source.CanonicalSource
+	lines = append(lines, "You are guiding the collaboration shaping stage for `plan`.")
+	lines = append(lines, "Goal: "+packet.Contract.Goal)
+	lines = append(lines, "Stage: "+packet.Mode.Stage)
+	lines = append(lines, "Source: "+defaultString(source, "collaboration_source"))
+	lines = append(lines, "Current summary: "+defaultString(packet.Session.Summary, "No collaboration summary saved yet."))
+	lines = append(lines, "Next action: "+defaultString(packet.Session.NextAction, "Review the current collaboration packet."))
+	lines = append(lines, "Durable artifact: "+packet.Contract.ArtifactStrategy.DurableArtifact)
+	if packet.Collaboration.Assessment != nil {
+		lines = append(lines, "Assessment: "+string(packet.Collaboration.Assessment.Decision.State))
+	}
+	if packet.Collaboration.PromotionDraft != nil && packet.Collaboration.PromotionDraft.PromotionDecision != "" {
+		lines = append(lines, "Promotion decision: "+string(packet.Collaboration.PromotionDraft.PromotionDecision))
+	}
+	lines = append(lines, "Do:")
+	for _, item := range packet.Contract.Do {
+		lines = append(lines, "- "+item)
+	}
+	lines = append(lines, "Avoid:")
+	for _, item := range packet.Contract.Avoid {
+		lines = append(lines, "- "+item)
+	}
+	lines = append(lines, "Completion gate:")
+	for _, item := range packet.Contract.CompletionGate {
+		lines = append(lines, "- "+item)
+	}
+	if len(packet.Actions) > 0 {
+		lines = append(lines, "Actions:")
+		for _, action := range packet.Actions {
+			status := "available"
+			if !action.Available {
+				status = "blocked"
+			}
+			line := fmt.Sprintf("- %s (%s)", action.Label, status)
+			if action.RequiresConfirmation {
+				line += " requires confirmation"
+			}
+			if strings.TrimSpace(action.BlockedReason) != "" {
+				line += ": " + action.BlockedReason
+			}
+			lines = append(lines, line)
+		}
 	}
 	return strings.Join(lines, "\n")
 }

--- a/internal/planning/guide_packet_test.go
+++ b/internal/planning/guide_packet_test.go
@@ -180,3 +180,195 @@ func TestCurrentGuidePacketDefaultsBlankSourceModeToLocal(t *testing.T) {
 		t.Fatalf("expected local ownership fallback: %+v", packet.Ownership)
 	}
 }
+
+func TestGuidePacketForLocalCollaborationSourceEmbedsCanonicalDraftsAndActions(t *testing.T) {
+	root := t.TempDir()
+	ws := workspace.New(root)
+	if _, err := ws.Init(); err != nil {
+		t.Fatal(err)
+	}
+	manager := New(ws)
+	createReadyCollaborationBrainstorm(t, manager, "guide-packet-collaboration")
+
+	packet, err := manager.GuidePacketForCollaborationSource("guide-packet-collaboration", "", "promotion_review")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if packet.Workspace.PlanningMode != guidePlanningModeCollab {
+		t.Fatalf("expected collaboration planning mode: %+v", packet.Workspace)
+	}
+	if packet.Collaboration == nil || packet.Collaboration.Assessment == nil || packet.Collaboration.PromotionDraft == nil {
+		t.Fatalf("expected embedded collaboration payloads: %+v", packet.Collaboration)
+	}
+	if packet.Collaboration.Assessment.Kind != maturityAssessmentKind {
+		t.Fatalf("expected canonical assessment payload: %+v", packet.Collaboration.Assessment)
+	}
+	if packet.Collaboration.PromotionDraft.Kind != promotionDraftKind {
+		t.Fatalf("expected canonical promotion draft payload: %+v", packet.Collaboration.PromotionDraft)
+	}
+	if len(packet.RenderedDrafts) != 1 || packet.RenderedDrafts[0].Kind != "spec_issue" {
+		t.Fatalf("expected rendered spec draft in packet: %+v", packet.RenderedDrafts)
+	}
+	if len(packet.Actions) < 3 {
+		t.Fatalf("expected structured review/apply actions: %+v", packet.Actions)
+	}
+	if !packet.Actions[1].Available || packet.Actions[1].Command == "" {
+		t.Fatalf("expected refresh draft action with command: %+v", packet.Actions[1])
+	}
+	foundConfirm := false
+	for _, action := range packet.Actions {
+		if action.RequiresConfirmation {
+			foundConfirm = true
+			break
+		}
+	}
+	if !foundConfirm {
+		t.Fatalf("expected explicit confirm action in packet: %+v", packet.Actions)
+	}
+}
+
+func TestGuidePacketForDiscussionSourceSupportsInitiativeDraftStage(t *testing.T) {
+	client := &stubGitHubClient{
+		preflight: &GitHubRepoInfo{
+			Repo:          "JimmyMcBride/plan",
+			RepoURL:       "https://github.com/JimmyMcBride/plan",
+			DefaultBranch: "develop",
+		},
+		context: &GitHubContext{
+			Repo: GitHubRepoInfo{
+				Repo:          "JimmyMcBride/plan",
+				RepoURL:       "https://github.com/JimmyMcBride/plan",
+				DefaultBranch: "develop",
+			},
+			CurrentBranch: "develop",
+			CurrentSHA:    "abc123",
+		},
+		discussions: map[int]*GitHubDiscussion{
+			49: {
+				Number: 49,
+				URL:    "https://github.com/JimmyMcBride/plan/discussions/49",
+				Title:  "Guide packet collaboration",
+				Body: strings.Join([]string{
+					"## Problem",
+					"Guide packets need collaboration-stage coverage.",
+					"",
+					"## Goals",
+					"Wrap the existing discuss contracts in runtime guidance.",
+					"",
+					"## Non-Goals",
+					"Do not replace canonical collaboration payloads.",
+					"",
+					"## Constraints",
+					"Keep JSON canonical and review-first.",
+					"",
+					"## Proposed Shape",
+					"Use one initiative issue and two spec issues.",
+					"",
+					"## Spec Split",
+					"- Guide packet v2 schema",
+					"- Guide packet v2 CLI",
+					"",
+					"Guide packet v2 CLI depends on Guide packet v2 schema.",
+				}, "\n"),
+			},
+		},
+	}
+	reset := SetGitHubClientFactoryForTesting(func() GitHubClient { return client })
+	defer reset()
+
+	root := t.TempDir()
+	ws := workspace.New(root)
+	if _, err := ws.Init(); err != nil {
+		t.Fatal(err)
+	}
+	manager := New(ws)
+
+	packet, err := manager.GuidePacketForCollaborationSource("", "49", "initiative_draft")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if packet.Collaboration == nil || packet.Collaboration.Source.Mode != CollaborationSourceGitHubDiscussion {
+		t.Fatalf("expected GitHub Discussion collaboration source: %+v", packet.Collaboration)
+	}
+	if len(packet.RenderedDrafts) != 1 || packet.RenderedDrafts[0].Kind != "initiative_issue" {
+		t.Fatalf("expected initiative draft rendering: %+v", packet.RenderedDrafts)
+	}
+	if packet.Artifact.Type != "github_discussion" {
+		t.Fatalf("expected discussion artifact: %+v", packet.Artifact)
+	}
+	if !strings.Contains(packet.RenderedPrompt, "Promotion decision: multi_spec") {
+		t.Fatalf("expected rendered prompt to include collaboration draft context: %s", packet.RenderedPrompt)
+	}
+}
+
+func TestGuidePacketNeedsRefinementStageRendersExplicitExceptions(t *testing.T) {
+	root := t.TempDir()
+	ws := workspace.New(root)
+	if _, err := ws.Init(); err != nil {
+		t.Fatal(err)
+	}
+	manager := New(ws)
+	createReadyCollaborationBrainstorm(t, manager, "guide-packet-needs-refinement")
+	if _, err := manager.UpdateBrainstormRefinement("guide-packet-needs-refinement", BrainstormRefinementInput{
+		Problem:                "Guide packet v2 needs a concrete refinement exception path.",
+		UserValue:              "The user can see exactly why a spec is not ready yet.",
+		Constraints:            "Keep JSON canonical.",
+		Appetite:               "One collaboration slice.",
+		RemainingOpenQuestions: "Needs-refinement: clarify the verification contract before execution.",
+		CandidateApproaches:    "Wrap discuss contracts.\nRender stage prompts.",
+		DecisionSnapshot:       "Promote directly into one spec once the gap is explicit.",
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	packet, err := manager.GuidePacketForCollaborationSource("guide-packet-needs-refinement", "", "needs_refinement")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if packet.Collaboration == nil || packet.Collaboration.PromotionDraft == nil {
+		t.Fatalf("expected promotion draft in needs-refinement packet: %+v", packet.Collaboration)
+	}
+	if len(packet.Collaboration.PromotionDraft.NeedsRefinementExceptions) != 1 {
+		t.Fatalf("expected one explicit refinement exception: %+v", packet.Collaboration.PromotionDraft.NeedsRefinementExceptions)
+	}
+	if len(packet.RenderedDrafts) != 1 || packet.RenderedDrafts[0].Kind != "refinement_exception" {
+		t.Fatalf("expected rendered refinement exception: %+v", packet.RenderedDrafts)
+	}
+	if !strings.Contains(packet.RenderedDrafts[0].Body, "## Recommended Clarification") {
+		t.Fatalf("expected rendered refinement markdown body: %s", packet.RenderedDrafts[0].Body)
+	}
+}
+
+func createReadyCollaborationBrainstorm(t *testing.T, manager *Manager, slug string) {
+	t.Helper()
+	title := strings.ReplaceAll(slug, "-", " ")
+	if _, err := manager.CreateBrainstorm(title); err != nil {
+		t.Fatal(err)
+	}
+	if _, _, err := manager.UpdateGuidedBrainstormIntake(slug, GuidedBrainstormIntakeInput{
+		Vision:             "Wrap collaboration shaping in runtime guide packets.",
+		SupportingMaterial: "docs/using-plan.md",
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := manager.UpdateBrainstormRefinement(slug, BrainstormRefinementInput{
+		Problem:                "Guide packets stop at brainstorm guidance today.",
+		UserValue:              "Agents need runtime help around collaboration shaping and promotion review.",
+		Constraints:            "Keep JSON canonical.\nDo not replace discuss contracts.",
+		Appetite:               "One bounded collaboration slice.",
+		RemainingOpenQuestions: "",
+		CandidateApproaches:    "Wrap maturity assessment.\nWrap promotion draft.",
+		DecisionSnapshot:       "Promote directly into one spec while collaboration scope stays bounded.",
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := manager.UpdateBrainstormChallenge(slug, BrainstormChallengeInput{
+		RabbitHoles:           "Do not add execution-state automation.",
+		NoGos:                 "No custom review UI.",
+		Assumptions:           "Guide packets can stay JSON-first.",
+		LikelyOverengineering: "Replacing canonical discuss payloads.",
+		SimplerAlternative:    "Embed the canonical payloads and add runtime guidance around them.",
+	}); err != nil {
+		t.Fatal(err)
+	}
+}

--- a/internal/planning/guide_packet_test.go
+++ b/internal/planning/guide_packet_test.go
@@ -212,8 +212,18 @@ func TestGuidePacketForLocalCollaborationSourceEmbedsCanonicalDraftsAndActions(t
 	if len(packet.Actions) < 3 {
 		t.Fatalf("expected structured review/apply actions: %+v", packet.Actions)
 	}
-	if !packet.Actions[1].Available || packet.Actions[1].Command == "" {
-		t.Fatalf("expected refresh draft action with command: %+v", packet.Actions[1])
+	var refreshAction *GuidePacketAction
+	for i := range packet.Actions {
+		if packet.Actions[i].ID == "refresh_promotion_draft" {
+			refreshAction = &packet.Actions[i]
+			break
+		}
+	}
+	if refreshAction == nil {
+		t.Fatalf("expected refresh draft action in packet: %+v", packet.Actions)
+	}
+	if !refreshAction.Available || refreshAction.Command == "" {
+		t.Fatalf("expected refresh draft action with command: %+v", *refreshAction)
 	}
 	foundConfirm := false
 	for _, action := range packet.Actions {
@@ -224,6 +234,18 @@ func TestGuidePacketForLocalCollaborationSourceEmbedsCanonicalDraftsAndActions(t
 	}
 	if !foundConfirm {
 		t.Fatalf("expected explicit confirm action in packet: %+v", packet.Actions)
+	}
+}
+
+func TestCollaborationSourceCommandTrimsSelectorValues(t *testing.T) {
+	command, display := collaborationSourceCommand("  demo-brainstorm  ", "")
+	if command != "--brainstorm demo-brainstorm" || display != "local brainstorm demo-brainstorm" {
+		t.Fatalf("expected trimmed brainstorm selector, got command=%q display=%q", command, display)
+	}
+
+	command, display = collaborationSourceCommand("", "  49  ")
+	if command != "--discussion 49" || display != "GitHub Discussion 49" {
+		t.Fatalf("expected trimmed discussion selector, got command=%q display=%q", command, display)
 	}
 }
 

--- a/skills/plan/SKILL.md
+++ b/skills/plan/SKILL.md
@@ -52,7 +52,9 @@ When a repo uses `plan`:
 - `plan discuss promote --project . --brainstorm <brainstorm-slug> --format json`
 - `plan discuss promote --project . --discussion <number-or-url> --format json`
 - `plan guide current --project . --format json` when a guided brainstorm session is active
-- `plan guide show --project . --chain <chain-id> --stage brainstorm --checkpoint <checkpoint> --format json` for explicit preview/debug use
+- `plan guide show --project . --chain <chain-id> --stage brainstorm --checkpoint <checkpoint> --format json` for explicit brainstorm preview/debug use
+- `plan guide show --project . --brainstorm <brainstorm-slug> --stage <discussion_assess|promotion_review|initiative_draft|spec_draft|needs_refinement> --format json`
+- `plan guide show --project . --discussion <number-or-url> --stage <discussion_assess|promotion_review|initiative_draft|spec_draft|needs_refinement> --format json`
 - `plan epic create|promote|shape ...` only when a repo still depends on the legacy transition path
 - `plan spec show --project . <spec-slug>`
 - `plan spec analyze --project . <spec-slug>`
@@ -78,6 +80,7 @@ When a repo uses `plan`:
 - `discuss promote` should stay draft-first unless the task explicitly calls for `--apply --confirm`.
 - today, `discuss promote --apply` is implemented for `github` and `hybrid`; repo-backed local promotion still uses the legacy compatibility path
 - When a guided brainstorm session is active, prefer live guide packets over static stage prose.
+- For collaboration shaping, use `plan guide show` to wrap the canonical `discuss` payloads instead of inventing a parallel promotion contract.
 - `epic shape` is now a legacy compatibility pass, not the preferred active model.
 - `spec analyze` should pressure-test a spec without rewriting its canonical sections.
 - `spec checklist` should add profile-driven rigor without mutating the canonical sections.


### PR DESCRIPTION
## Summary

- add collaboration-stage guide packet support on top of the shipped `discuss` assessment and promotion contracts
- expand `plan guide show` to preview collaboration packets from a local brainstorm or GitHub Discussion source
- add rendered draft payloads, explicit review/confirm action objects, and doc/skill updates for the new packet surface

## Target Branch

- Normal work targets `develop`.

## Testing

- [x] `go test ./...`
- [x] `go build ./...`
- [x] Other: `git diff --check`

## Release Notes

- User-facing change: `plan guide show` can now emit collaboration-stage guide packets for `discussion_assess`, `promotion_review`, `initiative_draft`, `spec_draft`, and `needs_refinement` from `--brainstorm` or `--discussion` sources.
- Planning or workflow impact: guide packets now wrap canonical `maturity_assessment` and `promotion_draft` payloads with rendered drafts and explicit review/confirm action objects.
- Follow-up work: none in this PR beyond future execution of the new guide packet v2 follow-on work.

## Planning

- Related epic/spec/story: #48, #57, #58, #59

Closes #48
Closes #57
Closes #58
Closes #59
