### PR TITLE
Add plan-execute skill

### DIFF
--- a/.brain/context/current-state.md
+++ b/.brain/context/current-state.md
@@ -1,5 +1,5 @@
 ---
-updated: "2026-04-25T05:03:09Z"
+updated: "2026-04-27T06:17:17Z"
 ---
 # Current State
 
@@ -37,3 +37,4 @@ Add repo-specific notes here. `brain context refresh` preserves content outside 
 - On April 23, 2026, workspace refresh stopped backfilling optional compatibility defaults into tracked metadata during `plan update`: `source_mode` and GitHub `planning` map now default in memory on read, so `./scripts/refresh-plan-develop-context.sh` no longer dirties `develop` just to normalize older `.plan/.meta/*.json` files.
 - On April 25, 2026, GitHub promotion became fail-closed: explicit multi-spec sources that parse as fewer than two specs now return `needs_source_repair`, `plan discuss repair` owns canonical `## Specs` repair, promotion drafts include hard agent policy and fallback gating, 5+ spec apply/adopt requires `--project-decision`, `plan github adopt` recovers manual issue sets, and `plan check` detects Plan-labeled GitHub planning drift.
 - On April 25, 2026, PR `#62` review comments tightened the fail-closed promotion branch: GitHub issue listing now raises on 1000-item truncation instead of silently missing Plan-labeled issues, `github adopt` validates output format before mutation, drift findings are deterministic and preserve milestone display casing, label ensuring only touches Plan-owned `plan:*` labels, and shell command quoting reuses a package-level regex.
+- On April 27, 2026, Plan skill installation expanded from one bundled skill to two: `plan skills install` now installs both the base `plan` planning skill and the companion `plan-execute` execution rail skill, with manifests recording the installed skill name.

--- a/.brain/resources/changes/implement-plan-execute-skill-bundled-with-plan-skills-install.md
+++ b/.brain/resources/changes/implement-plan-execute-skill-bundled-with-plan-skills-install.md
@@ -1,0 +1,15 @@
+---
+updated: "2026-04-27T06:17:40Z"
+---
+# Plan-Execute Skill Bundling
+
+## Verification
+
+Verified after adding the bundled `plan-execute` skill, multi-skill installer
+support, docs, and command/installer tests.
+
+Commands:
+
+- `go test ./...`
+- `go build ./...`
+- `go test -race ./...`

--- a/README.md
+++ b/README.md
@@ -259,7 +259,13 @@ go build -o plan .
 install -Dm0755 plan ~/.local/bin/plan
 ```
 
-## Install The Plan Skill
+## Install The Plan Skills
+
+The installer copies two companion skills:
+
+- `plan` for planning, spec truth, and shaping workflows
+- `plan-execute` for executing one approved spec through branch, code, tests,
+  commit, push, and a ready PR
 
 Global:
 
@@ -278,6 +284,10 @@ Preview install targets:
 ```bash
 plan skills targets --scope both --agent codex --project .
 ```
+
+`plan-execute` is intentionally plan-adjacent. It consumes approved `plan`
+specs but owns the agent execution rail instead of adding task-runner behavior
+to the core `plan` CLI.
 
 ## Codex Cloud + Brain
 

--- a/cmd/skills.go
+++ b/cmd/skills.go
@@ -15,12 +15,12 @@ func newSkillsCommand() *cobra.Command {
 
 	cmd := &cobra.Command{
 		Use:   "skills",
-		Short: "Install the Plan skill into global or project-local skill roots",
+		Short: "Install Plan skills into global or project-local skill roots",
 	}
 
 	install := &cobra.Command{
 		Use:   "install",
-		Short: "Install the Plan skill",
+		Short: "Install the Plan skills",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			results, err := skills.NewInstaller("").Install(skills.InstallRequest{
 				Scope:      skills.Scope(scope),
@@ -31,7 +31,7 @@ func newSkillsCommand() *cobra.Command {
 				return err
 			}
 			for _, result := range results {
-				fmt.Printf("%s [%s] plan %s -> %s\n", result.Agent, result.Scope, result.Method, result.Path)
+				fmt.Fprintf(cmd.OutOrStdout(), "%s [%s] %s %s -> %s\n", result.Agent, result.Scope, result.Skill, result.Method, result.Path)
 			}
 			return nil
 		},
@@ -50,7 +50,7 @@ func newSkillsCommand() *cobra.Command {
 				return err
 			}
 			for _, item := range items {
-				fmt.Printf("%s [%s] %s\n", item.Agent, item.Scope, item.Path)
+				fmt.Fprintf(cmd.OutOrStdout(), "%s [%s] %s\n", item.Agent, item.Scope, item.Path)
 			}
 			return nil
 		},

--- a/cmd/skills_test.go
+++ b/cmd/skills_test.go
@@ -1,0 +1,34 @@
+package cmd
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestSkillsInstallPrintsInstalledSkillNames(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
+
+	var buf bytes.Buffer
+	command := newRootCmd()
+	command.SetOut(&buf)
+	command.SetErr(&buf)
+	command.SetArgs([]string{"skills", "install", "--scope", "global", "--agent", "codex"})
+	if err := command.Execute(); err != nil {
+		t.Fatalf("expected skills install to succeed: %v\n%s", err, buf.String())
+	}
+
+	output := buf.String()
+	for _, skill := range []string{"plan", "plan-execute"} {
+		if !strings.Contains(output, "codex [global] "+skill+" copy ->") {
+			t.Fatalf("expected install output to include %s:\n%s", skill, output)
+		}
+		if _, err := os.Stat(filepath.Join(home, ".codex", "skills", skill, "SKILL.md")); err != nil {
+			t.Fatalf("expected installed %s skill: %v", skill, err)
+		}
+	}
+}

--- a/docs/using-plan.md
+++ b/docs/using-plan.md
@@ -665,13 +665,13 @@ plan roadmap edit --project .
 
 ## Skill Installation
 
-Install the `plan` skill globally:
+Install the `plan` and `plan-execute` skills globally:
 
 ```bash
 plan skills install --scope global --agent codex
 ```
 
-Install locally in the repo:
+Install both skills locally in the repo:
 
 ```bash
 plan skills install --scope local --agent codex --project .
@@ -684,6 +684,11 @@ plan skills targets --scope both --agent codex --project .
 ```
 
 You can repeat `--agent` for multiple targets.
+
+The base `plan` skill covers planning, source-of-truth ownership, brainstorms,
+specs, and promotion workflows. The `plan-execute` skill is the companion
+execution rail for one approved spec: resolve the spec, derive execution slices,
+branch, implement, verify, commit, push, and open a ready PR.
 
 ## End-To-End Examples
 

--- a/embedded_skills.go
+++ b/embedded_skills.go
@@ -8,11 +8,16 @@ import (
 )
 
 //go:embed skills/plan/**
+//go:embed skills/plan-execute/**
 var embeddedSkills embed.FS
 
 func init() {
-	bundle, err := fs.Sub(embeddedSkills, "skills/plan")
-	if err == nil {
-		skills.RegisterBundle(bundle)
+	bundles := map[string]fs.FS{}
+	for _, name := range []string{"plan", "plan-execute"} {
+		bundle, err := fs.Sub(embeddedSkills, "skills/"+name)
+		if err == nil {
+			bundles[name] = bundle
+		}
 	}
+	skills.RegisterBundles(bundles)
 }

--- a/internal/skills/bundle.go
+++ b/internal/skills/bundle.go
@@ -13,54 +13,101 @@ import (
 )
 
 type skillBundle struct {
+	Name string
 	FS   fs.FS
 	Hash string
 }
 
 var (
-	bundleMu         sync.RWMutex
-	registeredBundle fs.FS
+	bundleMu          sync.RWMutex
+	registeredBundles map[string]fs.FS
 )
 
+var defaultSkillNames = []string{"plan", "plan-execute"}
+
 func RegisterBundle(bundle fs.FS) {
+	if bundle == nil {
+		RegisterBundles(nil)
+		return
+	}
+	RegisterBundles(map[string]fs.FS{"plan": bundle})
+}
+
+func RegisterBundles(bundles map[string]fs.FS) {
 	bundleMu.Lock()
-	registeredBundle = bundle
+	if bundles == nil {
+		registeredBundles = nil
+	} else {
+		registeredBundles = map[string]fs.FS{}
+		for name, bundle := range bundles {
+			if name == "" || bundle == nil {
+				continue
+			}
+			registeredBundles[name] = bundle
+		}
+	}
 	bundleMu.Unlock()
 }
 
-func loadBundle() (skillBundle, error) {
-	bundleFS, err := currentBundleFS()
+func loadBundles() ([]skillBundle, error) {
+	bundleFSes, err := currentBundleFSes()
 	if err != nil {
-		return skillBundle{}, err
-	}
-	hash, err := bundleHash(bundleFS)
-	if err != nil {
-		return skillBundle{}, err
-	}
-	return skillBundle{FS: bundleFS, Hash: hash}, nil
-}
-
-func currentBundleFS() (fs.FS, error) {
-	bundleMu.RLock()
-	bundle := registeredBundle
-	bundleMu.RUnlock()
-	if bundle != nil {
-		return bundle, nil
-	}
-	return sourceTreeBundle()
-}
-
-func sourceTreeBundle() (fs.FS, error) {
-	_, file, _, ok := runtime.Caller(0)
-	if !ok {
-		return nil, fmt.Errorf("resolve bundled plan skill source")
-	}
-	root := filepath.Dir(filepath.Dir(filepath.Dir(file)))
-	source := filepath.Join(root, "skills", "plan")
-	if err := validateSkillSource(source); err != nil {
 		return nil, err
 	}
-	return os.DirFS(source), nil
+
+	names := make([]string, 0, len(bundleFSes))
+	for name := range bundleFSes {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+
+	bundles := make([]skillBundle, 0, len(names))
+	for _, name := range names {
+		bundleFS := bundleFSes[name]
+		if err := validateSkillFS(name, bundleFS); err != nil {
+			return nil, err
+		}
+		hash, err := bundleHash(bundleFS)
+		if err != nil {
+			return nil, err
+		}
+		bundles = append(bundles, skillBundle{Name: name, FS: bundleFS, Hash: hash})
+	}
+	return bundles, nil
+}
+
+func currentBundleFSes() (map[string]fs.FS, error) {
+	bundleMu.RLock()
+	registered := registeredBundles
+	var copy map[string]fs.FS
+	if len(registered) > 0 {
+		copy = map[string]fs.FS{}
+		for name, bundle := range registered {
+			copy[name] = bundle
+		}
+	}
+	bundleMu.RUnlock()
+	if len(copy) > 0 {
+		return copy, nil
+	}
+	return sourceTreeBundles()
+}
+
+func sourceTreeBundles() (map[string]fs.FS, error) {
+	_, file, _, ok := runtime.Caller(0)
+	if !ok {
+		return nil, fmt.Errorf("resolve bundled skill source")
+	}
+	root := filepath.Dir(filepath.Dir(filepath.Dir(file)))
+	bundles := map[string]fs.FS{}
+	for _, name := range defaultSkillNames {
+		source := filepath.Join(root, "skills", name)
+		if err := validateSkillSource(source); err != nil {
+			return nil, err
+		}
+		bundles[name] = os.DirFS(source)
+	}
+	return bundles, nil
 }
 
 func validateSkillSource(source string) error {
@@ -73,6 +120,20 @@ func validateSkillSource(source string) error {
 	}
 	if _, err := os.Stat(filepath.Join(source, "SKILL.md")); err != nil {
 		return fmt.Errorf("skill source missing SKILL.md: %w", err)
+	}
+	return nil
+}
+
+func validateSkillFS(name string, bundle fs.FS) error {
+	info, err := fs.Stat(bundle, ".")
+	if err != nil {
+		return fmt.Errorf("skill bundle %s: %w", name, err)
+	}
+	if !info.IsDir() {
+		return fmt.Errorf("skill bundle %s is not a directory", name)
+	}
+	if _, err := fs.Stat(bundle, "SKILL.md"); err != nil {
+		return fmt.Errorf("skill bundle %s missing SKILL.md: %w", name, err)
 	}
 	return nil
 }
@@ -108,7 +169,7 @@ func bundleFiles(bundle fs.FS) ([]string, error) {
 		files = append(files, path)
 		return nil
 	}); err != nil {
-		return nil, fmt.Errorf("walk bundled plan skill: %w", err)
+		return nil, fmt.Errorf("walk bundled skill: %w", err)
 	}
 	sort.Strings(files)
 	return files, nil

--- a/internal/skills/install.go
+++ b/internal/skills/install.go
@@ -37,6 +37,7 @@ type InstallResult struct {
 
 type Target struct {
 	Agent string `json:"agent"`
+	Skill string `json:"skill"`
 	Scope string `json:"scope"`
 	Root  string `json:"root"`
 	Path  string `json:"path"`
@@ -60,17 +61,26 @@ func NewInstaller(home string) *Installer {
 }
 
 func (i *Installer) Install(req InstallRequest) ([]InstallResult, error) {
-	targets, err := i.ResolveTargets(req)
+	bundles, err := loadBundles()
 	if err != nil {
 		return nil, err
 	}
-	bundle, err := loadBundle()
+	bundlesByName := map[string]skillBundle{}
+	for _, bundle := range bundles {
+		bundlesByName[bundle.Name] = bundle
+	}
+
+	targets, err := i.ResolveTargets(req)
 	if err != nil {
 		return nil, err
 	}
 
 	results := make([]InstallResult, 0, len(targets))
 	for _, target := range targets {
+		bundle, ok := bundlesByName[target.Skill]
+		if !ok {
+			return nil, fmt.Errorf("missing bundled skill %s", target.Skill)
+		}
 		if err := os.MkdirAll(target.Root, 0o755); err != nil {
 			return nil, fmt.Errorf("create skill root %s: %w", target.Root, err)
 		}
@@ -79,7 +89,7 @@ func (i *Installer) Install(req InstallRequest) ([]InstallResult, error) {
 		}
 		results = append(results, InstallResult{
 			Agent:  target.Agent,
-			Skill:  "plan",
+			Skill:  target.Skill,
 			Scope:  target.Scope,
 			Root:   target.Root,
 			Path:   target.Path,
@@ -90,6 +100,16 @@ func (i *Installer) Install(req InstallRequest) ([]InstallResult, error) {
 }
 
 func (i *Installer) ResolveTargets(req InstallRequest) ([]Target, error) {
+	bundles, err := loadBundles()
+	if err != nil {
+		return nil, err
+	}
+	skillNames := make([]string, 0, len(bundles))
+	for _, bundle := range bundles {
+		skillNames = append(skillNames, bundle.Name)
+	}
+	sort.Strings(skillNames)
+
 	scope := req.Scope
 	if scope == "" {
 		scope = ScopeGlobal
@@ -115,41 +135,56 @@ func (i *Installer) ResolveTargets(req InstallRequest) ([]Target, error) {
 		}
 		for _, agent := range agents {
 			root := knownLocalSkillRoot(resolvedProjectDir, agent)
-			targets = append(targets, Target{
-				Agent: agent,
-				Scope: string(ScopeLocal),
-				Root:  root,
-				Path:  filepath.Join(root, "plan"),
-			})
+			for _, skill := range skillNames {
+				targets = append(targets, Target{
+					Agent: agent,
+					Skill: skill,
+					Scope: string(ScopeLocal),
+					Root:  root,
+					Path:  filepath.Join(root, skill),
+				})
+			}
 		}
 	}
 	if scope == ScopeGlobal || scope == ScopeBoth {
 		for _, agent := range agents {
 			root := knownGlobalSkillRoot(i.Home, agent)
-			targets = append(targets, Target{
-				Agent: agent,
-				Scope: string(ScopeGlobal),
-				Root:  root,
-				Path:  filepath.Join(root, "plan"),
-			})
+			for _, skill := range skillNames {
+				targets = append(targets, Target{
+					Agent: agent,
+					Skill: skill,
+					Scope: string(ScopeGlobal),
+					Root:  root,
+					Path:  filepath.Join(root, skill),
+				})
+			}
 		}
 	}
 	return dedupeTargets(targets), nil
 }
 
 func (i *Installer) Inspect(req InstallRequest) ([]TargetStatus, error) {
-	targets, err := i.ResolveTargets(req)
+	bundles, err := loadBundles()
 	if err != nil {
 		return nil, err
 	}
-	bundle, err := loadBundle()
+	hashesByName := map[string]string{}
+	for _, bundle := range bundles {
+		hashesByName[bundle.Name] = bundle.Hash
+	}
+
+	targets, err := i.ResolveTargets(req)
 	if err != nil {
 		return nil, err
 	}
 
 	statuses := make([]TargetStatus, 0, len(targets))
 	for _, target := range targets {
-		status, err := inspectTarget(target, bundle.Hash)
+		bundleHash, ok := hashesByName[target.Skill]
+		if !ok {
+			return nil, fmt.Errorf("missing bundled skill %s", target.Skill)
+		}
+		status, err := inspectTarget(target, bundleHash)
 		if err != nil {
 			return nil, err
 		}
@@ -165,7 +200,7 @@ func installPath(bundle skillBundle, target Target) error {
 	if err := copyBundle(bundle, target.Path); err != nil {
 		return fmt.Errorf("copy skill to %s: %w", target.Path, err)
 	}
-	if err := writeManifest(target.Path, target.Agent, target.Scope, bundle.Hash); err != nil {
+	if err := writeManifest(target.Path, target.Skill, target.Agent, target.Scope, bundle.Hash); err != nil {
 		return fmt.Errorf("write skill manifest %s: %w", manifestPath(target.Path), err)
 	}
 	return nil
@@ -295,7 +330,7 @@ func dedupeTargets(targets []Target) []Target {
 	sort.Slice(out, func(i, j int) bool {
 		if out[i].Scope == out[j].Scope {
 			if out[i].Agent == out[j].Agent {
-				return out[i].Path < out[j].Path
+				return out[i].Skill < out[j].Skill
 			}
 			return out[i].Agent < out[j].Agent
 		}

--- a/internal/skills/install_test.go
+++ b/internal/skills/install_test.go
@@ -2,12 +2,15 @@ package skills
 
 import (
 	"encoding/json"
+	"io/fs"
 	"os"
 	"path/filepath"
 	"testing"
 )
 
 func TestResolveTargetsGlobalAndLocal(t *testing.T) {
+	registerTestBundles(t)
+
 	home := t.TempDir()
 	projectDir := t.TempDir()
 	installer := NewInstaller(home)
@@ -20,14 +23,22 @@ func TestResolveTargetsGlobalAndLocal(t *testing.T) {
 		t.Fatal(err)
 	}
 	want := map[string]bool{
-		filepath.Join(home, ".codex", "skills", "plan"):        true,
-		filepath.Join(home, ".copilot", "skills", "plan"):      true,
-		filepath.Join(home, ".pi", "agent", "skills", "plan"):  true,
-		filepath.Join(home, ".zed", "skills", "plan"):          true,
-		filepath.Join(projectDir, ".codex", "skills", "plan"):  true,
-		filepath.Join(projectDir, ".github", "skills", "plan"): true,
-		filepath.Join(projectDir, ".pi", "skills", "plan"):     true,
-		filepath.Join(projectDir, ".zed", "skills", "plan"):    true,
+		filepath.Join(home, ".codex", "skills", "plan"):                true,
+		filepath.Join(home, ".codex", "skills", "plan-execute"):        true,
+		filepath.Join(home, ".copilot", "skills", "plan"):              true,
+		filepath.Join(home, ".copilot", "skills", "plan-execute"):      true,
+		filepath.Join(home, ".pi", "agent", "skills", "plan"):          true,
+		filepath.Join(home, ".pi", "agent", "skills", "plan-execute"):  true,
+		filepath.Join(home, ".zed", "skills", "plan"):                  true,
+		filepath.Join(home, ".zed", "skills", "plan-execute"):          true,
+		filepath.Join(projectDir, ".codex", "skills", "plan"):          true,
+		filepath.Join(projectDir, ".codex", "skills", "plan-execute"):  true,
+		filepath.Join(projectDir, ".github", "skills", "plan"):         true,
+		filepath.Join(projectDir, ".github", "skills", "plan-execute"): true,
+		filepath.Join(projectDir, ".pi", "skills", "plan"):             true,
+		filepath.Join(projectDir, ".pi", "skills", "plan-execute"):     true,
+		filepath.Join(projectDir, ".zed", "skills", "plan"):            true,
+		filepath.Join(projectDir, ".zed", "skills", "plan-execute"):    true,
 	}
 	if len(targets) != len(want) {
 		t.Fatalf("expected %d targets, got %d", len(want), len(targets))
@@ -40,7 +51,7 @@ func TestResolveTargetsGlobalAndLocal(t *testing.T) {
 }
 
 func TestInstallCopiesSkillBundleAndWritesManifest(t *testing.T) {
-	bundleHash := registerTestBundle(t)
+	bundleHashes := registerTestBundles(t)
 
 	home := t.TempDir()
 	installer := NewInstaller(home)
@@ -51,24 +62,28 @@ func TestInstallCopiesSkillBundleAndWritesManifest(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if len(results) != 1 {
-		t.Fatalf("expected 1 result, got %d", len(results))
+	if len(results) != 2 {
+		t.Fatalf("expected 2 results, got %d", len(results))
 	}
 
-	skillDir := filepath.Join(home, ".codex", "skills", "plan")
-	if _, err := os.Stat(filepath.Join(skillDir, "SKILL.md")); err != nil {
-		t.Fatalf("expected skill file: %v", err)
-	}
-	manifest, err := readManifest(skillDir)
-	if err != nil {
-		t.Fatalf("expected manifest: %v", err)
-	}
-	if manifest.BundleHash != bundleHash {
-		t.Fatalf("unexpected bundle hash: %+v", manifest)
+	for _, skill := range []string{"plan", "plan-execute"} {
+		skillDir := filepath.Join(home, ".codex", "skills", skill)
+		if _, err := os.Stat(filepath.Join(skillDir, "SKILL.md")); err != nil {
+			t.Fatalf("expected %s skill file: %v", skill, err)
+		}
+		manifest, err := readManifest(skillDir)
+		if err != nil {
+			t.Fatalf("expected %s manifest: %v", skill, err)
+		}
+		if manifest.Skill != skill || manifest.BundleHash != bundleHashes[skill] {
+			t.Fatalf("unexpected %s manifest: %+v", skill, manifest)
+		}
 	}
 }
 
 func TestResolveTargetsLocalScopeUsesAbsoluteProjectDir(t *testing.T) {
+	registerTestBundles(t)
+
 	installer := NewInstaller("/home/tester")
 	projectDir := t.TempDir()
 	prevWD, err := os.Getwd()
@@ -90,19 +105,25 @@ func TestResolveTargetsLocalScopeUsesAbsoluteProjectDir(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if len(targets) != 1 {
-		t.Fatalf("expected 1 target, got %d", len(targets))
+	if len(targets) != 2 {
+		t.Fatalf("expected 2 targets, got %d", len(targets))
 	}
-	if !filepath.IsAbs(targets[0].Root) || !filepath.IsAbs(targets[0].Path) {
-		t.Fatalf("expected absolute local target paths: %+v", targets[0])
+	want := map[string]bool{
+		filepath.Join(projectDir, ".codex", "skills", "plan"):         true,
+		filepath.Join(projectDir, ".codex", "skills", "plan-execute"): true,
 	}
-	if targets[0].Path != filepath.Join(projectDir, ".codex", "skills", "plan") {
-		t.Fatalf("unexpected resolved target path: %+v", targets[0])
+	for _, target := range targets {
+		if !filepath.IsAbs(target.Root) || !filepath.IsAbs(target.Path) {
+			t.Fatalf("expected absolute local target paths: %+v", target)
+		}
+		if !want[target.Path] {
+			t.Fatalf("unexpected resolved target path: %+v", target)
+		}
 	}
 }
 
 func TestInspectFlagsLegacyAndStaleInstalls(t *testing.T) {
-	bundleHash := registerTestBundle(t)
+	bundleHashes := registerTestBundles(t)
 
 	home := t.TempDir()
 	installer := NewInstaller(home)
@@ -150,7 +171,7 @@ func TestInspectFlagsLegacyAndStaleInstalls(t *testing.T) {
 	reasons := map[string]string{}
 	for _, status := range statuses {
 		if status.Path == staleDir {
-			if status.Manifest == nil || status.Manifest.BundleHash == bundleHash {
+			if status.Manifest == nil || status.Manifest.BundleHash == bundleHashes["plan"] {
 				t.Fatalf("expected stale manifest to be inspected: %+v", status)
 			}
 		}
@@ -165,7 +186,7 @@ func TestInspectFlagsLegacyAndStaleInstalls(t *testing.T) {
 }
 
 func TestInstallRepairsLegacyInstallCleanly(t *testing.T) {
-	bundleHash := registerTestBundle(t)
+	bundleHashes := registerTestBundles(t)
 
 	home := t.TempDir()
 	installer := NewInstaller(home)
@@ -191,13 +212,16 @@ func TestInstallRepairsLegacyInstallCleanly(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if manifest.BundleHash != bundleHash {
+	if manifest.Skill != "plan" || manifest.BundleHash != bundleHashes["plan"] {
 		t.Fatalf("unexpected repaired manifest: %+v", manifest)
+	}
+	if _, err := os.Stat(filepath.Join(home, ".codex", "skills", "plan-execute", "SKILL.md")); err != nil {
+		t.Fatalf("expected plan-execute to install alongside plan: %v", err)
 	}
 }
 
-func TestSourceTreeBundleInstallsModelGuidanceFiles(t *testing.T) {
-	RegisterBundle(nil)
+func TestSourceTreeBundlesInstallPlanAndExecuteSkills(t *testing.T) {
+	RegisterBundles(nil)
 
 	home := t.TempDir()
 	installer := NewInstaller(home)
@@ -219,30 +243,42 @@ func TestSourceTreeBundleInstallsModelGuidanceFiles(t *testing.T) {
 			t.Fatalf("expected installed skill file %s: %v", rel, err)
 		}
 	}
+	if _, err := os.Stat(filepath.Join(home, ".codex", "skills", "plan-execute", "SKILL.md")); err != nil {
+		t.Fatalf("expected installed plan-execute skill file: %v", err)
+	}
 }
 
-func registerTestBundle(t *testing.T) string {
+func registerTestBundles(t *testing.T) map[string]string {
 	t.Helper()
 
-	bundleDir := t.TempDir()
-	if err := os.MkdirAll(filepath.Join(bundleDir, "agents"), 0o755); err != nil {
-		t.Fatal(err)
-	}
-	if err := os.WriteFile(filepath.Join(bundleDir, "SKILL.md"), []byte("skill"), 0o644); err != nil {
-		t.Fatal(err)
-	}
-	if err := os.WriteFile(filepath.Join(bundleDir, "agents", "openai.yaml"), []byte("name: plan"), 0o644); err != nil {
-		t.Fatal(err)
+	root := t.TempDir()
+	bundleFSes := map[string]fs.FS{}
+	for _, skill := range []string{"plan", "plan-execute"} {
+		bundleDir := filepath.Join(root, skill)
+		if err := os.MkdirAll(filepath.Join(bundleDir, "agents"), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(filepath.Join(bundleDir, "SKILL.md"), []byte("skill: "+skill), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(filepath.Join(bundleDir, "agents", "openai.yaml"), []byte("name: "+skill), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		bundleFSes[skill] = os.DirFS(bundleDir)
 	}
 
-	RegisterBundle(os.DirFS(bundleDir))
+	RegisterBundles(bundleFSes)
 	t.Cleanup(func() {
-		RegisterBundle(nil)
+		RegisterBundles(nil)
 	})
 
-	bundle, err := loadBundle()
+	loaded, err := loadBundles()
 	if err != nil {
 		t.Fatal(err)
 	}
-	return bundle.Hash
+	hashes := map[string]string{}
+	for _, bundle := range loaded {
+		hashes[bundle.Name] = bundle.Hash
+	}
+	return hashes
 }

--- a/internal/skills/manifest.go
+++ b/internal/skills/manifest.go
@@ -16,6 +16,7 @@ const (
 
 type Manifest struct {
 	SchemaVersion int    `json:"schema_version"`
+	Skill         string `json:"skill,omitempty"`
 	PlanVersion   string `json:"plan_version"`
 	PlanCommit    string `json:"plan_commit"`
 	BundleHash    string `json:"bundle_hash"`
@@ -40,10 +41,11 @@ func readManifest(target string) (*Manifest, error) {
 	return &manifest, nil
 }
 
-func writeManifest(target, agent, scope, bundleHash string) error {
+func writeManifest(target, skill, agent, scope, bundleHash string) error {
 	info := buildinfo.Current()
 	manifest := Manifest{
 		SchemaVersion: manifestSchemaVersion,
+		Skill:         skill,
 		PlanVersion:   info.Version,
 		PlanCommit:    info.Commit,
 		BundleHash:    bundleHash,

--- a/skills/plan-execute/SKILL.md
+++ b/skills/plan-execute/SKILL.md
@@ -1,0 +1,118 @@
+---
+name: plan-execute
+description: Execute an approved Plan spec from spec slug or GitHub URL through implementation, checks, commit, push, and a ready pull request. Use this skill whenever the user says `$plan-execute`, asks to execute or implement a Plan spec, provides a Plan spec slug, asks for a spec-to-PR workflow, or asks to turn an approved planning issue/spec into code.
+user-invocable: true
+args:
+  - name: spec
+    description: Plan spec slug or GitHub issue/discussion URL to execute.
+    required: true
+---
+
+# Plan Execute
+
+Use this skill to move one approved Plan spec from planning truth to a pull
+request. `plan` owns the spec contract; this skill owns the execution rail:
+git, code, tests, screenshots, commits, pushes, PRs, and Brain session hygiene.
+
+## Contract
+
+- Resolve exactly one spec from a `.plan` slug or GitHub URL before coding.
+- Verify the spec is approved and executable. Stop if it is vague, blocked,
+  unsafe, or not approved.
+- Keep implementation traceable from spec -> slices -> commits -> PR.
+- Create ready PRs by default. Use draft PRs only when the user explicitly asks
+  for draft mode.
+- Do not run production migrations, production seed changes, or destructive data
+  operations unless the user explicitly asks.
+- Do not open a PR until relevant tests pass, or failures are clearly documented
+  with the reason the PR is still needed.
+- Capture screenshots or manual QA notes only when UI behavior changes.
+
+## Startup
+
+1. Read repo instructions such as `AGENTS.md`.
+2. If a Brain workspace exists, start or reuse a Brain session for the task.
+3. Read `.plan/PROJECT.md`, `.plan/ROADMAP.md`, and the target spec.
+4. Check source mode with `plan source show --project .`.
+5. If the spec lives in GitHub or source mode is `github`/`hybrid`, inspect the
+   linked GitHub issue, discussion, milestone, and labels before coding.
+6. Confirm the worktree is clean enough to safely branch. Do not overwrite user
+   changes.
+
+## Execution Flow
+
+Use this sequence unless repo instructions require a stricter flow:
+
+1. Resolve input:
+   - local spec: `plan spec show --project . <spec-slug>`
+   - GitHub URL/number: inspect with Plan/GitHub commands, then map to the Plan
+     spec or planning issue.
+2. Verify readiness:
+   - spec status is approved or equivalent
+   - acceptance criteria and verification expectations are clear
+   - dependencies, migrations, and rollout constraints are understood
+3. Sync integration branch:
+   - use the repo's default development branch, commonly `develop`
+   - fetch and fast-forward before branching
+4. Create branch:
+   - branch name: `codex/<spec-slug>`
+   - if branch exists, inspect it before reusing or creating a suffixed branch
+5. Derive slices:
+   - run `plan spec execute --project . <spec-slug>`
+   - treat generated slices as ephemeral execution order, not new planning truth
+6. Implement slices in order:
+   - finish one coherent slice before starting the next
+   - run focused checks after each slice
+   - update Plan/GitHub story or spec status only when the repo workflow expects it
+7. Final review:
+   - inspect full diff
+   - run full relevant checks
+   - run migrations/seeds only in non-production test/dev contexts when needed
+   - capture screenshots/manual QA notes for UI work
+8. Commit:
+   - stage only intentional changes
+   - use a clear message referencing the spec when useful
+9. Push and PR:
+   - push `codex/<spec-slug>`
+   - open a ready PR to the repo's integration branch
+   - include summary, spec link, slice list, tests run, migration/seed notes,
+     manual QA, and screenshots when relevant
+10. Finish:
+   - finish the Brain session when one is active
+   - report PR URL, tests, and any documented risk
+
+## Stop Conditions
+
+Stop and ask or repair planning state before coding when:
+
+- the input does not resolve to exactly one spec
+- the spec is not approved
+- `plan spec execute` shows the work is too vague or blocked
+- source mode or GitHub metadata disagrees with the requested execution target
+- required credentials, services, or test data are missing
+- implementation requires production data changes not explicitly authorized
+- existing user changes make a safe branch or commit impossible
+
+## PR Body
+
+Use this structure unless the repo has a stricter template:
+
+```markdown
+## Summary
+
+## Spec
+
+## Slices
+
+## Tests
+
+## Migrations / Seeds
+
+## Manual QA
+
+## Screenshots
+```
+
+Write `None` for migration/seed, manual QA, or screenshot sections that do not
+apply. If tests fail and a PR is still opened, name the failing command and the
+reason it is not fixed in this PR.


### PR DESCRIPTION
## Summary

- Add bundled `plan-execute` skill for approved spec-to-PR execution workflows.
- Refactor skill installation to install both `plan` and `plan-execute` by default.
- Update install docs, manifests, embedding, and installer/CLI tests.

## Verification

- `go test ./...`
- `go build ./...`
- `go test -race ./...`

## Notes

Ready PR. No new `plan execute` CLI command; `plan-execute` is skill-only and plan-adjacent.
