### PR TITLE
[codex] Enforce fail-closed GitHub promotion flow

### DIFF
--- a/.brain/context/current-state.md
+++ b/.brain/context/current-state.md
@@ -1,5 +1,5 @@
 ---
-updated: "2026-04-25T04:43:54Z"
+updated: "2026-04-25T05:03:09Z"
 ---
 # Current State
 
@@ -36,3 +36,4 @@ Add repo-specific notes here. `brain context refresh` preserves content outside 
 - On April 23, 2026, PR `#55` review feedback tightened the GitHub collaboration foundation: promotion dependency edges now wire in a second pass after all issues exist, guide packets default blank `source_mode` to `local`, GraphQL responses now fail on `errors` and paginate Discussion comments, promotion drafts keep `proposed_spec_issues` as a stable empty array when not ready, and bullet parsing strips GitHub task-list markers before deriving spec titles.
 - On April 23, 2026, workspace refresh stopped backfilling optional compatibility defaults into tracked metadata during `plan update`: `source_mode` and GitHub `planning` map now default in memory on read, so `./scripts/refresh-plan-develop-context.sh` no longer dirties `develop` just to normalize older `.plan/.meta/*.json` files.
 - On April 25, 2026, GitHub promotion became fail-closed: explicit multi-spec sources that parse as fewer than two specs now return `needs_source_repair`, `plan discuss repair` owns canonical `## Specs` repair, promotion drafts include hard agent policy and fallback gating, 5+ spec apply/adopt requires `--project-decision`, `plan github adopt` recovers manual issue sets, and `plan check` detects Plan-labeled GitHub planning drift.
+- On April 25, 2026, PR `#62` review comments tightened the fail-closed promotion branch: GitHub issue listing now raises on 1000-item truncation instead of silently missing Plan-labeled issues, `github adopt` validates output format before mutation, drift findings are deterministic and preserve milestone display casing, label ensuring only touches Plan-owned `plan:*` labels, and shell command quoting reuses a package-level regex.

--- a/.brain/context/current-state.md
+++ b/.brain/context/current-state.md
@@ -1,5 +1,5 @@
 ---
-updated: "2026-04-22T20:01:22Z"
+updated: "2026-04-25T04:43:54Z"
 ---
 # Current State
 
@@ -35,3 +35,4 @@ Add repo-specific notes here. `brain context refresh` preserves content outside 
 - On April 22, 2026, the GitHub collaboration foundation landed on `codex/github-collaboration-foundation`: `plan source show|set`, `plan discuss assess|promote`, GitHub Discussion assessment, draft-first promotion, initiative/spec issue orchestration, milestone creation, dependency wiring, and local planning mirrors in `.plan/.meta/github.json`.
 - On April 23, 2026, PR `#55` review feedback tightened the GitHub collaboration foundation: promotion dependency edges now wire in a second pass after all issues exist, guide packets default blank `source_mode` to `local`, GraphQL responses now fail on `errors` and paginate Discussion comments, promotion drafts keep `proposed_spec_issues` as a stable empty array when not ready, and bullet parsing strips GitHub task-list markers before deriving spec titles.
 - On April 23, 2026, workspace refresh stopped backfilling optional compatibility defaults into tracked metadata during `plan update`: `source_mode` and GitHub `planning` map now default in memory on read, so `./scripts/refresh-plan-develop-context.sh` no longer dirties `develop` just to normalize older `.plan/.meta/*.json` files.
+- On April 25, 2026, GitHub promotion became fail-closed: explicit multi-spec sources that parse as fewer than two specs now return `needs_source_repair`, `plan discuss repair` owns canonical `## Specs` repair, promotion drafts include hard agent policy and fallback gating, 5+ spec apply/adopt requires `--project-decision`, `plan github adopt` recovers manual issue sets, and `plan check` detects Plan-labeled GitHub planning drift.

--- a/README.md
+++ b/README.md
@@ -154,6 +154,11 @@ plan discuss promote --project . --discussion 49 --format json
 plan discuss promote --project . --discussion 49 --apply --confirm --target github --format json
 ```
 
+If Plan says the source needs repair, use the emitted repair command before
+promotion. In GitHub or hybrid source mode, do not create planning issues,
+labels, or milestones manually unless Plan emitted `manual_fallback_allowed=true`;
+after any allowed fallback, run `plan github adopt`.
+
 Full guide:
 
 - [Using plan](docs/using-plan.md)
@@ -168,11 +173,12 @@ Full guide:
 - `plan brainstorm start|idea|show|refine`
 - `plan brainstorm challenge`
 - `plan discuss assess|promote`
+- `plan discuss repair`
 - `plan guide current|show` for brainstorm and collaboration guide packets
 - `plan epic create|promote|list|show|shape` for legacy compatibility during migration
 - `plan spec show|edit|status|analyze|checklist|initiative|execute|handoff`
 - `plan story create|update|list|show|slice|critique` for legacy compatibility during migration
-- `plan github enable|reconcile`
+- `plan github enable|reconcile|adopt`
 - `plan roadmap show|edit`
 - `plan check`
 - `plan status`

--- a/cmd/discuss.go
+++ b/cmd/discuss.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"strings"
 
@@ -41,12 +42,13 @@ func newDiscussCommand() *cobra.Command {
 	assess.Flags().StringVar(&assessFormat, "format", "json", "output format: json")
 
 	var (
-		promoteBrainstorm string
-		promoteDiscussion string
-		promoteFormat     string
-		promoteApply      bool
-		promoteConfirm    bool
-		promoteTarget     string
+		promoteBrainstorm      string
+		promoteDiscussion      string
+		promoteFormat          string
+		promoteApply           bool
+		promoteConfirm         bool
+		promoteTarget          string
+		promoteProjectDecision string
 	)
 	promote := &cobra.Command{
 		Use:   "promote",
@@ -64,12 +66,19 @@ func newDiscussCommand() *cobra.Command {
 				return writeDiscussJSON(cmd, promoteFormat, draft)
 			}
 			result, err := planningManager().ApplyPromotionDraft(planning.PromotionApplyInput{
-				BrainstormSlug: promoteBrainstorm,
-				DiscussionRef:  promoteDiscussion,
-				Confirm:        promoteConfirm,
-				TargetMode:     planning.SourceOfTruthMode(strings.TrimSpace(promoteTarget)),
+				BrainstormSlug:  promoteBrainstorm,
+				DiscussionRef:   promoteDiscussion,
+				Confirm:         promoteConfirm,
+				TargetMode:      planning.SourceOfTruthMode(strings.TrimSpace(promoteTarget)),
+				ProjectDecision: strings.TrimSpace(promoteProjectDecision),
 			})
 			if err != nil {
+				var fallback *planning.PromotionApplyManualFallbackError
+				if errors.As(err, &fallback) && fallback.Result != nil {
+					if writeErr := writeDiscussJSON(cmd, promoteFormat, fallback.Result); writeErr != nil {
+						return writeErr
+					}
+				}
 				return err
 			}
 			return writeDiscussJSON(cmd, promoteFormat, result)
@@ -81,8 +90,40 @@ func newDiscussCommand() *cobra.Command {
 	promote.Flags().BoolVar(&promoteApply, "apply", false, "create the promoted GitHub issue set after review")
 	promote.Flags().BoolVar(&promoteConfirm, "confirm", false, "required acknowledgement before apply mutates GitHub")
 	promote.Flags().StringVar(&promoteTarget, "target", "", "promotion ownership target: local, github, or hybrid")
+	promote.Flags().StringVar(&promoteProjectDecision, "project-decision", "", "project prompt decision for 5+ spec promotions: create or skip")
 
-	cmd.AddCommand(assess, promote)
+	var (
+		repairBrainstorm string
+		repairDiscussion string
+		repairFormat     string
+		repairSpecs      []string
+		repairConfirm    bool
+	)
+	repair := &cobra.Command{
+		Use:     "repair",
+		Aliases: []string{"repair-spec-split"},
+		Short:   "Repair a collaboration source with a canonical Specs section",
+		Args:    cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			result, err := planningManager().RepairSpecSplit(planning.RepairSpecSplitInput{
+				BrainstormSlug: repairBrainstorm,
+				DiscussionRef:  repairDiscussion,
+				Specs:          repairSpecs,
+				Confirm:        repairConfirm,
+			})
+			if err != nil {
+				return err
+			}
+			return writeDiscussJSON(cmd, repairFormat, result)
+		},
+	}
+	repair.Flags().StringVar(&repairBrainstorm, "brainstorm", "", "local brainstorm slug to repair")
+	repair.Flags().StringVar(&repairDiscussion, "discussion", "", "GitHub Discussion number or URL to repair")
+	repair.Flags().StringVar(&repairFormat, "format", "json", "output format: json")
+	repair.Flags().StringArrayVar(&repairSpecs, "spec", nil, "spec title for the repaired split; repeat for each spec")
+	repair.Flags().BoolVar(&repairConfirm, "confirm", false, "required acknowledgement before repairing a GitHub Discussion")
+
+	cmd.AddCommand(assess, promote, repair)
 	return cmd
 }
 

--- a/cmd/discuss_test.go
+++ b/cmd/discuss_test.go
@@ -3,6 +3,8 @@ package cmd
 import (
 	"bytes"
 	"encoding/json"
+	"os"
+	"strings"
 	"testing"
 
 	"plan/internal/planning"
@@ -60,6 +62,50 @@ func TestDiscussAssessCommandPrintsJSONForBrainstorm(t *testing.T) {
 	}
 	if payload.Kind != "maturity_assessment" || payload.Decision.State != planning.MaturityReadySingleSpec {
 		t.Fatalf("unexpected discuss assess payload: %+v", payload)
+	}
+}
+
+func TestDiscussRepairCommandWritesSpecsSection(t *testing.T) {
+	root := t.TempDir()
+	ws := workspace.New(root)
+	if _, err := ws.Init(); err != nil {
+		t.Fatal(err)
+	}
+	manager := planning.New(ws)
+	if _, err := manager.CreateBrainstorm("Repair Command"); err != nil {
+		t.Fatal(err)
+	}
+
+	var buf bytes.Buffer
+	command := newRootCmd()
+	command.SetOut(&buf)
+	command.SetErr(&buf)
+	command.SetArgs([]string{
+		"--project", root,
+		"discuss", "repair",
+		"--brainstorm", "repair-command",
+		"--spec", "Operational Data UI CRUD",
+		"--spec", "Readiness Dashboard",
+		"--format", "json",
+	})
+	if err := command.Execute(); err != nil {
+		t.Fatalf("expected discuss repair to succeed: %v\n%s", err, buf.String())
+	}
+
+	var payload planning.RepairSpecSplitResult
+	if err := json.Unmarshal(buf.Bytes(), &payload); err != nil {
+		t.Fatalf("expected JSON repair output, got %v\n%s", err, buf.String())
+	}
+	if len(payload.Specs) != 2 || payload.Kind != "source_repair" {
+		t.Fatalf("unexpected repair payload: %+v", payload)
+	}
+	raw, err := os.ReadFile(root + "/.plan/brainstorms/repair-command.md")
+	if err != nil {
+		t.Fatal(err)
+	}
+	body := string(raw)
+	if !strings.Contains(body, "## Specs") || !strings.Contains(body, "- Operational Data UI CRUD") || !strings.Contains(body, "- Readiness Dashboard") {
+		t.Fatalf("expected repaired specs section:\n%s", body)
 	}
 }
 

--- a/cmd/github.go
+++ b/cmd/github.go
@@ -73,6 +73,9 @@ func newGitHubCommand() *cobra.Command {
 		Short: "Adopt existing GitHub planning issues into Plan metadata",
 		Args:  cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
+			if strings.TrimSpace(adoptFormat) != "json" {
+				return fmt.Errorf("unsupported github adopt output format %q; only json is supported", adoptFormat)
+			}
 			issueNumbers, err := parseIssueNumbers(adoptIssues)
 			if err != nil {
 				return err
@@ -85,9 +88,6 @@ func newGitHubCommand() *cobra.Command {
 			})
 			if err != nil {
 				return err
-			}
-			if strings.TrimSpace(adoptFormat) != "json" {
-				return fmt.Errorf("unsupported github adopt output format %q; only json is supported", adoptFormat)
 			}
 			encoder := json.NewEncoder(cmd.OutOrStdout())
 			encoder.SetIndent("", "  ")

--- a/cmd/github.go
+++ b/cmd/github.go
@@ -1,7 +1,9 @@
 package cmd
 
 import (
+	"encoding/json"
 	"fmt"
+	"strconv"
 	"strings"
 
 	"plan/internal/planning"
@@ -59,6 +61,66 @@ func newGitHubCommand() *cobra.Command {
 	}
 	reconcile.Flags().BoolVar(&updateVisible, "update-visible", false, "update optional GitHub-visible readiness markers while reconciling")
 
-	cmd.AddCommand(enable, reconcile)
+	var (
+		adoptBrainstorm      string
+		adoptDiscussion      string
+		adoptIssues          []string
+		adoptFormat          string
+		adoptProjectDecision string
+	)
+	adopt := &cobra.Command{
+		Use:   "adopt",
+		Short: "Adopt existing GitHub planning issues into Plan metadata",
+		Args:  cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			issueNumbers, err := parseIssueNumbers(adoptIssues)
+			if err != nil {
+				return err
+			}
+			result, err := planningManager().AdoptGitHubPromotion(planning.GitHubAdoptInput{
+				BrainstormSlug:  adoptBrainstorm,
+				DiscussionRef:   adoptDiscussion,
+				IssueNumbers:    issueNumbers,
+				ProjectDecision: strings.TrimSpace(adoptProjectDecision),
+			})
+			if err != nil {
+				return err
+			}
+			if strings.TrimSpace(adoptFormat) != "json" {
+				return fmt.Errorf("unsupported github adopt output format %q; only json is supported", adoptFormat)
+			}
+			encoder := json.NewEncoder(cmd.OutOrStdout())
+			encoder.SetIndent("", "  ")
+			return encoder.Encode(result)
+		},
+	}
+	adopt.Flags().StringVar(&adoptBrainstorm, "brainstorm", "", "local brainstorm slug that produced the promotion draft")
+	adopt.Flags().StringVar(&adoptDiscussion, "discussion", "", "GitHub Discussion number or URL that produced the promotion draft")
+	adopt.Flags().StringSliceVar(&adoptIssues, "issues", nil, "GitHub issue numbers in draft order, comma-separated or repeated")
+	adopt.Flags().StringVar(&adoptFormat, "format", "json", "output format: json")
+	adopt.Flags().StringVar(&adoptProjectDecision, "project-decision", "", "project prompt decision for 5+ spec promotions: create or skip")
+
+	cmd.AddCommand(enable, reconcile, adopt)
 	return cmd
+}
+
+func parseIssueNumbers(values []string) ([]int, error) {
+	var out []int
+	for _, value := range values {
+		for _, part := range strings.Split(value, ",") {
+			part = strings.TrimSpace(strings.TrimPrefix(part, "#"))
+			if part == "" {
+				continue
+			}
+			number, err := strconv.Atoi(part)
+			if err != nil || number <= 0 {
+				return nil, fmt.Errorf("invalid issue number %q", part)
+			}
+			out = append(out, number)
+		}
+	}
+	if len(out) == 0 {
+		return nil, fmt.Errorf("github adopt requires --issues")
+	}
+	return out, nil
 }

--- a/cmd/github_test.go
+++ b/cmd/github_test.go
@@ -2,6 +2,8 @@ package cmd
 
 import (
 	"bytes"
+	"encoding/json"
+	"strings"
 	"testing"
 
 	"plan/internal/planning"
@@ -36,6 +38,14 @@ func (s *stubGitHubEnableClient) GetIssue(projectDir, repo string, issueNumber i
 	panic("unexpected GetIssue call")
 }
 
+func (s *stubGitHubEnableClient) ListIssuesByLabel(projectDir, repo string, labels []string) ([]planning.GitHubIssue, error) {
+	panic("unexpected ListIssuesByLabel call")
+}
+
+func (s *stubGitHubEnableClient) EnsureLabel(projectDir, repo string, input planning.GitHubLabelInput) error {
+	panic("unexpected EnsureLabel call")
+}
+
 func (s *stubGitHubEnableClient) FindMilestone(projectDir, repo, title string) (*planning.GitHubMilestone, error) {
 	panic("unexpected FindMilestone call")
 }
@@ -46,6 +56,10 @@ func (s *stubGitHubEnableClient) CreateMilestone(projectDir, repo string, input 
 
 func (s *stubGitHubEnableClient) GetDiscussion(projectDir, repo string, number int) (*planning.GitHubDiscussion, error) {
 	panic("unexpected GetDiscussion call")
+}
+
+func (s *stubGitHubEnableClient) UpdateDiscussionBody(projectDir, repo string, number int, body string) (*planning.GitHubDiscussion, error) {
+	panic("unexpected UpdateDiscussionBody call")
 }
 
 func (s *stubGitHubEnableClient) AddSubIssue(projectDir, repo string, issueNumber, subIssueNumber int) error {
@@ -86,6 +100,82 @@ func TestGitHubEnableCommandPrintsBackendSummary(t *testing.T) {
 	output := buf.String()
 	if !containsLine(output, "github_backend: github") || !containsLine(output, "repo: JimmyMcBride/plan") || !containsLine(output, "default_branch: main") {
 		t.Fatalf("unexpected github enable output:\n%s", output)
+	}
+}
+
+func TestGitHubAdoptCommandPrintsJSON(t *testing.T) {
+	client := &stubGitHubStoryClient{
+		preflight: &planning.GitHubRepoInfo{
+			Repo:          "JimmyMcBride/plan",
+			RepoURL:       "https://github.com/JimmyMcBride/plan",
+			DefaultBranch: "develop",
+		},
+		context: &planning.GitHubContext{
+			Repo: planning.GitHubRepoInfo{
+				Repo:          "JimmyMcBride/plan",
+				RepoURL:       "https://github.com/JimmyMcBride/plan",
+				DefaultBranch: "develop",
+			},
+			CurrentBranch: "develop",
+			CurrentSHA:    "abc123",
+		},
+		issues: map[int]*planning.GitHubIssue{
+			201: {Number: 201, URL: "https://github.com/JimmyMcBride/plan/issues/201", Title: "Adopt Command", State: "open"},
+			202: {Number: 202, URL: "https://github.com/JimmyMcBride/plan/issues/202", Title: "Adopt command schema", State: "open"},
+			203: {Number: 203, URL: "https://github.com/JimmyMcBride/plan/issues/203", Title: "Adopt command CLI", State: "open"},
+		},
+		discussions: map[int]*planning.GitHubDiscussion{
+			90: {
+				Number: 90,
+				URL:    "https://github.com/JimmyMcBride/plan/discussions/90",
+				Title:  "Adopt Command",
+				Body: strings.Join([]string{
+					"## Problem",
+					"Existing issues need Plan metadata adoption.",
+					"",
+					"## Goals",
+					"Adopt the issue set.",
+					"",
+					"## Non-Goals",
+					"Do not create unrelated issues.",
+					"",
+					"## Constraints",
+					"Keep issue order explicit.",
+					"",
+					"## Proposed Shape",
+					"Use two spec issues.",
+					"",
+					"## Spec Split",
+					"- Adopt command schema",
+					"- Adopt command CLI",
+				}, "\n"),
+			},
+		},
+	}
+	reset := planning.SetGitHubClientFactoryForTesting(func() planning.GitHubClient { return client })
+	t.Cleanup(reset)
+
+	root := t.TempDir()
+	ws := workspace.New(root)
+	if _, err := ws.Init(); err != nil {
+		t.Fatal(err)
+	}
+
+	var buf bytes.Buffer
+	command := newRootCmd()
+	command.SetOut(&buf)
+	command.SetErr(&buf)
+	command.SetArgs([]string{"--project", root, "github", "adopt", "--discussion", "90", "--issues", "201,202,203", "--format", "json"})
+	if err := command.Execute(); err != nil {
+		t.Fatalf("expected github adopt to succeed: %v\n%s", err, buf.String())
+	}
+
+	var payload planning.GitHubAdoptResult
+	if err := json.Unmarshal(buf.Bytes(), &payload); err != nil {
+		t.Fatalf("expected JSON output, got %v\n%s", err, buf.String())
+	}
+	if payload.Initiative == nil || len(payload.Specs) != 2 {
+		t.Fatalf("unexpected adopt payload: %+v", payload)
 	}
 }
 

--- a/cmd/guide_test.go
+++ b/cmd/guide_test.go
@@ -450,6 +450,14 @@ func (s *stubGuideGitHubClient) GetIssue(projectDir, repo string, issueNumber in
 	return nil, nil
 }
 
+func (s *stubGuideGitHubClient) ListIssuesByLabel(projectDir, repo string, labels []string) ([]planning.GitHubIssue, error) {
+	return nil, nil
+}
+
+func (s *stubGuideGitHubClient) EnsureLabel(projectDir, repo string, input planning.GitHubLabelInput) error {
+	return nil
+}
+
 func (s *stubGuideGitHubClient) FindMilestone(projectDir, repo, title string) (*planning.GitHubMilestone, error) {
 	return nil, nil
 }
@@ -459,6 +467,11 @@ func (s *stubGuideGitHubClient) CreateMilestone(projectDir, repo string, input p
 }
 
 func (s *stubGuideGitHubClient) GetDiscussion(projectDir, repo string, number int) (*planning.GitHubDiscussion, error) {
+	return s.discussions[number], nil
+}
+
+func (s *stubGuideGitHubClient) UpdateDiscussionBody(projectDir, repo string, number int, body string) (*planning.GitHubDiscussion, error) {
+	s.discussions[number].Body = body
 	return s.discussions[number], nil
 }
 

--- a/cmd/story_github_test.go
+++ b/cmd/story_github_test.go
@@ -61,6 +61,14 @@ func (s *stubGitHubStoryClient) GetIssue(projectDir, repo string, issueNumber in
 	return &copy, nil
 }
 
+func (s *stubGitHubStoryClient) ListIssuesByLabel(projectDir, repo string, labels []string) ([]planning.GitHubIssue, error) {
+	return nil, nil
+}
+
+func (s *stubGitHubStoryClient) EnsureLabel(projectDir, repo string, input planning.GitHubLabelInput) error {
+	return nil
+}
+
 func (s *stubGitHubStoryClient) FindMilestone(projectDir, repo, title string) (*planning.GitHubMilestone, error) {
 	return nil, nil
 }
@@ -80,6 +88,16 @@ func (s *stubGitHubStoryClient) GetDiscussion(projectDir, repo string, number in
 	copy := *item
 	copy.Comments = append([]planning.GitHubDiscussionComment(nil), item.Comments...)
 	return &copy, nil
+}
+
+func (s *stubGitHubStoryClient) UpdateDiscussionBody(projectDir, repo string, number int, body string) (*planning.GitHubDiscussion, error) {
+	item, err := s.GetDiscussion(projectDir, repo, number)
+	if err != nil {
+		return nil, err
+	}
+	item.Body = body
+	s.discussions[number].Body = body
+	return item, nil
 }
 
 func (s *stubGitHubStoryClient) AddSubIssue(projectDir, repo string, issueNumber, subIssueNumber int) error {

--- a/docs/using-plan.md
+++ b/docs/using-plan.md
@@ -307,6 +307,7 @@ plan discuss assess --project . --discussion 49 --format json
 The assessment decides whether the source is:
 
 - `not_ready`
+- `needs_source_repair`
 - `ready_single_spec`
 - `ready_multi_spec`
 
@@ -317,6 +318,15 @@ The JSON output includes:
 - recommended path
 - suggested issue titles
 - an initial dependency guess
+- a blocking repair command when explicit multi-spec intent cannot be parsed
+
+If the source asks for multiple spec issues but Plan cannot parse at least two
+spec titles, repair the source instead of creating GitHub issues manually:
+
+```bash
+plan discuss repair --project . --brainstorm newsletter-system --spec "Template CRUD" --spec "Preview API" --format json
+plan discuss repair --project . --discussion 49 --spec "Template CRUD" --spec "Preview API" --confirm --format json
+```
 
 ### 6. Review The Promotion Draft
 
@@ -342,6 +352,8 @@ The draft tells you:
 - whether a milestone should be created
 - whether a project should be recommended
 - whether any spec should start with `needs-refinement`
+- the agent policy that forbids manual GitHub planning mutations unless Plan
+  emits `manual_fallback_allowed=true`
 
 Rules:
 
@@ -373,6 +385,11 @@ Current shipped boundary:
   compatibility path to create the local spec file today
 - the promoted issue body becomes the canonical distilled planning artifact
 - the original GitHub Discussion stays linked as collaboration history
+- promotions with 5+ specs require `--project-decision create|skip` so project
+  tracking is never silently skipped
+- if a valid apply path fails on the GitHub API, Plan emits
+  `manual_fallback_allowed=true`; only then may an agent use manual `gh`
+  commands, followed by `plan github adopt`
 
 When a multi-spec promotion is applied, `plan` will:
 
@@ -386,6 +403,12 @@ When a multi-spec promotion is applied, `plan` will:
 
 By default, new spec issues are `ready`. A spec starts as `needs-refinement`
 only when the draft identified a concrete execution gap.
+
+Recover manually-created or pre-existing planning issues with:
+
+```bash
+plan github adopt --project . --discussion 49 --issues 101,102,103 --format json
+```
 
 ### 8. Preview Collaboration Guide Packets
 

--- a/internal/planning/check.go
+++ b/internal/planning/check.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"sort"
 	"strconv"
 	"strings"
 
@@ -153,6 +154,7 @@ func (m *Manager) checkGitHubPlanningDrift(info *workspace.Info) ([]CheckFinding
 	recordsByIssue := map[int]workspace.GitHubPlanningRecord{}
 	specsByParent := map[int]int{}
 	specsByMilestone := map[string]int{}
+	milestoneTitlesByKey := map[string]string{}
 	for _, record := range state.Planning {
 		if record.IssueNumber > 0 {
 			recordsByIssue[record.IssueNumber] = record
@@ -164,6 +166,9 @@ func (m *Manager) checkGitHubPlanningDrift(info *workspace.Info) ([]CheckFinding
 			}
 			if key := milestoneKey(record.MilestoneNumber, record.MilestoneTitle); key != "" {
 				specsByMilestone[key]++
+				if milestoneTitlesByKey[key] == "" {
+					milestoneTitlesByKey[key] = strings.TrimSpace(record.MilestoneTitle)
+				}
 			}
 		}
 	}
@@ -228,6 +233,10 @@ func (m *Manager) checkGitHubPlanningDrift(info *workspace.Info) ([]CheckFinding
 			continue
 		}
 		number, title := splitMilestoneKey(key)
+		displayTitle := milestoneTitlesByKey[key]
+		if displayTitle == "" {
+			displayTitle = title
+		}
 		if hasProjectDecisionForMilestone(state, number, title) {
 			continue
 		}
@@ -235,10 +244,10 @@ func (m *Manager) checkGitHubPlanningDrift(info *workspace.Info) ([]CheckFinding
 			Severity:      "error",
 			Rule:          "github_planning.missing_project_decision",
 			ArtifactType:  "github_milestone",
-			ArtifactPath:  title,
-			ArtifactTitle: title,
+			ArtifactPath:  displayTitle,
+			ArtifactTitle: displayTitle,
 			Section:       "GitHub Planning",
-			Message:       fmt.Sprintf("Milestone %q has %d promoted specs but no project prompt decision record.", title, count),
+			Message:       fmt.Sprintf("Milestone %q has %d promoted specs but no project prompt decision record.", displayTitle, count),
 			Suggestion:    "Rerun promotion/adoption with `--project-decision create|skip` so coordination intent is explicit.",
 		})
 	}
@@ -260,6 +269,9 @@ func (m *Manager) planLabeledIssues(projectDir, repo string) ([]GitHubIssue, err
 	for _, issue := range byNumber {
 		out = append(out, issue)
 	}
+	sort.Slice(out, func(i, j int) bool {
+		return out[i].Number < out[j].Number
+	})
 	return out, nil
 }
 

--- a/internal/planning/check.go
+++ b/internal/planning/check.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 
 	"plan/internal/notes"
@@ -77,6 +78,11 @@ func (m *Manager) Check(input CheckInput) (*CheckReport, error) {
 	for _, story := range stories {
 		report.Findings = append(report.Findings, checkStoryNote(rel(info.ProjectDir, story.Path), story)...)
 	}
+	githubFindings, err := m.checkGitHubPlanningDrift(info)
+	if err != nil {
+		return nil, err
+	}
+	report.Findings = append(report.Findings, githubFindings...)
 
 	return report, nil
 }
@@ -117,6 +123,186 @@ func (m *Manager) storyNotesForCheck(info *workspace.Info, input CheckInput) ([]
 	default:
 		return nil, nil
 	}
+}
+
+func (m *Manager) checkGitHubPlanningDrift(info *workspace.Info) ([]CheckFinding, error) {
+	meta, err := m.workspace.ReadWorkspaceMeta()
+	if err != nil {
+		return nil, err
+	}
+	if meta.SourceMode != workspace.SourceOfTruthGitHub && meta.SourceMode != workspace.SourceOfTruthHybrid {
+		return nil, nil
+	}
+	state, err := m.workspace.ReadGitHubState()
+	if err != nil {
+		return nil, err
+	}
+	repo := strings.TrimSpace(state.Repo)
+	if repo == "" {
+		context, err := m.github.CurrentContext(info.ProjectDir)
+		if err != nil {
+			return nil, err
+		}
+		repo = context.Repo.Repo
+	}
+	remoteIssues, err := m.planLabeledIssues(info.ProjectDir, repo)
+	if err != nil {
+		return nil, err
+	}
+
+	recordsByIssue := map[int]workspace.GitHubPlanningRecord{}
+	specsByParent := map[int]int{}
+	specsByMilestone := map[string]int{}
+	for _, record := range state.Planning {
+		if record.IssueNumber > 0 {
+			recordsByIssue[record.IssueNumber] = record
+		}
+		switch record.Kind {
+		case "spec":
+			if record.ParentIssueNumber > 0 {
+				specsByParent[record.ParentIssueNumber]++
+			}
+			if key := milestoneKey(record.MilestoneNumber, record.MilestoneTitle); key != "" {
+				specsByMilestone[key]++
+			}
+		}
+	}
+
+	var findings []CheckFinding
+	initiativeTitles := map[string]struct{}{}
+	for _, record := range state.Planning {
+		if record.Kind != "initiative" {
+			continue
+		}
+		initiativeTitles[strings.ToLower(record.Title)] = struct{}{}
+		initiativeTitles[strings.ToLower(record.Slug)] = struct{}{}
+		if specsByParent[record.IssueNumber] > 1 && record.MilestoneNumber == 0 {
+			findings = append(findings, githubDriftFinding(
+				"github_planning.missing_multi_spec_milestone",
+				record.IssueURL,
+				record.Title,
+				"Multi-spec initiative is missing milestone metadata.",
+				"Run `plan github adopt` or rerun `plan discuss promote --apply` so the milestone is created and mirrored.",
+			))
+		}
+	}
+
+	for _, issue := range remoteIssues {
+		record, tracked := recordsByIssue[issue.Number]
+		if !tracked {
+			findings = append(findings, githubDriftFinding(
+				"github_planning.untracked_issue",
+				issue.URL,
+				issue.Title,
+				"GitHub planning issue has a Plan label but no .plan/.meta/github.json planning record.",
+				"Run `plan github adopt` with the source and issue numbers, or remove the Plan label if this is not Plan-managed.",
+			))
+		}
+		if issue.Milestone == nil {
+			for _, label := range issue.Labels {
+				if _, ok := initiativeTitles[strings.ToLower(label)]; ok {
+					findings = append(findings, githubDriftFinding(
+						"github_planning.label_used_as_milestone",
+						issue.URL,
+						issue.Title,
+						fmt.Sprintf("Issue uses label %q where Plan expects the initiative milestone.", label),
+						"Remove the grouping label and attach the issue to the Plan-created milestone.",
+					))
+					break
+				}
+			}
+		}
+		if tracked && record.Kind == "initiative" && issue.Milestone == nil && specsByParent[record.IssueNumber] > 1 {
+			findings = append(findings, githubDriftFinding(
+				"github_planning.remote_missing_milestone",
+				issue.URL,
+				issue.Title,
+				"Remote multi-spec initiative issue is not attached to its milestone.",
+				"Run `plan github adopt` to attach the milestone and refresh metadata.",
+			))
+		}
+	}
+
+	for key, count := range specsByMilestone {
+		if count < 5 {
+			continue
+		}
+		number, title := splitMilestoneKey(key)
+		if hasProjectDecisionForMilestone(state, number, title) {
+			continue
+		}
+		findings = append(findings, CheckFinding{
+			Severity:      "error",
+			Rule:          "github_planning.missing_project_decision",
+			ArtifactType:  "github_milestone",
+			ArtifactPath:  title,
+			ArtifactTitle: title,
+			Section:       "GitHub Planning",
+			Message:       fmt.Sprintf("Milestone %q has %d promoted specs but no project prompt decision record.", title, count),
+			Suggestion:    "Rerun promotion/adoption with `--project-decision create|skip` so coordination intent is explicit.",
+		})
+	}
+	return findings, nil
+}
+
+func (m *Manager) planLabeledIssues(projectDir, repo string) ([]GitHubIssue, error) {
+	byNumber := map[int]GitHubIssue{}
+	for _, label := range []string{planIssueInitiativeLabel, planIssueSpecLabel} {
+		issues, err := m.github.ListIssuesByLabel(projectDir, repo, []string{label})
+		if err != nil {
+			return nil, err
+		}
+		for _, issue := range issues {
+			byNumber[issue.Number] = issue
+		}
+	}
+	out := make([]GitHubIssue, 0, len(byNumber))
+	for _, issue := range byNumber {
+		out = append(out, issue)
+	}
+	return out, nil
+}
+
+func githubDriftFinding(rule, path, title, message, suggestion string) CheckFinding {
+	return CheckFinding{
+		Severity:      "error",
+		Rule:          rule,
+		ArtifactType:  "github_issue",
+		ArtifactPath:  path,
+		ArtifactTitle: title,
+		Section:       "GitHub Planning",
+		Message:       message,
+		Suggestion:    suggestion,
+	}
+}
+
+func milestoneKey(number int, title string) string {
+	title = strings.TrimSpace(title)
+	if number == 0 && title == "" {
+		return ""
+	}
+	return fmt.Sprintf("%d:%s", number, strings.ToLower(title))
+}
+
+func splitMilestoneKey(key string) (int, string) {
+	parts := strings.SplitN(key, ":", 2)
+	if len(parts) != 2 {
+		return 0, key
+	}
+	number, _ := strconv.Atoi(parts[0])
+	return number, parts[1]
+}
+
+func hasProjectDecisionForMilestone(state *workspace.GitHubState, number int, title string) bool {
+	for _, decision := range state.ProjectDecisions {
+		if number > 0 && decision.MilestoneNumber == number {
+			return true
+		}
+		if strings.EqualFold(strings.TrimSpace(decision.MilestoneTitle), strings.TrimSpace(title)) && strings.TrimSpace(title) != "" {
+			return true
+		}
+	}
+	return false
 }
 
 func (m *Manager) readStoriesByFilter(info *workspace.Info, keep func(StoryInfo) bool) ([]*notes.Note, error) {

--- a/internal/planning/check_test.go
+++ b/internal/planning/check_test.go
@@ -1,6 +1,7 @@
 package planning
 
 import (
+	"fmt"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -287,4 +288,121 @@ func TestCheckStorySupportsGitHubBackedStories(t *testing.T) {
 	if report.HasErrors() {
 		t.Fatalf("expected GitHub-backed story check to pass: %+v", report.Findings)
 	}
+}
+
+func TestCheckFlagsUntrackedPlanLabeledGitHubIssue(t *testing.T) {
+	client := checkDriftClient(map[int]*GitHubIssue{
+		301: {Number: 301, URL: "https://github.com/JimmyMcBride/plan/issues/301", Title: "Manual Spec", State: "open", Labels: []string{planIssueSpecLabel}},
+	})
+	reset := SetGitHubClientFactoryForTesting(func() GitHubClient { return client })
+	t.Cleanup(reset)
+	manager := setupGitHubSourceModeCheck(t)
+
+	report, err := manager.Check(CheckInput{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	assertHasFinding(t, report.Findings, "github_planning.untracked_issue", "GitHub Planning")
+}
+
+func TestCheckFlagsMultiSpecInitiativeWithoutMilestone(t *testing.T) {
+	reset := SetGitHubClientFactoryForTesting(func() GitHubClient { return checkDriftClient(nil) })
+	t.Cleanup(reset)
+	manager := setupGitHubSourceModeCheck(t)
+	state, err := manager.workspace.ReadGitHubState()
+	if err != nil {
+		t.Fatal(err)
+	}
+	state.Planning["initiative"] = workspace.GitHubPlanningRecord{Slug: "initiative", Kind: "initiative", Title: "Initiative", IssueNumber: 401, IssueURL: "https://github.com/JimmyMcBride/plan/issues/401"}
+	state.Planning["spec-a"] = workspace.GitHubPlanningRecord{Slug: "spec-a", Kind: "spec", Title: "Spec A", IssueNumber: 402, ParentIssueNumber: 401}
+	state.Planning["spec-b"] = workspace.GitHubPlanningRecord{Slug: "spec-b", Kind: "spec", Title: "Spec B", IssueNumber: 403, ParentIssueNumber: 401}
+	if err := manager.workspace.WriteGitHubState(*state); err != nil {
+		t.Fatal(err)
+	}
+
+	report, err := manager.Check(CheckInput{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	assertHasFinding(t, report.Findings, "github_planning.missing_multi_spec_milestone", "GitHub Planning")
+}
+
+func TestCheckFlagsMissingProjectDecisionForFiveSpecMilestone(t *testing.T) {
+	reset := SetGitHubClientFactoryForTesting(func() GitHubClient { return checkDriftClient(nil) })
+	t.Cleanup(reset)
+	manager := setupGitHubSourceModeCheck(t)
+	state, err := manager.workspace.ReadGitHubState()
+	if err != nil {
+		t.Fatal(err)
+	}
+	for i := 0; i < 5; i++ {
+		slug := fmt.Sprintf("spec-%d", i)
+		state.Planning[slug] = workspace.GitHubPlanningRecord{
+			Slug:            slug,
+			Kind:            "spec",
+			Title:           fmt.Sprintf("Spec %d", i),
+			IssueNumber:     500 + i,
+			MilestoneNumber: 7,
+			MilestoneTitle:  "Readiness",
+		}
+	}
+	if err := manager.workspace.WriteGitHubState(*state); err != nil {
+		t.Fatal(err)
+	}
+
+	report, err := manager.Check(CheckInput{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	assertHasFinding(t, report.Findings, "github_planning.missing_project_decision", "GitHub Planning")
+}
+
+func TestCheckFlagsLabelUsedWhereMilestoneExpected(t *testing.T) {
+	client := checkDriftClient(map[int]*GitHubIssue{
+		601: {Number: 601, URL: "https://github.com/JimmyMcBride/plan/issues/601", Title: "Spec", State: "open", Labels: []string{planIssueSpecLabel, "Readiness Initiative"}},
+	})
+	reset := SetGitHubClientFactoryForTesting(func() GitHubClient { return client })
+	t.Cleanup(reset)
+	manager := setupGitHubSourceModeCheck(t)
+	state, err := manager.workspace.ReadGitHubState()
+	if err != nil {
+		t.Fatal(err)
+	}
+	state.Planning["readiness-initiative"] = workspace.GitHubPlanningRecord{Slug: "readiness-initiative", Kind: "initiative", Title: "Readiness Initiative", IssueNumber: 600}
+	state.Planning["spec"] = workspace.GitHubPlanningRecord{Slug: "spec", Kind: "spec", Title: "Spec", IssueNumber: 601, ParentIssueNumber: 600}
+	if err := manager.workspace.WriteGitHubState(*state); err != nil {
+		t.Fatal(err)
+	}
+
+	report, err := manager.Check(CheckInput{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	assertHasFinding(t, report.Findings, "github_planning.label_used_as_milestone", "GitHub Planning")
+}
+
+func checkDriftClient(issues map[int]*GitHubIssue) *stubGitHubClient {
+	return &stubGitHubClient{
+		preflight: &GitHubRepoInfo{Repo: "JimmyMcBride/plan", RepoURL: "https://github.com/JimmyMcBride/plan", DefaultBranch: "develop"},
+		context: &GitHubContext{
+			Repo:          GitHubRepoInfo{Repo: "JimmyMcBride/plan", RepoURL: "https://github.com/JimmyMcBride/plan", DefaultBranch: "develop"},
+			CurrentBranch: "develop",
+			CurrentSHA:    "abc123",
+		},
+		issues: issues,
+	}
+}
+
+func setupGitHubSourceModeCheck(t *testing.T) *Manager {
+	t.Helper()
+	root := t.TempDir()
+	ws := workspace.New(root)
+	if _, err := ws.Init(); err != nil {
+		t.Fatal(err)
+	}
+	manager := New(ws)
+	if _, err := manager.SetSourceMode(workspace.SourceOfTruthGitHub); err != nil {
+		t.Fatal(err)
+	}
+	return manager
 }

--- a/internal/planning/collaboration.go
+++ b/internal/planning/collaboration.go
@@ -44,9 +44,10 @@ const (
 type MaturityState string
 
 const (
-	MaturityNotReady        MaturityState = "not_ready"
-	MaturityReadySingleSpec MaturityState = "ready_single_spec"
-	MaturityReadyMultiSpec  MaturityState = "ready_multi_spec"
+	MaturityNotReady          MaturityState = "not_ready"
+	MaturityNeedsSourceRepair MaturityState = "needs_source_repair"
+	MaturityReadySingleSpec   MaturityState = "ready_single_spec"
+	MaturityReadyMultiSpec    MaturityState = "ready_multi_spec"
 )
 
 type MaturityConfidence string
@@ -110,15 +111,18 @@ type CollaborationAssessment struct {
 }
 
 type CollaborationMaturityDecision struct {
-	State           MaturityState             `json:"state"`
-	Confidence      MaturityConfidence        `json:"confidence"`
-	SourceMode      CollaborationSourceMode   `json:"source_mode"`
-	Reason          string                    `json:"reason"`
-	Strengths       []string                  `json:"strengths,omitempty"`
-	Gaps            []string                  `json:"gaps,omitempty"`
-	RecommendedPath PromotionPath             `json:"recommended_path,omitempty"`
-	SuggestedTitles MaturitySuggestedTitles   `json:"suggested_titles"`
-	DependencyGuess []MaturityDependencyGuess `json:"dependency_guess,omitempty"`
+	State            MaturityState             `json:"state"`
+	Confidence       MaturityConfidence        `json:"confidence"`
+	SourceMode       CollaborationSourceMode   `json:"source_mode"`
+	Reason           string                    `json:"reason"`
+	BlockingReason   string                    `json:"blocking_reason,omitempty"`
+	Strengths        []string                  `json:"strengths,omitempty"`
+	Gaps             []string                  `json:"gaps,omitempty"`
+	RecommendedPath  PromotionPath             `json:"recommended_path,omitempty"`
+	SuggestedTitles  MaturitySuggestedTitles   `json:"suggested_titles"`
+	DependencyGuess  []MaturityDependencyGuess `json:"dependency_guess,omitempty"`
+	RepairCandidates []string                  `json:"repair_candidates,omitempty"`
+	NextCommand      string                    `json:"next_command,omitempty"`
 }
 
 type CollaborationOwnership struct {
@@ -146,8 +150,16 @@ type PromotionDraft struct {
 	DependencyPlan            []PromotionDependencyPlan      `json:"dependency_plan,omitempty"`
 	MilestonePlan             *PromotionMilestonePlan        `json:"milestone_plan,omitempty"`
 	ProjectPrompt             *PromotionProjectPrompt        `json:"project_prompt,omitempty"`
+	AgentPolicy               PromotionAgentPolicy           `json:"agent_policy"`
+	ManualFallbackAllowed     bool                           `json:"manual_fallback_allowed"`
 	NeedsRefinementExceptions []PromotionRefinementException `json:"needs_refinement_exceptions,omitempty"`
 	ConfirmationRequired      bool                           `json:"confirmation_required"`
+}
+
+type PromotionAgentPolicy struct {
+	AllowedMutations   []string `json:"allowed_mutations"`
+	ForbiddenMutations []string `json:"forbidden_mutations"`
+	ManualFallback     string   `json:"manual_fallback"`
 }
 
 type PromotionIssueDraft struct {
@@ -186,6 +198,14 @@ type PromotionRefinementException struct {
 	ExitCriteria             []string `json:"exit_criteria,omitempty"`
 }
 
+func defaultPromotionAgentPolicy() PromotionAgentPolicy {
+	return PromotionAgentPolicy{
+		AllowedMutations:   []string{"plan discuss promote --apply"},
+		ForbiddenMutations: []string{"gh issue create", "gh label create", "gh milestone create"},
+		ManualFallback:     "only after plan emits manual_fallback_allowed=true",
+	}
+}
+
 type CollaborationAssessInput struct {
 	BrainstormSlug string
 	DiscussionRef  string
@@ -197,32 +217,92 @@ type PromotionDraftInput struct {
 }
 
 type PromotionApplyInput struct {
-	BrainstormSlug string
-	DiscussionRef  string
-	Confirm        bool
-	TargetMode     SourceOfTruthMode
+	BrainstormSlug  string
+	DiscussionRef   string
+	Confirm         bool
+	TargetMode      SourceOfTruthMode
+	ProjectDecision string
 }
 
 type PromotionApplyResult struct {
-	Draft       *PromotionDraft  `json:"draft"`
-	Initiative  *GitHubIssue     `json:"initiative,omitempty"`
-	Specs       []GitHubIssue    `json:"specs,omitempty"`
-	Milestone   *GitHubMilestone `json:"milestone,omitempty"`
-	ParentIssue int              `json:"parent_issue,omitempty"`
+	Draft                 *PromotionDraft                        `json:"draft"`
+	Initiative            *GitHubIssue                           `json:"initiative,omitempty"`
+	Specs                 []GitHubIssue                          `json:"specs,omitempty"`
+	Milestone             *GitHubMilestone                       `json:"milestone,omitempty"`
+	ParentIssue           int                                    `json:"parent_issue,omitempty"`
+	ProjectDecision       *workspace.GitHubProjectDecisionRecord `json:"project_decision,omitempty"`
+	ManualFallbackAllowed bool                                   `json:"manual_fallback_allowed"`
+	ManualFallbackReason  string                                 `json:"manual_fallback_reason,omitempty"`
+	NextCommand           string                                 `json:"next_command,omitempty"`
+}
+
+type PromotionApplyManualFallbackError struct {
+	Result *PromotionApplyResult
+	Err    error
+}
+
+func (e *PromotionApplyManualFallbackError) Error() string {
+	if e == nil || e.Err == nil {
+		return "promotion apply failed; manual fallback is allowed"
+	}
+	return e.Err.Error()
+}
+
+func (e *PromotionApplyManualFallbackError) Unwrap() error {
+	if e == nil {
+		return nil
+	}
+	return e.Err
+}
+
+type RepairSpecSplitInput struct {
+	BrainstormSlug string
+	DiscussionRef  string
+	Specs          []string
+	Confirm        bool
+}
+
+type RepairSpecSplitResult struct {
+	SchemaVersion int                    `json:"schema_version"`
+	Kind          string                 `json:"kind"`
+	GeneratedAt   string                 `json:"generated_at"`
+	Source        CollaborationSourceRef `json:"source"`
+	Specs         []string               `json:"specs"`
+	UpdatedPath   string                 `json:"updated_path,omitempty"`
+	UpdatedURL    string                 `json:"updated_url,omitempty"`
+	NextCommands  []string               `json:"next_commands"`
+}
+
+type GitHubAdoptInput struct {
+	BrainstormSlug  string
+	DiscussionRef   string
+	IssueNumbers    []int
+	ProjectDecision string
+}
+
+type GitHubAdoptResult struct {
+	Draft           *PromotionDraft                        `json:"draft"`
+	Initiative      *GitHubIssue                           `json:"initiative,omitempty"`
+	Specs           []GitHubIssue                          `json:"specs,omitempty"`
+	Milestone       *GitHubMilestone                       `json:"milestone,omitempty"`
+	ProjectDecision *workspace.GitHubProjectDecisionRecord `json:"project_decision,omitempty"`
+	Adopted         []workspace.GitHubPlanningRecord       `json:"adopted"`
 }
 
 type collaborationSourceData struct {
-	source      CollaborationSourceRef
-	title       string
-	body        string
-	problem     string
-	goals       string
-	constraints string
-	nonGoals    string
-	shape       string
-	openQs      string
-	suggested   []string
-	deps        []MaturityDependencyGuess
+	source                  CollaborationSourceRef
+	title                   string
+	body                    string
+	problem                 string
+	goals                   string
+	constraints             string
+	nonGoals                string
+	shape                   string
+	openQs                  string
+	suggested               []string
+	deps                    []MaturityDependencyGuess
+	explicitMultiSpecIntent bool
+	repairCandidates        []string
 }
 
 func (m *Manager) AssessCollaborationSource(input CollaborationAssessInput) (*CollaborationAssessment, error) {
@@ -255,9 +335,10 @@ func (m *Manager) BuildPromotionDraft(input PromotionDraftInput) (*PromotionDraf
 		Ownership:            ownership,
 		Assessment:           decision,
 		ProposedSpecIssues:   []PromotionIssueDraft{},
+		AgentPolicy:          defaultPromotionAgentPolicy(),
 		ConfirmationRequired: true,
 	}
-	if decision.State == MaturityNotReady {
+	if decision.State == MaturityNotReady || decision.State == MaturityNeedsSourceRepair {
 		return draft, nil
 	}
 	draft.PromotionDecision = decision.RecommendedPath
@@ -319,6 +400,73 @@ func (m *Manager) BuildPromotionDraft(input PromotionDraftInput) (*PromotionDraf
 	return draft, nil
 }
 
+func (m *Manager) RepairSpecSplit(input RepairSpecSplitInput) (*RepairSpecSplitResult, error) {
+	data, _, err := m.loadCollaborationSourceData(input.BrainstormSlug, input.DiscussionRef)
+	if err != nil {
+		return nil, err
+	}
+	specs := dedupeTitles(input.Specs)
+	if len(specs) == 0 {
+		specs = dedupeTitles(data.repairCandidates)
+	}
+	if len(specs) < 2 {
+		return nil, fmt.Errorf("repair requires at least two spec titles; pass repeated --spec values")
+	}
+	section := renderSpecSplitSection(specs)
+	result := &RepairSpecSplitResult{
+		SchemaVersion: CollaborationSchemaVersion,
+		Kind:          "source_repair",
+		GeneratedAt:   time.Now().UTC().Format(time.RFC3339),
+		Source:        data.source,
+		Specs:         specs,
+		NextCommands: []string{
+			refreshAssessCommand(data.source),
+			refreshPromoteCommand(data.source),
+		},
+	}
+	switch data.source.Mode {
+	case CollaborationSourceGitHubDiscussion:
+		if !input.Confirm {
+			return nil, fmt.Errorf("GitHub Discussion repair requires --confirm")
+		}
+		info, err := m.workspace.EnsureInitialized()
+		if err != nil {
+			return nil, err
+		}
+		context, err := m.github.CurrentContext(info.ProjectDir)
+		if err != nil {
+			return nil, err
+		}
+		discussionNumber := discussionNumber(data.source.Discussion)
+		discussion, err := m.github.GetDiscussion(info.ProjectDir, context.Repo.Repo, discussionNumber)
+		if err != nil {
+			return nil, err
+		}
+		body := notes.SetSection(discussion.Body, "Specs", section)
+		updated, err := m.github.UpdateDiscussionBody(info.ProjectDir, context.Repo.Repo, discussionNumber, body)
+		if err != nil {
+			return nil, err
+		}
+		result.UpdatedURL = updated.URL
+	default:
+		info, err := m.workspace.EnsureInitialized()
+		if err != nil {
+			return nil, err
+		}
+		path := filepath.Join(info.BrainstormsDir, data.source.BrainstormSlug+".md")
+		note, err := notes.Read(path)
+		if err != nil {
+			return nil, err
+		}
+		body := notes.SetSection(note.Content, "Specs", section)
+		if _, err := notes.Update(note.Path, notes.UpdateInput{Body: &body}); err != nil {
+			return nil, err
+		}
+		result.UpdatedPath = rel(info.ProjectDir, note.Path)
+	}
+	return result, nil
+}
+
 func (m *Manager) ApplyPromotionDraft(input PromotionApplyInput) (*PromotionApplyResult, error) {
 	if !input.Confirm {
 		return nil, fmt.Errorf("promotion apply requires explicit confirmation; rerun with --confirm")
@@ -330,8 +478,14 @@ func (m *Manager) ApplyPromotionDraft(input PromotionApplyInput) (*PromotionAppl
 	if err != nil {
 		return nil, err
 	}
-	if draft.Assessment.State == MaturityNotReady {
+	if draft.Assessment.State != MaturityReadySingleSpec && draft.Assessment.State != MaturityReadyMultiSpec {
+		if draft.Assessment.BlockingReason != "" {
+			return nil, fmt.Errorf("source is not ready for promotion: %s", draft.Assessment.BlockingReason)
+		}
 		return nil, fmt.Errorf("source is not ready for promotion")
+	}
+	if err := validateProjectDecision(input.ProjectDecision, draft); err != nil {
+		return nil, err
 	}
 	mode := input.TargetMode
 	if mode == "" {
@@ -376,14 +530,28 @@ func (m *Manager) ApplyPromotionDraft(input PromotionApplyInput) (*PromotionAppl
 	if state.Planning == nil {
 		state.Planning = map[string]workspace.GitHubPlanningRecord{}
 	}
+	if state.ProjectDecisions == nil {
+		state.ProjectDecisions = map[string]workspace.GitHubProjectDecisionRecord{}
+	}
 	result := &PromotionApplyResult{Draft: draft}
+	fallback := func(err error) (*PromotionApplyResult, error) {
+		return nil, promotionManualFallbackError(draft, result, err)
+	}
+	if err := m.ensurePromotionLabels(info.ProjectDir, state.Repo, draft); err != nil {
+		return fallback(err)
+	}
 	var milestone *GitHubMilestone
 	if draft.MilestonePlan != nil && draft.MilestonePlan.Create {
 		milestone, err = m.ensureMilestone(info.ProjectDir, state.Repo, draft.MilestonePlan.Title)
 		if err != nil {
-			return nil, err
+			return fallback(err)
 		}
 		result.Milestone = milestone
+	}
+	if strings.TrimSpace(input.ProjectDecision) != "" {
+		record := buildProjectDecisionRecord(draft, input.ProjectDecision, milestone)
+		state.ProjectDecisions[record.Slug] = record
+		result.ProjectDecision = &record
 	}
 	var initiativeIssue *GitHubIssue
 	if draft.ProposedInitiativeIssue != nil {
@@ -398,7 +566,7 @@ func (m *Manager) ApplyPromotionDraft(input PromotionApplyInput) (*PromotionAppl
 		}
 		initIssue, err := m.github.CreateIssue(info.ProjectDir, state.Repo, initInput)
 		if err != nil {
-			return nil, err
+			return fallback(err)
 		}
 		initiativeIssue = initIssue
 		result.Initiative = initIssue
@@ -436,11 +604,11 @@ func (m *Manager) ApplyPromotionDraft(input PromotionApplyInput) (*PromotionAppl
 		}
 		specIssue, err := m.github.CreateIssue(info.ProjectDir, state.Repo, specInput)
 		if err != nil {
-			return nil, err
+			return fallback(err)
 		}
 		if initiativeIssue != nil {
 			if err := m.github.AddSubIssue(info.ProjectDir, state.Repo, initiativeIssue.Number, specIssue.Number); err != nil {
-				return nil, err
+				return fallback(err)
 			}
 		}
 		specIssuesBySlug[specDraft.Slug] = specIssue
@@ -455,7 +623,7 @@ func (m *Manager) ApplyPromotionDraft(input PromotionApplyInput) (*PromotionAppl
 				return nil, fmt.Errorf("promotion dependency %q for %q was not created in this promotion set", dep, specDraft.Title)
 			}
 			if err := m.github.AddBlockedBy(info.ProjectDir, state.Repo, specIssue.Number, depIssue.Number); err != nil {
-				return nil, err
+				return fallback(err)
 			}
 		}
 	}
@@ -488,6 +656,198 @@ func (m *Manager) ApplyPromotionDraft(input PromotionApplyInput) (*PromotionAppl
 		return nil, err
 	}
 	return result, nil
+}
+
+func (m *Manager) AdoptGitHubPromotion(input GitHubAdoptInput) (*GitHubAdoptResult, error) {
+	draft, err := m.BuildPromotionDraft(PromotionDraftInput{
+		BrainstormSlug: input.BrainstormSlug,
+		DiscussionRef:  input.DiscussionRef,
+	})
+	if err != nil {
+		return nil, err
+	}
+	if draft.Assessment.State != MaturityReadySingleSpec && draft.Assessment.State != MaturityReadyMultiSpec {
+		if draft.Assessment.BlockingReason != "" {
+			return nil, fmt.Errorf("source is not ready for adoption: %s", draft.Assessment.BlockingReason)
+		}
+		return nil, fmt.Errorf("source is not ready for adoption")
+	}
+	if err := validateProjectDecision(input.ProjectDecision, draft); err != nil {
+		return nil, err
+	}
+	expected := len(draft.ProposedSpecIssues)
+	if draft.ProposedInitiativeIssue != nil {
+		expected++
+	}
+	if len(input.IssueNumbers) != expected {
+		return nil, fmt.Errorf("adopt requires %d issue numbers in draft order; got %d", expected, len(input.IssueNumbers))
+	}
+	info, err := m.workspace.EnsureInitialized()
+	if err != nil {
+		return nil, err
+	}
+	context, err := m.github.CurrentContext(info.ProjectDir)
+	if err != nil {
+		return nil, err
+	}
+	meta, err := m.workspace.ReadWorkspaceMeta()
+	if err != nil {
+		return nil, err
+	}
+	mode := meta.SourceMode
+	if mode == "" || mode == SourceOfTruthLocal {
+		mode = SourceOfTruthGitHub
+	}
+	meta.SourceMode = mode
+	meta.UpdatedAt = time.Now().UTC().Format(time.RFC3339)
+	if err := m.workspace.WriteWorkspaceMeta(*meta); err != nil {
+		return nil, err
+	}
+	state, err := m.workspace.ReadGitHubState()
+	if err != nil {
+		return nil, err
+	}
+	if strings.TrimSpace(state.Repo) == "" {
+		state.Repo = context.Repo.Repo
+	}
+	if strings.TrimSpace(state.RepoURL) == "" {
+		state.RepoURL = context.Repo.RepoURL
+	}
+	if strings.TrimSpace(state.DefaultBranch) == "" {
+		state.DefaultBranch = context.Repo.DefaultBranch
+	}
+	if state.Planning == nil {
+		state.Planning = map[string]workspace.GitHubPlanningRecord{}
+	}
+	if state.ProjectDecisions == nil {
+		state.ProjectDecisions = map[string]workspace.GitHubProjectDecisionRecord{}
+	}
+	if err := m.ensurePromotionLabels(info.ProjectDir, state.Repo, draft); err != nil {
+		return nil, err
+	}
+	var milestone *GitHubMilestone
+	if draft.MilestonePlan != nil && draft.MilestonePlan.Create {
+		milestone, err = m.ensureMilestone(info.ProjectDir, state.Repo, draft.MilestonePlan.Title)
+		if err != nil {
+			return nil, err
+		}
+	}
+	result := &GitHubAdoptResult{Draft: draft, Milestone: milestone}
+	if strings.TrimSpace(input.ProjectDecision) != "" {
+		record := buildProjectDecisionRecord(draft, input.ProjectDecision, milestone)
+		state.ProjectDecisions[record.Slug] = record
+		result.ProjectDecision = &record
+	}
+
+	index := 0
+	var initiativeIssue *GitHubIssue
+	if draft.ProposedInitiativeIssue != nil {
+		issue, err := m.adoptPromotionIssue(info.ProjectDir, state.Repo, input.IssueNumbers[index], *draft.ProposedInitiativeIssue, milestone)
+		if err != nil {
+			return nil, err
+		}
+		initiativeIssue = issue
+		result.Initiative = issue
+		record := workspace.GitHubPlanningRecord{
+			Slug:            draft.ProposedInitiativeIssue.Slug,
+			Kind:            "initiative",
+			Title:           issue.Title,
+			IssueNumber:     issue.Number,
+			IssueURL:        issue.URL,
+			RemoteState:     issue.State,
+			Readiness:       string(ReadinessReady),
+			OwnershipMode:   string(mode),
+			EntryMode:       string(draft.Source.EntryMode),
+			SourceMode:      string(draft.Source.Mode),
+			MilestoneNumber: milestoneNumberOrZero(milestone),
+			MilestoneTitle:  milestoneTitle(milestone),
+			UpdatedAt:       time.Now().UTC().Format(time.RFC3339),
+		}
+		record.DiscussionNumber = discussionNumber(draft.Source.Discussion)
+		record.DiscussionURL = discussionURL(draft.Source.Discussion)
+		state.Planning[record.Slug] = record
+		result.Adopted = append(result.Adopted, record)
+		index++
+	}
+
+	specIssuesBySlug := make(map[string]*GitHubIssue, len(draft.ProposedSpecIssues))
+	specDraftsBySlug := make(map[string]PromotionIssueDraft, len(draft.ProposedSpecIssues))
+	for _, specDraft := range draft.ProposedSpecIssues {
+		issue, err := m.adoptPromotionIssue(info.ProjectDir, state.Repo, input.IssueNumbers[index], specDraft, milestone)
+		if err != nil {
+			return nil, err
+		}
+		if initiativeIssue != nil {
+			if err := m.github.AddSubIssue(info.ProjectDir, state.Repo, initiativeIssue.Number, issue.Number); err != nil {
+				return nil, err
+			}
+		}
+		specIssuesBySlug[specDraft.Slug] = issue
+		specDraftsBySlug[specDraft.Slug] = specDraft
+		result.Specs = append(result.Specs, *issue)
+		index++
+	}
+	for slug, specIssue := range specIssuesBySlug {
+		specDraft := specDraftsBySlug[slug]
+		for _, dep := range specDraft.BlockedBy {
+			depIssue, ok := specIssuesBySlug[slugify(dep)]
+			if !ok {
+				return nil, fmt.Errorf("promotion dependency %q for %q was not adopted in this promotion set", dep, specDraft.Title)
+			}
+			if err := m.github.AddBlockedBy(info.ProjectDir, state.Repo, specIssue.Number, depIssue.Number); err != nil {
+				return nil, err
+			}
+		}
+	}
+	for slug, specIssue := range specIssuesBySlug {
+		specDraft := specDraftsBySlug[slug]
+		record := workspace.GitHubPlanningRecord{
+			Slug:              specDraft.Slug,
+			Kind:              "spec",
+			Title:             specIssue.Title,
+			IssueNumber:       specIssue.Number,
+			IssueURL:          specIssue.URL,
+			RemoteState:       specIssue.State,
+			Readiness:         string(specDraft.Readiness),
+			OwnershipMode:     string(mode),
+			EntryMode:         string(draft.Source.EntryMode),
+			SourceMode:        string(draft.Source.Mode),
+			ParentIssueNumber: issueNumberOrZero(initiativeIssue),
+			MilestoneNumber:   milestoneNumberOrZero(milestone),
+			MilestoneTitle:    milestoneTitle(milestone),
+			BlockedBy:         slugs(specDraft.BlockedBy),
+			UpdatedAt:         time.Now().UTC().Format(time.RFC3339),
+		}
+		record.DiscussionNumber = discussionNumber(draft.Source.Discussion)
+		record.DiscussionURL = discussionURL(draft.Source.Discussion)
+		state.Planning[record.Slug] = record
+		result.Adopted = append(result.Adopted, record)
+	}
+	state.LastUpdatedAt = time.Now().UTC().Format(time.RFC3339)
+	if err := m.workspace.WriteGitHubState(*state); err != nil {
+		return nil, err
+	}
+	return result, nil
+}
+
+func (m *Manager) adoptPromotionIssue(projectDir, repo string, issueNumber int, draft PromotionIssueDraft, milestone *GitHubMilestone) (*GitHubIssue, error) {
+	issue, err := m.github.GetIssue(projectDir, repo, issueNumber)
+	if err != nil {
+		return nil, err
+	}
+	if !strings.EqualFold(strings.TrimSpace(issue.Title), strings.TrimSpace(draft.Title)) {
+		return nil, fmt.Errorf("issue #%d title %q does not match promotion draft title %q", issue.Number, issue.Title, draft.Title)
+	}
+	input := GitHubIssueInput{
+		Title:  issue.Title,
+		Body:   draft.Body,
+		State:  issue.State,
+		Labels: mergeLabels(issue.Labels, draft.Labels),
+	}
+	if milestone != nil {
+		input.Milestone = &milestone.Number
+	}
+	return m.github.UpdateIssue(projectDir, repo, issue.Number, input)
 }
 
 func (m *Manager) loadCollaborationSourceData(brainstormSlug, discussionRef string) (*collaborationSourceData, CollaborationOwnership, error) {
@@ -576,19 +936,21 @@ func (m *Manager) loadLocalBrainstormSource(info *workspace.Info, slug string) (
 		SourceLinks:     []string{rel(info.ProjectDir, note.Path)},
 		CanonicalSource: "local_brainstorm",
 	}
-	suggested := extractSpecCandidates(content)
+	specParse := extractSpecCandidateParse(content)
 	return &collaborationSourceData{
-		source:      source,
-		title:       defaultString(title, slugify(slug)),
-		body:        content,
-		problem:     firstNonEmpty(refinement.Problem, notes.ExtractSection(content, "Problem"), notes.ExtractSection(content, "Focus Question")),
-		goals:       firstNonEmpty(refinement.UserValue, notes.ExtractSection(content, "Desired Outcome"), vision),
-		constraints: firstNonEmpty(refinement.Constraints, notes.ExtractSection(content, "Constraints")),
-		nonGoals:    firstNonEmpty(challenge.NoGos, extractSubsection(content, "Challenge", "No-Gos")),
-		shape:       firstNonEmpty(refinement.DecisionSnapshot, refinement.CandidateApproaches, challenge.SimplerAlternative),
-		openQs:      firstNonEmpty(refinement.RemainingOpenQuestions, notes.ExtractSection(content, "Open Questions")),
-		suggested:   suggested,
-		deps:        buildDependencyGuess(suggested, content),
+		source:                  source,
+		title:                   defaultString(title, slugify(slug)),
+		body:                    content,
+		problem:                 firstNonEmpty(refinement.Problem, notes.ExtractSection(content, "Problem"), notes.ExtractSection(content, "Focus Question")),
+		goals:                   firstNonEmpty(refinement.UserValue, notes.ExtractSection(content, "Desired Outcome"), vision),
+		constraints:             firstNonEmpty(refinement.Constraints, notes.ExtractSection(content, "Constraints")),
+		nonGoals:                firstNonEmpty(challenge.NoGos, extractSubsection(content, "Challenge", "No-Gos")),
+		shape:                   firstNonEmpty(refinement.DecisionSnapshot, refinement.CandidateApproaches, challenge.SimplerAlternative),
+		openQs:                  firstNonEmpty(refinement.RemainingOpenQuestions, notes.ExtractSection(content, "Open Questions")),
+		suggested:               specParse.Titles,
+		deps:                    buildDependencyGuess(specParse.Titles, content),
+		explicitMultiSpecIntent: specParse.ExplicitMultiSpecIntent,
+		repairCandidates:        specParse.RepairCandidates,
 	}, nil
 }
 
@@ -623,19 +985,21 @@ func (m *Manager) loadGitHubDiscussionSource(info *workspace.Info, discussionRef
 		SourceLinks:     []string{discussion.URL},
 		CanonicalSource: "github_discussion",
 	}
-	suggested := extractSpecCandidates(content)
+	specParse := extractSpecCandidateParse(content)
 	return &collaborationSourceData{
-		source:      source,
-		title:       discussion.Title,
-		body:        content,
-		problem:     firstSectionOrKeyword(content, "Problem", "problem"),
-		goals:       firstSectionOrKeyword(content, "Goals", "goal"),
-		constraints: firstSectionOrKeyword(content, "Constraints", "constraint"),
-		nonGoals:    firstSectionOrKeyword(content, "Non-Goals", "non-goal"),
-		shape:       firstNonEmpty(firstSectionOrKeyword(content, "Proposed Shape", "shape"), firstSectionOrKeyword(content, "Decision Snapshot", "decision"), firstSectionOrKeyword(content, "Candidate Approaches", "approach")),
-		openQs:      firstNonEmpty(firstSectionOrKeyword(content, "Open Questions", "open question"), firstSectionOrKeyword(content, "Remaining Open Questions", "remaining open question")),
-		suggested:   suggested,
-		deps:        buildDependencyGuess(suggested, content),
+		source:                  source,
+		title:                   discussion.Title,
+		body:                    content,
+		problem:                 firstSectionOrKeyword(content, "Problem", "problem"),
+		goals:                   firstSectionOrKeyword(content, "Goals", "goal"),
+		constraints:             firstSectionOrKeyword(content, "Constraints", "constraint"),
+		nonGoals:                firstSectionOrKeyword(content, "Non-Goals", "non-goal"),
+		shape:                   firstNonEmpty(firstSectionOrKeyword(content, "Proposed Shape", "shape"), firstSectionOrKeyword(content, "Decision Snapshot", "decision"), firstSectionOrKeyword(content, "Candidate Approaches", "approach")),
+		openQs:                  firstNonEmpty(firstSectionOrKeyword(content, "Open Questions", "open question"), firstSectionOrKeyword(content, "Remaining Open Questions", "remaining open question")),
+		suggested:               specParse.Titles,
+		deps:                    buildDependencyGuess(specParse.Titles, content),
+		explicitMultiSpecIntent: specParse.ExplicitMultiSpecIntent,
+		repairCandidates:        specParse.RepairCandidates,
 	}, nil
 }
 
@@ -683,6 +1047,21 @@ func assessCollaborationData(data *collaborationSourceData) CollaborationMaturit
 		return decision
 	}
 	specTitles := append([]string(nil), dedupeTitles(data.suggested)...)
+	if data.explicitMultiSpecIntent && len(specTitles) < 2 {
+		candidates := dedupeTitles(append(append([]string(nil), data.repairCandidates...), specTitles...))
+		decision.State = MaturityNeedsSourceRepair
+		decision.Confidence = MaturityConfidenceMedium
+		decision.Reason = "The source asks for multiple spec issues, but Plan could not parse at least two spec titles."
+		decision.BlockingReason = "requested multi-spec promotion but source parsed as single spec"
+		decision.Gaps = nil
+		decision.SuggestedTitles = MaturitySuggestedTitles{
+			Initiative: defaultString(data.title, "Untitled initiative"),
+			Specs:      specTitles,
+		}
+		decision.RepairCandidates = candidates
+		decision.NextCommand = repairSpecSplitCommand(data.source, candidates)
+		return decision
+	}
 	if len(specTitles) == 0 {
 		specTitles = []string{fallbackSpecTitle(data.title)}
 	}
@@ -745,7 +1124,7 @@ func buildPromotionInitiativeDraft(data *collaborationSourceData, title string, 
 		Body:           strings.TrimSpace(strings.Join(lines, "\n")),
 		Slug:           slugify(title),
 		Readiness:      ReadinessReady,
-		Labels:         []string{"enhancement"},
+		Labels:         []string{"enhancement", planIssueInitiativeLabel},
 		SourceLinks:    append([]string(nil), data.source.SourceLinks...),
 		ReadyByDefault: true,
 	}
@@ -758,13 +1137,13 @@ func buildPromotionSpecDraft(data *collaborationSourceData, title string, blocke
 	}
 	body := renderPromotionSpecBody(title, data, blockedBy, exceptionPtr)
 	readiness := ReadinessReady
-	labels := []string{"enhancement", planIssueReadyLabel}
+	labels := []string{"enhancement", planIssueSpecLabel, planIssueReadyLabel}
 	if exceptionPtr != nil {
 		readiness = ReadinessNeedsRefinement
-		labels = []string{"enhancement"}
+		labels = []string{"enhancement", planIssueSpecLabel}
 	} else if len(blockedBy) > 0 {
 		readiness = ReadinessBlocked
-		labels = []string{"enhancement", planIssueBlockedLabel}
+		labels = []string{"enhancement", planIssueSpecLabel, planIssueBlockedLabel}
 	}
 	return PromotionIssueDraft{
 		Kind:           "spec",
@@ -888,31 +1267,90 @@ func renderPromotionSpecBody(title string, data *collaborationSourceData, blocke
 	return strings.TrimSpace(strings.Join(lines, "\n"))
 }
 
+type specCandidateParse struct {
+	Titles                  []string
+	RepairCandidates        []string
+	ExplicitMultiSpecIntent bool
+}
+
 func extractSpecCandidates(content string) []string {
+	return extractSpecCandidateParse(content).Titles
+}
+
+func extractSpecCandidateParse(content string) specCandidateParse {
+	lower := strings.ToLower(content)
+	explicitIssueIntent := containsAny(lower, []string{
+		"create spec issues",
+		"spec issues for:",
+		"create specs for:",
+		"create spec issue",
+	})
+	explicitMultiIntent := explicitIssueIntent ||
+		strings.Contains(lower, "multiple specs") ||
+		strings.Contains(lower, "multi-spec") ||
+		strings.Contains(lower, "split into")
+
 	for _, heading := range []string{"Spec Split", "Initial Spec Split", "Planned Specs", "Specs"} {
 		if section := strings.TrimSpace(notes.ExtractSection(content, heading)); section != "" {
 			items := bulletItems(section)
 			if len(items) > 0 {
-				return items
+				return specCandidateParse{
+					Titles:                  items,
+					RepairCandidates:        items,
+					ExplicitMultiSpecIntent: explicitMultiIntent || len(items) > 1,
+				}
 			}
 		}
 	}
-	if strings.Contains(strings.ToLower(content), "multiple specs") || strings.Contains(strings.ToLower(content), "split into") {
+
+	phraseItems := specIssuePhraseItems(content)
+	if len(phraseItems) > 0 {
+		return specCandidateParse{
+			Titles:                  phraseItems,
+			RepairCandidates:        phraseItems,
+			ExplicitMultiSpecIntent: true,
+		}
+	}
+
+	if explicitIssueIntent {
+		if items := numberedItems(content); len(items) > 0 {
+			return specCandidateParse{
+				Titles:                  items,
+				RepairCandidates:        items,
+				ExplicitMultiSpecIntent: true,
+			}
+		}
+	}
+
+	if explicitMultiIntent {
+		if section := strings.TrimSpace(notes.ExtractSection(content, "Desired Outcome")); section != "" {
+			if items := bulletItems(section); len(items) > 0 {
+				return specCandidateParse{
+					Titles:                  items,
+					RepairCandidates:        items,
+					ExplicitMultiSpecIntent: true,
+				}
+			}
+		}
 		if section := strings.TrimSpace(extractSubsection(content, "Refinement", "Candidate Approaches")); section != "" {
 			if items := bulletItems(section); len(items) > 1 {
-				return items
+				return specCandidateParse{Titles: items, RepairCandidates: items, ExplicitMultiSpecIntent: true}
 			}
 		}
 		if section := strings.TrimSpace(notes.ExtractSection(content, "Ideas")); section != "" {
 			if items := bulletItems(section); len(items) > 1 {
-				return items
+				return specCandidateParse{Titles: items, RepairCandidates: items, ExplicitMultiSpecIntent: true}
 			}
 		}
 		if items := bulletItems(content); len(items) > 1 {
-			return items
+			return specCandidateParse{Titles: items, RepairCandidates: items, ExplicitMultiSpecIntent: true}
 		}
 	}
-	return nil
+
+	return specCandidateParse{
+		ExplicitMultiSpecIntent: explicitMultiIntent,
+		RepairCandidates:        phraseItems,
+	}
 }
 
 func buildDependencyGuess(specs []string, content string) []MaturityDependencyGuess {
@@ -1003,6 +1441,62 @@ func parseDiscussionRef(value string) (int, error) {
 	return 0, fmt.Errorf("could not resolve discussion number from %q", value)
 }
 
+func specIssuePhraseItems(content string) []string {
+	lines := strings.Split(strings.ReplaceAll(content, "\r\n", "\n"), "\n")
+	var out []string
+	pattern := regexp.MustCompile(`(?i)\b(?:create\s+)?spec\s+issues?\s+for\s*:\s*(.*)$`)
+	for i := 0; i < len(lines); i++ {
+		line := strings.TrimSpace(lines[i])
+		match := pattern.FindStringSubmatch(line)
+		if len(match) != 2 {
+			continue
+		}
+		if items := splitInlineSpecList(match[1]); len(items) > 0 {
+			out = append(out, items...)
+			continue
+		}
+		var block []string
+		for j := i + 1; j < len(lines); j++ {
+			next := strings.TrimSpace(lines[j])
+			if next == "" {
+				break
+			}
+			if strings.HasPrefix(next, "#") {
+				break
+			}
+			block = append(block, next)
+		}
+		if items := bulletItems(strings.Join(block, "\n")); len(items) > 0 {
+			out = append(out, items...)
+			continue
+		}
+		if items := numberedItems(strings.Join(block, "\n")); len(items) > 0 {
+			out = append(out, items...)
+		}
+	}
+	return dedupeTitles(out)
+}
+
+func splitInlineSpecList(raw string) []string {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return nil
+	}
+	parts := regexp.MustCompile(`[;,]`).Split(raw, -1)
+	out := make([]string, 0, len(parts))
+	for _, part := range parts {
+		item := cleanCandidateTitle(part)
+		if item == "" {
+			continue
+		}
+		out = append(out, item)
+	}
+	if len(out) == 0 {
+		return nil
+	}
+	return dedupeTitles(out)
+}
+
 func bulletItems(section string) []string {
 	lines := strings.Split(section, "\n")
 	out := make([]string, 0, len(lines))
@@ -1019,13 +1513,41 @@ func bulletItems(section string) []string {
 		case strings.HasPrefix(strings.ToLower(trimmed), "[x] "):
 			trimmed = trimmed[4:]
 		}
-		trimmed = strings.TrimSpace(trimmed)
+		trimmed = cleanCandidateTitle(trimmed)
 		if trimmed == "" {
 			continue
 		}
 		out = append(out, trimmed)
 	}
 	return dedupeTitles(out)
+}
+
+func numberedItems(section string) []string {
+	lines := strings.Split(section, "\n")
+	out := make([]string, 0, len(lines))
+	pattern := regexp.MustCompile(`^\s*\d+[\.)]\s+(.+)$`)
+	for _, line := range lines {
+		match := pattern.FindStringSubmatch(line)
+		if len(match) != 2 {
+			continue
+		}
+		item := cleanCandidateTitle(match[1])
+		if item == "" {
+			continue
+		}
+		out = append(out, item)
+	}
+	return dedupeTitles(out)
+}
+
+func cleanCandidateTitle(item string) string {
+	item = strings.TrimSpace(item)
+	item = strings.TrimPrefix(item, "[ ] ")
+	if strings.HasPrefix(strings.ToLower(item), "[x] ") {
+		item = item[4:]
+	}
+	item = strings.Trim(item, " \t-*:;,.")
+	return strings.TrimSpace(item)
 }
 
 func dedupeTitles(items []string) []string {
@@ -1044,6 +1566,104 @@ func dedupeTitles(items []string) []string {
 		out = append(out, item)
 	}
 	return out
+}
+
+func mergeLabels(existing, desired []string) []string {
+	seen := map[string]struct{}{}
+	out := make([]string, 0, len(existing)+len(desired))
+	for _, label := range append(append([]string(nil), existing...), desired...) {
+		label = strings.TrimSpace(label)
+		if label == "" {
+			continue
+		}
+		key := strings.ToLower(label)
+		if _, ok := seen[key]; ok {
+			continue
+		}
+		seen[key] = struct{}{}
+		out = append(out, label)
+	}
+	return out
+}
+
+func repairSpecSplitCommand(source CollaborationSourceRef, candidates []string) string {
+	args := []string{"plan", "discuss", "repair", "--project", "."}
+	switch source.Mode {
+	case CollaborationSourceGitHubDiscussion:
+		args = append(args, "--discussion", strconv.Itoa(discussionNumber(source.Discussion)))
+	default:
+		args = append(args, "--brainstorm", source.BrainstormSlug)
+	}
+	for _, candidate := range candidates {
+		if strings.TrimSpace(candidate) == "" {
+			continue
+		}
+		args = append(args, "--spec", candidate)
+	}
+	for i := len(candidates); i < 2; i++ {
+		placeholder := "<spec title>"
+		if i > 0 {
+			placeholder = "<another spec title>"
+		}
+		args = append(args, "--spec", placeholder)
+	}
+	if source.Mode == CollaborationSourceGitHubDiscussion {
+		args = append(args, "--confirm")
+	}
+	args = append(args, "--format", "json")
+	return shellCommand(args)
+}
+
+func refreshAssessCommand(source CollaborationSourceRef) string {
+	args := []string{"plan", "discuss", "assess", "--project", "."}
+	args = append(args, sourceSelectorArgs(source)...)
+	args = append(args, "--format", "json")
+	return shellCommand(args)
+}
+
+func refreshPromoteCommand(source CollaborationSourceRef) string {
+	args := []string{"plan", "discuss", "promote", "--project", "."}
+	args = append(args, sourceSelectorArgs(source)...)
+	args = append(args, "--format", "json")
+	return shellCommand(args)
+}
+
+func sourceSelectorArgs(source CollaborationSourceRef) []string {
+	switch source.Mode {
+	case CollaborationSourceGitHubDiscussion:
+		return []string{"--discussion", strconv.Itoa(discussionNumber(source.Discussion))}
+	default:
+		return []string{"--brainstorm", source.BrainstormSlug}
+	}
+}
+
+func renderSpecSplitSection(specs []string) string {
+	lines := make([]string, 0, len(specs))
+	for _, spec := range specs {
+		if strings.TrimSpace(spec) == "" {
+			continue
+		}
+		lines = append(lines, "- "+strings.TrimSpace(spec))
+	}
+	return strings.Join(lines, "\n")
+}
+
+func shellCommand(args []string) string {
+	quoted := make([]string, 0, len(args))
+	for _, arg := range args {
+		quoted = append(quoted, shellQuote(arg))
+	}
+	return strings.Join(quoted, " ")
+}
+
+func shellQuote(arg string) string {
+	if arg == "" {
+		return "''"
+	}
+	if regexp.MustCompile(`^[A-Za-z0-9_./:=+-]+$`).MatchString(arg) {
+		return arg
+	}
+	return "'" + strings.ReplaceAll(arg, "'", "'\"'\"'") + "'"
 }
 
 func findBlockedByForTitle(guesses []MaturityDependencyGuess, title string) []string {
@@ -1073,6 +1693,148 @@ func shouldRecommendProject(specCount int, deps []PromotionDependencyPlan) bool 
 		}
 	}
 	return false
+}
+
+func validateProjectDecision(decision string, draft *PromotionDraft) error {
+	decision = strings.TrimSpace(decision)
+	switch decision {
+	case "", "create", "skip":
+	default:
+		return fmt.Errorf("unsupported project decision %q; use create or skip", decision)
+	}
+	if requiresProjectDecision(draft) && decision == "" {
+		return fmt.Errorf("promotion has %d specs and requires --project-decision create|skip before apply", len(draft.ProposedSpecIssues))
+	}
+	return nil
+}
+
+func requiresProjectDecision(draft *PromotionDraft) bool {
+	return draft != nil && len(draft.ProposedSpecIssues) >= 5
+}
+
+func buildProjectDecisionRecord(draft *PromotionDraft, decision string, milestone *GitHubMilestone) workspace.GitHubProjectDecisionRecord {
+	now := time.Now().UTC().Format(time.RFC3339)
+	record := workspace.GitHubProjectDecisionRecord{
+		Slug:             promotionProjectDecisionSlug(draft),
+		Decision:         strings.TrimSpace(decision),
+		SpecCount:        len(draft.ProposedSpecIssues),
+		MilestoneNumber:  milestoneNumberOrZero(milestone),
+		MilestoneTitle:   milestoneTitle(milestone),
+		SourceMode:       string(draft.Source.Mode),
+		EntryMode:        string(draft.Source.EntryMode),
+		DiscussionNumber: discussionNumber(draft.Source.Discussion),
+		DiscussionURL:    discussionURL(draft.Source.Discussion),
+		UpdatedAt:        now,
+	}
+	if draft.ProjectPrompt != nil {
+		record.Reason = draft.ProjectPrompt.Reason
+	}
+	return record
+}
+
+func promotionProjectDecisionSlug(draft *PromotionDraft) string {
+	if draft != nil && draft.ProposedInitiativeIssue != nil {
+		return draft.ProposedInitiativeIssue.Slug
+	}
+	if draft != nil && len(draft.ProposedSpecIssues) > 0 {
+		return draft.ProposedSpecIssues[0].Slug
+	}
+	return "promotion"
+}
+
+func (m *Manager) ensurePromotionLabels(projectDir, repo string, draft *PromotionDraft) error {
+	for _, label := range promotionLabelInputs(draft) {
+		if err := m.github.EnsureLabel(projectDir, repo, label); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func promotionLabelInputs(draft *PromotionDraft) []GitHubLabelInput {
+	colors := map[string]string{
+		"enhancement":            "a2eeef",
+		planIssueInitiativeLabel: "5319e7",
+		planIssueSpecLabel:       "1d76db",
+		planIssueReadyLabel:      "0e8a16",
+		planIssueBlockedLabel:    "d93f0b",
+	}
+	descriptions := map[string]string{
+		"enhancement":            "New feature or request",
+		planIssueInitiativeLabel: "Plan-managed initiative issue",
+		planIssueSpecLabel:       "Plan-managed spec issue",
+		planIssueReadyLabel:      "Plan-managed issue is ready for execution",
+		planIssueBlockedLabel:    "Plan-managed issue is blocked by another planning issue",
+	}
+	names := map[string]struct{}{}
+	if draft != nil && draft.ProposedInitiativeIssue != nil {
+		for _, label := range draft.ProposedInitiativeIssue.Labels {
+			names[label] = struct{}{}
+		}
+	}
+	if draft != nil {
+		for _, spec := range draft.ProposedSpecIssues {
+			for _, label := range spec.Labels {
+				names[label] = struct{}{}
+			}
+		}
+	}
+	out := make([]GitHubLabelInput, 0, len(names))
+	for name := range names {
+		if strings.TrimSpace(name) == "" {
+			continue
+		}
+		color := colors[name]
+		if color == "" {
+			color = "ededed"
+		}
+		out = append(out, GitHubLabelInput{
+			Name:        name,
+			Color:       color,
+			Description: descriptions[name],
+		})
+	}
+	return out
+}
+
+func promotionManualFallbackError(draft *PromotionDraft, result *PromotionApplyResult, err error) error {
+	if draft != nil {
+		draft.ManualFallbackAllowed = true
+	}
+	if result == nil {
+		result = &PromotionApplyResult{Draft: draft}
+	}
+	result.ManualFallbackAllowed = true
+	if err != nil {
+		result.ManualFallbackReason = err.Error()
+	}
+	result.NextCommand = manualFallbackAdoptCommand(draft)
+	return &PromotionApplyManualFallbackError{Result: result, Err: err}
+}
+
+func manualFallbackAdoptCommand(draft *PromotionDraft) string {
+	args := []string{"plan", "github", "adopt", "--project", "."}
+	if draft != nil {
+		args = append(args, sourceSelectorArgs(draft.Source)...)
+	}
+	placeholders := []string{}
+	if draft != nil && draft.ProposedInitiativeIssue != nil {
+		placeholders = append(placeholders, "<initiative issue>")
+	}
+	if draft != nil {
+		for range draft.ProposedSpecIssues {
+			placeholders = append(placeholders, "<spec issue>")
+		}
+	}
+	if len(placeholders) == 0 {
+		placeholders = append(placeholders, "<issue>")
+	}
+	args = append(args, "--issues", strings.Join(placeholders, ","))
+	if requiresProjectDecision(draft) {
+		args = append(args, "--project-decision", "<create|skip>")
+	}
+	args = append(args, "--format", "json")
+	return shellCommand(args)
 }
 
 func milestoneNumberOrZero(m *GitHubMilestone) int {

--- a/internal/planning/collaboration.go
+++ b/internal/planning/collaboration.go
@@ -19,6 +19,8 @@ const (
 	promotionDraftKind         = "promotion_draft"
 )
 
+var safeShellArgPattern = regexp.MustCompile(`^[A-Za-z0-9_./:=+-]+$`)
+
 type SourceOfTruthMode = workspace.SourceOfTruthMode
 
 const (
@@ -1660,7 +1662,7 @@ func shellQuote(arg string) string {
 	if arg == "" {
 		return "''"
 	}
-	if regexp.MustCompile(`^[A-Za-z0-9_./:=+-]+$`).MatchString(arg) {
+	if safeShellArgPattern.MatchString(arg) {
 		return arg
 	}
 	return "'" + strings.ReplaceAll(arg, "'", "'\"'\"'") + "'"
@@ -1753,14 +1755,12 @@ func (m *Manager) ensurePromotionLabels(projectDir, repo string, draft *Promotio
 
 func promotionLabelInputs(draft *PromotionDraft) []GitHubLabelInput {
 	colors := map[string]string{
-		"enhancement":            "a2eeef",
 		planIssueInitiativeLabel: "5319e7",
 		planIssueSpecLabel:       "1d76db",
 		planIssueReadyLabel:      "0e8a16",
 		planIssueBlockedLabel:    "d93f0b",
 	}
 	descriptions := map[string]string{
-		"enhancement":            "New feature or request",
 		planIssueInitiativeLabel: "Plan-managed initiative issue",
 		planIssueSpecLabel:       "Plan-managed spec issue",
 		planIssueReadyLabel:      "Plan-managed issue is ready for execution",
@@ -1782,6 +1782,9 @@ func promotionLabelInputs(draft *PromotionDraft) []GitHubLabelInput {
 	out := make([]GitHubLabelInput, 0, len(names))
 	for name := range names {
 		if strings.TrimSpace(name) == "" {
+			continue
+		}
+		if !strings.HasPrefix(name, "plan:") {
 			continue
 		}
 		color := colors[name]

--- a/internal/planning/collaboration_test.go
+++ b/internal/planning/collaboration_test.go
@@ -2,6 +2,7 @@ package planning
 
 import (
 	"encoding/json"
+	"errors"
 	"strings"
 	"testing"
 
@@ -196,6 +197,300 @@ func TestAssessAndPromoteGitHubDiscussion(t *testing.T) {
 	}
 }
 
+func TestSixSpecProsePromotesAsMultiSpecWithProjectDecision(t *testing.T) {
+	client := &stubGitHubClient{
+		preflight: &GitHubRepoInfo{
+			Repo:          "JimmyMcBride/plan",
+			RepoURL:       "https://github.com/JimmyMcBride/plan",
+			DefaultBranch: "develop",
+		},
+		context: &GitHubContext{
+			Repo: GitHubRepoInfo{
+				Repo:          "JimmyMcBride/plan",
+				RepoURL:       "https://github.com/JimmyMcBride/plan",
+				DefaultBranch: "develop",
+			},
+			CurrentBranch: "develop",
+			CurrentSHA:    "abc123",
+		},
+		discussions: map[int]*GitHubDiscussion{
+			88: {
+				Number: 88,
+				URL:    "https://github.com/JimmyMcBride/plan/discussions/88",
+				Title:  "Pre-planning Center Product Readiness",
+				Body: strings.Join([]string{
+					"## Problem",
+					"Product readiness work is being shaped inconsistently across operational surfaces.",
+					"",
+					"## Goals",
+					"Create predictable GitHub planning issues for the readiness work.",
+					"",
+					"## Non-Goals",
+					"Do not implement the product surfaces during promotion.",
+					"",
+					"## Constraints",
+					"Keep the promoted issue set milestone-backed and reviewable.",
+					"",
+					"## Proposed Shape",
+					"Create spec issues for: Operational Data UI CRUD, Product Readiness API, Import Pipeline, Permission Model, Audit Trail, Release Coordination",
+				}, "\n"),
+			},
+		},
+	}
+	reset := SetGitHubClientFactoryForTesting(func() GitHubClient { return client })
+	t.Cleanup(reset)
+
+	root := t.TempDir()
+	ws := workspace.New(root)
+	if _, err := ws.Init(); err != nil {
+		t.Fatal(err)
+	}
+	manager := New(ws)
+
+	assessment, err := manager.AssessCollaborationSource(CollaborationAssessInput{DiscussionRef: "88"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if assessment.Decision.State != MaturityReadyMultiSpec {
+		t.Fatalf("expected multi-spec readiness: %+v", assessment.Decision)
+	}
+	if len(assessment.Decision.SuggestedTitles.Specs) != 6 {
+		t.Fatalf("expected six specs: %+v", assessment.Decision.SuggestedTitles.Specs)
+	}
+
+	draft, err := manager.BuildPromotionDraft(PromotionDraftInput{DiscussionRef: "88"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if draft.ProjectPrompt == nil || !draft.ProjectPrompt.Recommended {
+		t.Fatalf("expected project prompt recommendation: %+v", draft.ProjectPrompt)
+	}
+	if draft.ManualFallbackAllowed {
+		t.Fatalf("draft fallback should be disabled by default: %+v", draft)
+	}
+	if len(draft.AgentPolicy.ForbiddenMutations) == 0 || !containsString(draft.AgentPolicy.ForbiddenMutations, "gh issue create") {
+		t.Fatalf("expected hard agent policy: %+v", draft.AgentPolicy)
+	}
+
+	_, err = manager.ApplyPromotionDraft(PromotionApplyInput{
+		DiscussionRef: "88",
+		Confirm:       true,
+		TargetMode:    SourceOfTruthGitHub,
+	})
+	if err == nil || !strings.Contains(err.Error(), "--project-decision create|skip") {
+		t.Fatalf("expected project decision gate, got %v", err)
+	}
+
+	result, err := manager.ApplyPromotionDraft(PromotionApplyInput{
+		DiscussionRef:   "88",
+		Confirm:         true,
+		TargetMode:      SourceOfTruthGitHub,
+		ProjectDecision: "create",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.Initiative == nil || len(result.Specs) != 6 || result.Milestone == nil {
+		t.Fatalf("expected initiative plus six specs and milestone: %+v", result)
+	}
+	if result.ProjectDecision == nil || result.ProjectDecision.Decision != "create" {
+		t.Fatalf("expected project decision record: %+v", result.ProjectDecision)
+	}
+	if !containsString(result.Initiative.Labels, planIssueInitiativeLabel) {
+		t.Fatalf("expected initiative label: %+v", result.Initiative.Labels)
+	}
+	for _, spec := range result.Specs {
+		if !containsString(spec.Labels, planIssueSpecLabel) {
+			t.Fatalf("expected spec label on %s: %+v", spec.Title, spec.Labels)
+		}
+	}
+	state, err := ws.ReadGitHubState()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(state.Planning) != 7 {
+		t.Fatalf("expected initiative plus six specs in metadata: %+v", state.Planning)
+	}
+	if len(state.ProjectDecisions) != 1 {
+		t.Fatalf("expected project decision metadata: %+v", state.ProjectDecisions)
+	}
+}
+
+func TestAssessBlocksExplicitMultiSpecSourceThatNeedsRepair(t *testing.T) {
+	root := t.TempDir()
+	ws := workspace.New(root)
+	if _, err := ws.Init(); err != nil {
+		t.Fatal(err)
+	}
+	manager := New(ws)
+	if _, err := manager.CreateBrainstorm("Repair Split"); err != nil {
+		t.Fatal(err)
+	}
+	if _, _, err := manager.UpdateGuidedBrainstormIntake("repair-split", GuidedBrainstormIntakeInput{
+		Vision: "Create spec issues for a multi-spec readiness initiative.",
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := manager.UpdateBrainstormRefinement("repair-split", BrainstormRefinementInput{
+		Problem:             "Agents can collapse multi-spec requests into one issue.",
+		UserValue:           "The user gets deterministic promotion structure.",
+		Constraints:         "Promotion must fail closed.",
+		CandidateApproaches: "Create spec issues for: Operational Data UI CRUD",
+		DecisionSnapshot:    "Repair the source split before promotion.",
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := manager.UpdateBrainstormChallenge("repair-split", BrainstormChallengeInput{
+		NoGos:              "Do not create GitHub issues manually.",
+		SimplerAlternative: "Repair the Specs section.",
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	assessment, err := manager.AssessCollaborationSource(CollaborationAssessInput{BrainstormSlug: "repair-split"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if assessment.Decision.State != MaturityNeedsSourceRepair {
+		t.Fatalf("expected source repair state: %+v", assessment.Decision)
+	}
+	if assessment.Decision.BlockingReason != "requested multi-spec promotion but source parsed as single spec" {
+		t.Fatalf("unexpected blocking reason: %+v", assessment.Decision)
+	}
+	if !strings.Contains(assessment.Decision.NextCommand, "plan discuss repair") {
+		t.Fatalf("expected repair command: %+v", assessment.Decision)
+	}
+}
+
+func TestApplyPromotionDraftEmitsManualFallbackPayloadOnGitHubFailure(t *testing.T) {
+	client := &stubGitHubClient{
+		preflight: &GitHubRepoInfo{
+			Repo:          "JimmyMcBride/plan",
+			RepoURL:       "https://github.com/JimmyMcBride/plan",
+			DefaultBranch: "develop",
+		},
+		context: &GitHubContext{
+			Repo: GitHubRepoInfo{
+				Repo:          "JimmyMcBride/plan",
+				RepoURL:       "https://github.com/JimmyMcBride/plan",
+				DefaultBranch: "develop",
+			},
+			CurrentBranch: "develop",
+			CurrentSHA:    "abc123",
+		},
+		createIssueErr: errors.New("api unavailable"),
+	}
+	reset := SetGitHubClientFactoryForTesting(func() GitHubClient { return client })
+	t.Cleanup(reset)
+
+	root := t.TempDir()
+	ws := workspace.New(root)
+	if _, err := ws.Init(); err != nil {
+		t.Fatal(err)
+	}
+	manager := New(ws)
+	createReadyCollaborationBrainstormForTest(t, manager, "fallback-flow")
+
+	_, err := manager.ApplyPromotionDraft(PromotionApplyInput{
+		BrainstormSlug: "fallback-flow",
+		Confirm:        true,
+		TargetMode:     SourceOfTruthGitHub,
+	})
+	var fallback *PromotionApplyManualFallbackError
+	if !errors.As(err, &fallback) {
+		t.Fatalf("expected fallback error, got %v", err)
+	}
+	if fallback.Result == nil || !fallback.Result.ManualFallbackAllowed || fallback.Result.Draft == nil || !fallback.Result.Draft.ManualFallbackAllowed {
+		t.Fatalf("expected fallback payload: %+v", fallback.Result)
+	}
+	if !strings.Contains(fallback.Result.NextCommand, "plan github adopt") {
+		t.Fatalf("expected adopt command: %+v", fallback.Result)
+	}
+}
+
+func TestAdoptGitHubPromotionMirrorsExistingIssues(t *testing.T) {
+	client := &stubGitHubClient{
+		preflight: &GitHubRepoInfo{
+			Repo:          "JimmyMcBride/plan",
+			RepoURL:       "https://github.com/JimmyMcBride/plan",
+			DefaultBranch: "develop",
+		},
+		context: &GitHubContext{
+			Repo: GitHubRepoInfo{
+				Repo:          "JimmyMcBride/plan",
+				RepoURL:       "https://github.com/JimmyMcBride/plan",
+				DefaultBranch: "develop",
+			},
+			CurrentBranch: "develop",
+			CurrentSHA:    "abc123",
+		},
+		issues: map[int]*GitHubIssue{
+			201: {Number: 201, URL: "https://github.com/JimmyMcBride/plan/issues/201", Title: "Adopt Flow", State: "open"},
+			202: {Number: 202, URL: "https://github.com/JimmyMcBride/plan/issues/202", Title: "Adopt schema", State: "open"},
+			203: {Number: 203, URL: "https://github.com/JimmyMcBride/plan/issues/203", Title: "Adopt CLI", State: "open"},
+		},
+		discussions: map[int]*GitHubDiscussion{
+			89: {
+				Number: 89,
+				URL:    "https://github.com/JimmyMcBride/plan/discussions/89",
+				Title:  "Adopt Flow",
+				Body: strings.Join([]string{
+					"## Problem",
+					"Manual issue creation needs a Plan-owned recovery path.",
+					"",
+					"## Goals",
+					"Adopt existing issues into metadata.",
+					"",
+					"## Non-Goals",
+					"Do not create unrelated work.",
+					"",
+					"## Constraints",
+					"Validate issue order.",
+					"",
+					"## Proposed Shape",
+					"Use an initiative issue and two specs.",
+					"",
+					"## Spec Split",
+					"- Adopt schema",
+					"- Adopt CLI",
+				}, "\n"),
+			},
+		},
+	}
+	reset := SetGitHubClientFactoryForTesting(func() GitHubClient { return client })
+	t.Cleanup(reset)
+
+	root := t.TempDir()
+	ws := workspace.New(root)
+	if _, err := ws.Init(); err != nil {
+		t.Fatal(err)
+	}
+	manager := New(ws)
+	result, err := manager.AdoptGitHubPromotion(GitHubAdoptInput{
+		DiscussionRef: "89",
+		IssueNumbers:  []int{201, 202, 203},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.Initiative == nil || len(result.Specs) != 2 || result.Milestone == nil {
+		t.Fatalf("expected adopted initiative/spec set: %+v", result)
+	}
+	if len(client.subIssues) != 2 {
+		t.Fatalf("expected adopted sub-issue edges: %+v", client.subIssues)
+	}
+	state, err := ws.ReadGitHubState()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(state.Planning) != 3 {
+		t.Fatalf("expected adopted planning metadata: %+v", state.Planning)
+	}
+	if !containsString(client.issues[202].Labels, planIssueSpecLabel) {
+		t.Fatalf("expected spec labels after adopt: %+v", client.issues[202].Labels)
+	}
+}
+
 func TestBuildPromotionDraftNotReadyUsesEmptySpecSliceInJSON(t *testing.T) {
 	root := t.TempDir()
 	ws := workspace.New(root)
@@ -223,6 +518,34 @@ func TestBuildPromotionDraftNotReadyUsesEmptySpecSliceInJSON(t *testing.T) {
 	}
 	if !strings.Contains(string(raw), `"proposed_spec_issues":[]`) {
 		t.Fatalf("expected stable empty array in json output: %s", string(raw))
+	}
+}
+
+func createReadyCollaborationBrainstormForTest(t *testing.T, manager *Manager, slug string) {
+	t.Helper()
+	title := strings.ReplaceAll(slug, "-", " ")
+	if _, err := manager.CreateBrainstorm(title); err != nil {
+		t.Fatal(err)
+	}
+	if _, _, err := manager.UpdateGuidedBrainstormIntake(slug, GuidedBrainstormIntakeInput{
+		Vision: "Create a reviewed promotion draft.",
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := manager.UpdateBrainstormRefinement(slug, BrainstormRefinementInput{
+		Problem:             "Promotion needs a deterministic gate.",
+		UserValue:           "The user can review before GitHub writes happen.",
+		Constraints:         "Use Plan-owned commands.",
+		CandidateApproaches: "Build promotion draft review.",
+		DecisionSnapshot:    "Promote directly into one spec.",
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := manager.UpdateBrainstormChallenge(slug, BrainstormChallengeInput{
+		NoGos:              "No manual GitHub creation.",
+		SimplerAlternative: "Use discuss promote.",
+	}); err != nil {
+		t.Fatal(err)
 	}
 }
 
@@ -314,5 +637,52 @@ func TestBulletItemsStripsGitHubTaskMarkers(t *testing.T) {
 	}
 	if items[0] != "First spec" || items[1] != "Second spec" || items[2] != "Third spec" {
 		t.Fatalf("expected task markers to be stripped: %+v", items)
+	}
+}
+
+func TestExtractSpecCandidatesSupportsExplicitSpecIssuePatterns(t *testing.T) {
+	tests := []struct {
+		name    string
+		content string
+		want    []string
+	}{
+		{
+			name:    "comma semicolon phrase",
+			content: "Create spec issues for: Operational Data UI CRUD, Product Readiness API; Audit Trail",
+			want:    []string{"Operational Data UI CRUD", "Product Readiness API", "Audit Trail"},
+		},
+		{
+			name: "numbered list behind explicit intent",
+			content: strings.Join([]string{
+				"Please create spec issues for:",
+				"1. Operational Data UI CRUD",
+				"2. Product Readiness API",
+			}, "\n"),
+			want: []string{"Operational Data UI CRUD", "Product Readiness API"},
+		},
+		{
+			name: "desired outcome bullets",
+			content: strings.Join([]string{
+				"Create spec issues for this outcome.",
+				"",
+				"## Desired Outcome",
+				"- Operational Data UI CRUD",
+				"- Product Readiness API",
+			}, "\n"),
+			want: []string{"Operational Data UI CRUD", "Product Readiness API"},
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := extractSpecCandidates(tc.content)
+			if len(got) != len(tc.want) {
+				t.Fatalf("expected %d specs, got %+v", len(tc.want), got)
+			}
+			for i := range tc.want {
+				if got[i] != tc.want[i] {
+					t.Fatalf("expected %+v, got %+v", tc.want, got)
+				}
+			}
+		})
 	}
 }

--- a/internal/planning/github_backend_test.go
+++ b/internal/planning/github_backend_test.go
@@ -17,6 +17,7 @@ type stubGitHubClient struct {
 	context          *GitHubContext
 	issues           map[int]*GitHubIssue
 	milestones       map[string]*GitHubMilestone
+	labels           map[string]GitHubLabelInput
 	milestoneLookups []string
 	discussions      map[int]*GitHubDiscussion
 	subIssues        [][2]int
@@ -24,6 +25,8 @@ type stubGitHubClient struct {
 	nextIssue        int
 	lastCreate       GitHubIssueInput
 	lastUpdate       GitHubIssueInput
+	createIssueErr   error
+	ensureLabelErr   error
 }
 
 func (s *stubGitHubClient) Preflight(projectDir string) (*GitHubRepoInfo, error) {
@@ -41,6 +44,9 @@ func (s *stubGitHubClient) CurrentContext(projectDir string) (*GitHubContext, er
 }
 
 func (s *stubGitHubClient) CreateIssue(projectDir, repo string, input GitHubIssueInput) (*GitHubIssue, error) {
+	if s.createIssueErr != nil {
+		return nil, s.createIssueErr
+	}
 	s.lastCreate = input
 	if s.issues == nil {
 		s.issues = map[int]*GitHubIssue{}
@@ -113,6 +119,32 @@ func (s *stubGitHubClient) GetIssue(projectDir, repo string, issueNumber int) (*
 	return &copy, nil
 }
 
+func (s *stubGitHubClient) ListIssuesByLabel(projectDir, repo string, labels []string) ([]GitHubIssue, error) {
+	var out []GitHubIssue
+	for _, issue := range s.issues {
+		for _, label := range labels {
+			if containsString(issue.Labels, label) {
+				copy := *issue
+				copy.Labels = append([]string(nil), issue.Labels...)
+				out = append(out, copy)
+				break
+			}
+		}
+	}
+	return out, nil
+}
+
+func (s *stubGitHubClient) EnsureLabel(projectDir, repo string, input GitHubLabelInput) error {
+	if s.ensureLabelErr != nil {
+		return s.ensureLabelErr
+	}
+	if s.labels == nil {
+		s.labels = map[string]GitHubLabelInput{}
+	}
+	s.labels[input.Name] = input
+	return nil
+}
+
 func (s *stubGitHubClient) FindMilestone(projectDir, repo, title string) (*GitHubMilestone, error) {
 	s.milestoneLookups = append(s.milestoneLookups, title)
 	if s.milestones == nil {
@@ -145,6 +177,20 @@ func (s *stubGitHubClient) GetDiscussion(projectDir, repo string, number int) (*
 	if !ok {
 		return nil, fmt.Errorf("discussion %d not found", number)
 	}
+	copy := *item
+	copy.Comments = append([]GitHubDiscussionComment(nil), item.Comments...)
+	return &copy, nil
+}
+
+func (s *stubGitHubClient) UpdateDiscussionBody(projectDir, repo string, number int, body string) (*GitHubDiscussion, error) {
+	if s.discussions == nil {
+		return nil, fmt.Errorf("unexpected UpdateDiscussionBody call")
+	}
+	item, ok := s.discussions[number]
+	if !ok {
+		return nil, fmt.Errorf("discussion %d not found", number)
+	}
+	item.Body = body
 	copy := *item
 	copy.Comments = append([]GitHubDiscussionComment(nil), item.Comments...)
 	return &copy, nil

--- a/internal/planning/github_client.go
+++ b/internal/planning/github_client.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"os/exec"
 	"path/filepath"
+	"strconv"
 	"strings"
 )
 
@@ -111,6 +112,8 @@ func SetGitHubClientFactoryForTesting(factory func() GitHubClient) func() {
 }
 
 type cliGitHubClient struct{}
+
+const gitHubIssueListLimit = 1000
 
 func (c *cliGitHubClient) Preflight(projectDir string) (*GitHubRepoInfo, error) {
 	if _, err := exec.LookPath("gh"); err != nil {
@@ -257,7 +260,7 @@ func (c *cliGitHubClient) GetIssue(projectDir, repo string, issueNumber int) (*G
 }
 
 func (c *cliGitHubClient) ListIssuesByLabel(projectDir, repo string, labels []string) ([]GitHubIssue, error) {
-	args := []string{"issue", "list", "--repo", repo, "--state", "all", "--limit", "100", "--json", "number,url,title,body,state,labels,milestone"}
+	args := []string{"issue", "list", "--repo", repo, "--state", "all", "--limit", strconv.Itoa(gitHubIssueListLimit), "--json", "number,url,title,body,state,labels,milestone"}
 	for _, label := range labels {
 		if strings.TrimSpace(label) == "" {
 			continue
@@ -268,7 +271,14 @@ func (c *cliGitHubClient) ListIssuesByLabel(projectDir, repo string, labels []st
 	if err != nil {
 		return nil, fmt.Errorf("gh issue list failed: %w", err)
 	}
-	return parseGitHubIssueList(out)
+	issues, err := parseGitHubIssueList(out)
+	if err != nil {
+		return nil, err
+	}
+	if len(issues) >= gitHubIssueListLimit {
+		return nil, fmt.Errorf("GitHub issue listing for labels %s reached the %d issue safety limit; rerun with a narrower Plan label or add pagination before relying on drift checks", strings.Join(labels, ","), gitHubIssueListLimit)
+	}
+	return issues, nil
 }
 
 func (c *cliGitHubClient) EnsureLabel(projectDir, repo string, input GitHubLabelInput) error {

--- a/internal/planning/github_client.go
+++ b/internal/planning/github_client.go
@@ -15,9 +15,12 @@ type GitHubClient interface {
 	CreateIssue(projectDir, repo string, input GitHubIssueInput) (*GitHubIssue, error)
 	UpdateIssue(projectDir, repo string, issueNumber int, input GitHubIssueInput) (*GitHubIssue, error)
 	GetIssue(projectDir, repo string, issueNumber int) (*GitHubIssue, error)
+	ListIssuesByLabel(projectDir, repo string, labels []string) ([]GitHubIssue, error)
+	EnsureLabel(projectDir, repo string, input GitHubLabelInput) error
 	FindMilestone(projectDir, repo, title string) (*GitHubMilestone, error)
 	CreateMilestone(projectDir, repo string, input GitHubMilestoneInput) (*GitHubMilestone, error)
 	GetDiscussion(projectDir, repo string, number int) (*GitHubDiscussion, error)
+	UpdateDiscussionBody(projectDir, repo string, number int, body string) (*GitHubDiscussion, error)
 	AddSubIssue(projectDir, repo string, issueNumber, subIssueNumber int) error
 	AddBlockedBy(projectDir, repo string, issueNumber, blockingIssueNumber int) error
 }
@@ -65,6 +68,12 @@ type GitHubIssue struct {
 	State     string
 	Labels    []string
 	Milestone *GitHubMilestone
+}
+
+type GitHubLabelInput struct {
+	Name        string
+	Color       string
+	Description string
 }
 
 type GitHubMilestone struct {
@@ -247,6 +256,35 @@ func (c *cliGitHubClient) GetIssue(projectDir, repo string, issueNumber int) (*G
 	return parseGitHubIssue(out)
 }
 
+func (c *cliGitHubClient) ListIssuesByLabel(projectDir, repo string, labels []string) ([]GitHubIssue, error) {
+	args := []string{"issue", "list", "--repo", repo, "--state", "all", "--limit", "100", "--json", "number,url,title,body,state,labels,milestone"}
+	for _, label := range labels {
+		if strings.TrimSpace(label) == "" {
+			continue
+		}
+		args = append(args, "--label", label)
+	}
+	out, err := c.run(projectDir, nil, "gh", args...)
+	if err != nil {
+		return nil, fmt.Errorf("gh issue list failed: %w", err)
+	}
+	return parseGitHubIssueList(out)
+}
+
+func (c *cliGitHubClient) EnsureLabel(projectDir, repo string, input GitHubLabelInput) error {
+	args := []string{"label", "create", input.Name, "--repo", repo, "--force"}
+	if strings.TrimSpace(input.Color) != "" {
+		args = append(args, "--color", strings.TrimSpace(input.Color))
+	}
+	if strings.TrimSpace(input.Description) != "" {
+		args = append(args, "--description", strings.TrimSpace(input.Description))
+	}
+	if _, err := c.run(projectDir, nil, "gh", args...); err != nil {
+		return fmt.Errorf("ensure GitHub label %q: %w", input.Name, err)
+	}
+	return nil
+}
+
 func (c *cliGitHubClient) FindMilestone(projectDir, repo, title string) (*GitHubMilestone, error) {
 	type milestonePayload struct {
 		Number int    `json:"number"`
@@ -374,6 +412,88 @@ func (c *cliGitHubClient) GetDiscussion(projectDir, repo string, number int) (*G
 	}
 	item.Comments = comments
 	return item, nil
+}
+
+func (c *cliGitHubClient) UpdateDiscussionBody(projectDir, repo string, number int, body string) (*GitHubDiscussion, error) {
+	owner, name, err := splitRepo(repo)
+	if err != nil {
+		return nil, err
+	}
+	query := `query($owner:String!, $name:String!, $number:Int!) {
+  repository(owner:$owner, name:$name) {
+    discussion(number:$number) {
+      id
+      number
+      url
+      title
+      body
+    }
+  }
+}`
+	var lookup struct {
+		Data struct {
+			Repository struct {
+				Discussion *struct {
+					ID     string `json:"id"`
+					Number int    `json:"number"`
+					URL    string `json:"url"`
+					Title  string `json:"title"`
+					Body   string `json:"body"`
+				} `json:"discussion"`
+			} `json:"repository"`
+		} `json:"data"`
+	}
+	payload := map[string]any{
+		"query": query,
+		"variables": map[string]any{
+			"owner":  owner,
+			"name":   name,
+			"number": number,
+		},
+	}
+	if err := c.graphql(projectDir, payload, &lookup); err != nil {
+		return nil, err
+	}
+	if lookup.Data.Repository.Discussion == nil || strings.TrimSpace(lookup.Data.Repository.Discussion.ID) == "" {
+		return nil, fmt.Errorf("discussion #%d not found in %s", number, repo)
+	}
+	mutation := map[string]any{
+		"query": `mutation($discussionId:ID!, $body:String!) {
+  updateDiscussion(input:{discussionId:$discussionId, body:$body}) {
+    discussion {
+      number
+      url
+      title
+      body
+    }
+  }
+}`,
+		"variables": map[string]any{
+			"discussionId": lookup.Data.Repository.Discussion.ID,
+			"body":         body,
+		},
+	}
+	var response struct {
+		Data struct {
+			UpdateDiscussion struct {
+				Discussion struct {
+					Number int    `json:"number"`
+					URL    string `json:"url"`
+					Title  string `json:"title"`
+					Body   string `json:"body"`
+				} `json:"discussion"`
+			} `json:"updateDiscussion"`
+		} `json:"data"`
+	}
+	if err := c.graphql(projectDir, mutation, &response); err != nil {
+		return nil, err
+	}
+	return &GitHubDiscussion{
+		Number: response.Data.UpdateDiscussion.Discussion.Number,
+		URL:    response.Data.UpdateDiscussion.Discussion.URL,
+		Title:  response.Data.UpdateDiscussion.Discussion.Title,
+		Body:   response.Data.UpdateDiscussion.Discussion.Body,
+	}, nil
 }
 
 func (c *cliGitHubClient) AddSubIssue(projectDir, repo string, issueNumber, subIssueNumber int) error {
@@ -581,4 +701,49 @@ func parseGitHubIssue(raw []byte) (*GitHubIssue, error) {
 		}
 	}
 	return issue, nil
+}
+
+func parseGitHubIssueList(raw []byte) ([]GitHubIssue, error) {
+	type label struct {
+		Name string `json:"name"`
+	}
+	type payload struct {
+		Number    int     `json:"number"`
+		URL       string  `json:"url"`
+		Title     string  `json:"title"`
+		Body      string  `json:"body"`
+		State     string  `json:"state"`
+		Labels    []label `json:"labels"`
+		Milestone *struct {
+			Number int    `json:"number"`
+			Title  string `json:"title"`
+		} `json:"milestone"`
+	}
+	var items []payload
+	if err := json.Unmarshal(raw, &items); err != nil {
+		return nil, fmt.Errorf("parse issue list payload: %w", err)
+	}
+	out := make([]GitHubIssue, 0, len(items))
+	for _, item := range items {
+		issue := GitHubIssue{
+			Number: item.Number,
+			URL:    item.URL,
+			Title:  item.Title,
+			Body:   item.Body,
+			State:  item.State,
+		}
+		for _, label := range item.Labels {
+			if strings.TrimSpace(label.Name) != "" {
+				issue.Labels = append(issue.Labels, label.Name)
+			}
+		}
+		if item.Milestone != nil {
+			issue.Milestone = &GitHubMilestone{
+				Number: item.Milestone.Number,
+				Title:  item.Milestone.Title,
+			}
+		}
+		out = append(out, issue)
+	}
+	return out, nil
 }

--- a/internal/planning/github_story_backend.go
+++ b/internal/planning/github_story_backend.go
@@ -12,11 +12,13 @@ import (
 )
 
 const (
-	planIssueBlockStart   = "<!-- plan:start -->"
-	planIssueBlockEnd     = "<!-- plan:end -->"
-	planIssueMetaPrefix   = "<!-- plan:meta"
-	planIssueReadyLabel   = "plan:ready"
-	planIssueBlockedLabel = "plan:blocked"
+	planIssueBlockStart      = "<!-- plan:start -->"
+	planIssueBlockEnd        = "<!-- plan:end -->"
+	planIssueMetaPrefix      = "<!-- plan:meta"
+	planIssueInitiativeLabel = "plan:initiative"
+	planIssueSpecLabel       = "plan:spec"
+	planIssueReadyLabel      = "plan:ready"
+	planIssueBlockedLabel    = "plan:blocked"
 )
 
 func (m *Manager) storyBackendForInfo() (workspace.StoryBackend, error) {

--- a/internal/planning/guide_packet.go
+++ b/internal/planning/guide_packet.go
@@ -474,6 +474,7 @@ func collaborationGuideContract(stage, artifactPath string) GuidePacketContract 
 			"Do not replace the canonical discuss payloads with ad hoc packet-only data.",
 			"Do not mutate the collaboration source while rendering the packet.",
 			"Do not invent execution-state automation during collaboration shaping.",
+			"Do not create GitHub planning issues, labels, milestones, or projects manually unless Plan emits manual_fallback_allowed=true.",
 		},
 		StrengthenSections: collaborationStrengthenSections(stage),
 	}
@@ -489,6 +490,7 @@ func collaborationGuideContract(stage, artifactPath string) GuidePacketContract 
 			"Do not treat the guide packet as the canonical collaboration record.",
 			"Do not bypass the explicit review and confirmation flow.",
 			"Do not mutate GitHub or local planning state while previewing the packet.",
+			"Do not create GitHub planning issues manually; repair the source and rerun Plan commands when output disagrees with user intent.",
 		},
 		QualityBar: []string{
 			"The packet should make the next collaboration decision obvious without re-deriving the discuss payloads.",
@@ -642,6 +644,9 @@ func collaborationNextAction(stage string, mode SourceOfTruthMode, assessment *C
 		if assessment != nil && assessment.Decision.State == MaturityNotReady {
 			return "Refine the source material until the missing gaps are resolved, then reassess."
 		}
+		if assessment != nil && assessment.Decision.State == MaturityNeedsSourceRepair {
+			return "Repair the source spec split with `plan discuss repair`, then reassess before promotion."
+		}
 		return "Review the promotion draft before any apply action."
 	case "promotion_review":
 		return nextApplyAction(mode, draft)
@@ -742,7 +747,19 @@ func buildCollaborationActions(stage string, mode SourceOfTruthMode, brainstormS
 	if stage == "promotion_review" || stage == "initiative_draft" || stage == "spec_draft" || stage == "needs_refinement" {
 		actions = append(actions, collaborationApplyActions(mode, sourceArg, draft)...)
 	}
-	if stage == "discussion_assess" && assessment != nil && assessment.Decision.State != MaturityNotReady {
+	if stage == "discussion_assess" && assessment != nil && assessment.Decision.State == MaturityNeedsSourceRepair {
+		actions = append(actions, GuidePacketAction{
+			ID:            "repair_spec_split",
+			Kind:          "repair",
+			Label:         "Repair spec split",
+			Description:   "Write a canonical Specs section before promotion can continue.",
+			Command:       assessment.Decision.NextCommand,
+			Target:        "collaboration_source",
+			Available:     true,
+			BlockedReason: assessment.Decision.BlockingReason,
+		})
+	}
+	if stage == "discussion_assess" && assessment != nil && (assessment.Decision.State == MaturityReadySingleSpec || assessment.Decision.State == MaturityReadyMultiSpec) {
 		actions = append(actions, GuidePacketAction{
 			ID:          "build_promotion_draft",
 			Kind:        "review",

--- a/internal/workspace/workspace.go
+++ b/internal/workspace/workspace.go
@@ -43,14 +43,15 @@ type WorkspaceMeta struct {
 }
 
 type GitHubState struct {
-	Repo           string                          `json:"repo,omitempty"`
-	RepoURL        string                          `json:"repo_url,omitempty"`
-	DefaultBranch  string                          `json:"default_branch,omitempty"`
-	LastEnabledAt  string                          `json:"last_enabled_at,omitempty"`
-	LastUpdatedAt  string                          `json:"last_updated_at,omitempty"`
-	LastReconciled string                          `json:"last_reconciled_at,omitempty"`
-	Stories        map[string]GitHubStoryRecord    `json:"stories"`
-	Planning       map[string]GitHubPlanningRecord `json:"planning"`
+	Repo             string                                 `json:"repo,omitempty"`
+	RepoURL          string                                 `json:"repo_url,omitempty"`
+	DefaultBranch    string                                 `json:"default_branch,omitempty"`
+	LastEnabledAt    string                                 `json:"last_enabled_at,omitempty"`
+	LastUpdatedAt    string                                 `json:"last_updated_at,omitempty"`
+	LastReconciled   string                                 `json:"last_reconciled_at,omitempty"`
+	Stories          map[string]GitHubStoryRecord           `json:"stories"`
+	Planning         map[string]GitHubPlanningRecord        `json:"planning"`
+	ProjectDecisions map[string]GitHubProjectDecisionRecord `json:"project_decisions,omitempty"`
 }
 
 type GitHubPlanningRecord struct {
@@ -71,6 +72,20 @@ type GitHubPlanningRecord struct {
 	MilestoneTitle    string   `json:"milestone_title,omitempty"`
 	BlockedBy         []string `json:"blocked_by,omitempty"`
 	UpdatedAt         string   `json:"updated_at,omitempty"`
+}
+
+type GitHubProjectDecisionRecord struct {
+	Slug             string `json:"slug"`
+	Decision         string `json:"decision"`
+	Reason           string `json:"reason,omitempty"`
+	SpecCount        int    `json:"spec_count,omitempty"`
+	MilestoneNumber  int    `json:"milestone_number,omitempty"`
+	MilestoneTitle   string `json:"milestone_title,omitempty"`
+	SourceMode       string `json:"source_mode,omitempty"`
+	EntryMode        string `json:"entry_mode,omitempty"`
+	DiscussionNumber int    `json:"discussion_number,omitempty"`
+	DiscussionURL    string `json:"discussion_url,omitempty"`
+	UpdatedAt        string `json:"updated_at,omitempty"`
 }
 
 type GitHubStoryRecord struct {
@@ -456,6 +471,9 @@ func readGitHubStateFile(path string) (*GitHubState, error) {
 	}
 	if state.Planning == nil {
 		state.Planning = map[string]GitHubPlanningRecord{}
+	}
+	if state.ProjectDecisions == nil {
+		state.ProjectDecisions = map[string]GitHubProjectDecisionRecord{}
 	}
 	return &state, nil
 }
@@ -959,9 +977,10 @@ func defaultMigrationState(now string) MigrationState {
 
 func defaultGitHubState(now string) GitHubState {
 	return GitHubState{
-		LastUpdatedAt: now,
-		Stories:       map[string]GitHubStoryRecord{},
-		Planning:      map[string]GitHubPlanningRecord{},
+		LastUpdatedAt:    now,
+		Stories:          map[string]GitHubStoryRecord{},
+		Planning:         map[string]GitHubPlanningRecord{},
+		ProjectDecisions: map[string]GitHubProjectDecisionRecord{},
 	}
 }
 

--- a/skills/plan/SKILL.md
+++ b/skills/plan/SKILL.md
@@ -51,6 +51,10 @@ When a repo uses `plan`:
 - `plan discuss assess --project . --discussion <number-or-url> --format json`
 - `plan discuss promote --project . --brainstorm <brainstorm-slug> --format json`
 - `plan discuss promote --project . --discussion <number-or-url> --format json`
+- `plan discuss repair --project . --brainstorm <brainstorm-slug> --spec "<title>" --spec "<title>" --format json`
+- `plan discuss repair --project . --discussion <number-or-url> --spec "<title>" --spec "<title>" --confirm --format json`
+- `plan github adopt --project . --brainstorm <brainstorm-slug> --issues <numbers> --format json`
+- `plan github adopt --project . --discussion <number-or-url> --issues <numbers> --format json`
 - `plan guide current --project . --format json` when a guided brainstorm session is active
 - `plan guide show --project . --chain <chain-id> --stage brainstorm --checkpoint <checkpoint> --format json` for explicit brainstorm preview/debug use
 - `plan guide show --project . --brainstorm <brainstorm-slug> --stage <discussion_assess|promotion_review|initiative_draft|spec_draft|needs_refinement> --format json`
@@ -78,6 +82,8 @@ When a repo uses `plan`:
 - `brainstorm challenge` should pressure-test risk, no-gos, and overengineering before promotion.
 - `discuss assess` should produce an explicit maturity decision before a GitHub-backed promotion happens.
 - `discuss promote` should stay draft-first unless the task explicitly calls for `--apply --confirm`.
+- In `github` or `hybrid` source mode, never create planning issues, labels, milestones, or project prompts with `gh` unless Plan emitted `manual_fallback_allowed=true`.
+- If Plan output disagrees with user intent, repair the Plan source with `plan discuss repair` and rerun assess/promote instead of filling the gap manually.
 - today, `discuss promote --apply` is implemented for `github` and `hybrid`; repo-backed local promotion still uses the legacy compatibility path
 - When a guided brainstorm session is active, prefer live guide packets over static stage prose.
 - For collaboration shaping, use `plan guide show` to wrap the canonical `discuss` payloads instead of inventing a parallel promotion contract.
@@ -134,6 +140,7 @@ Use the smallest pass that resolves the current planning gap:
 
 - if the next shaping pass is obvious, run it
 - if two passes could apply, choose the lighter one first
-- if the repo is in `github` or `hybrid` mode, prefer `discuss assess` and `discuss promote` before inventing new issue text manually
+- if the repo is in `github` or `hybrid` mode, use `discuss assess` and `discuss promote`; do not invent issue text or create GitHub planning objects manually
+- if `discuss assess` returns `needs_source_repair`, run the emitted repair command and reassess before promotion
 - if backend ownership is unclear, inspect project rules and current GitHub state before editing durable planning artifacts
 - do not turn `plan` into memory, context, or execution orchestration


### PR DESCRIPTION
## Summary

- make GitHub promotion fail closed when explicit multi-spec intent cannot be parsed
- add Plan-owned source repair, manual fallback adoption, Plan labels, project-decision gating, and drift checks
- strengthen agent-facing guide packets, docs, and Plan skill rules to forbid manual GitHub planning mutation unless Plan allows fallback

## Validation

- go test ./...
- go build ./...
