### PR TITLE
feat: extend github project decision metadata

### DIFF
--- a/cmd/discuss.go
+++ b/cmd/discuss.go
@@ -90,7 +90,7 @@ func newDiscussCommand() *cobra.Command {
 	promote.Flags().BoolVar(&promoteApply, "apply", false, "create the promoted GitHub issue set after review")
 	promote.Flags().BoolVar(&promoteConfirm, "confirm", false, "required acknowledgement before apply mutates GitHub")
 	promote.Flags().StringVar(&promoteTarget, "target", "", "promotion ownership target: local, github, or hybrid")
-	promote.Flags().StringVar(&promoteProjectDecision, "project-decision", "", "project prompt decision for 5+ spec promotions: create, skip, or connect")
+	promote.Flags().StringVar(&promoteProjectDecision, "project-decision", "", "project prompt decision for 5+ spec promotions: create or skip; connect is reserved and not yet implemented")
 
 	var (
 		repairBrainstorm string

--- a/cmd/discuss.go
+++ b/cmd/discuss.go
@@ -90,7 +90,7 @@ func newDiscussCommand() *cobra.Command {
 	promote.Flags().BoolVar(&promoteApply, "apply", false, "create the promoted GitHub issue set after review")
 	promote.Flags().BoolVar(&promoteConfirm, "confirm", false, "required acknowledgement before apply mutates GitHub")
 	promote.Flags().StringVar(&promoteTarget, "target", "", "promotion ownership target: local, github, or hybrid")
-	promote.Flags().StringVar(&promoteProjectDecision, "project-decision", "", "project prompt decision for 5+ spec promotions: create or skip")
+	promote.Flags().StringVar(&promoteProjectDecision, "project-decision", "", "project prompt decision for 5+ spec promotions: create, skip, or connect")
 
 	var (
 		repairBrainstorm string

--- a/cmd/github.go
+++ b/cmd/github.go
@@ -98,7 +98,7 @@ func newGitHubCommand() *cobra.Command {
 	adopt.Flags().StringVar(&adoptDiscussion, "discussion", "", "GitHub Discussion number or URL that produced the promotion draft")
 	adopt.Flags().StringSliceVar(&adoptIssues, "issues", nil, "GitHub issue numbers in draft order, comma-separated or repeated")
 	adopt.Flags().StringVar(&adoptFormat, "format", "json", "output format: json")
-	adopt.Flags().StringVar(&adoptProjectDecision, "project-decision", "", "project prompt decision for 5+ spec promotions: create, skip, or connect")
+	adopt.Flags().StringVar(&adoptProjectDecision, "project-decision", "", "project prompt decision for 5+ spec promotions: create or skip; connect is reserved and not yet implemented")
 
 	cmd.AddCommand(enable, reconcile, adopt)
 	return cmd

--- a/cmd/github.go
+++ b/cmd/github.go
@@ -98,7 +98,7 @@ func newGitHubCommand() *cobra.Command {
 	adopt.Flags().StringVar(&adoptDiscussion, "discussion", "", "GitHub Discussion number or URL that produced the promotion draft")
 	adopt.Flags().StringSliceVar(&adoptIssues, "issues", nil, "GitHub issue numbers in draft order, comma-separated or repeated")
 	adopt.Flags().StringVar(&adoptFormat, "format", "json", "output format: json")
-	adopt.Flags().StringVar(&adoptProjectDecision, "project-decision", "", "project prompt decision for 5+ spec promotions: create or skip")
+	adopt.Flags().StringVar(&adoptProjectDecision, "project-decision", "", "project prompt decision for 5+ spec promotions: create, skip, or connect")
 
 	cmd.AddCommand(enable, reconcile, adopt)
 	return cmd

--- a/docs/using-plan.md
+++ b/docs/using-plan.md
@@ -385,10 +385,12 @@ Current shipped boundary:
   compatibility path to create the local spec file today
 - the promoted issue body becomes the canonical distilled planning artifact
 - the original GitHub Discussion stays linked as collaboration history
-- promotions with 5+ specs require `--project-decision create|skip|connect`
-  so project tracking is never silently skipped
+- promotions with 5+ specs require an explicit project decision so project
+  tracking is never silently skipped; supported values today are
+  `--project-decision create|skip`
 - `connect` is a reserved project decision until project-reference wiring ships;
-  it returns a clear error instead of guessing which Project to use
+  Plan recognizes it but returns a clear error instead of guessing which Project
+  to use
 - if a valid apply path fails on the GitHub API, Plan emits
   `manual_fallback_allowed=true`; only then may an agent use manual `gh`
   commands, followed by `plan github adopt`

--- a/docs/using-plan.md
+++ b/docs/using-plan.md
@@ -385,8 +385,10 @@ Current shipped boundary:
   compatibility path to create the local spec file today
 - the promoted issue body becomes the canonical distilled planning artifact
 - the original GitHub Discussion stays linked as collaboration history
-- promotions with 5+ specs require `--project-decision create|skip` so project
-  tracking is never silently skipped
+- promotions with 5+ specs require `--project-decision create|skip|connect`
+  so project tracking is never silently skipped
+- `connect` is a reserved project decision until project-reference wiring ships;
+  it returns a clear error instead of guessing which Project to use
 - if a valid apply path fails on the GitHub API, Plan emits
   `manual_fallback_allowed=true`; only then may an agent use manual `gh`
   commands, followed by `plan github adopt`

--- a/internal/planning/check.go
+++ b/internal/planning/check.go
@@ -247,7 +247,7 @@ func (m *Manager) checkGitHubPlanningDrift(info *workspace.Info) ([]CheckFinding
 				ArtifactTitle: displayTitle,
 				Section:       "GitHub Planning",
 				Message:       fmt.Sprintf("Milestone %q has %d promoted specs but no project prompt decision record.", displayTitle, count),
-				Suggestion:    "Rerun promotion/adoption with `--project-decision create|skip|connect` so coordination intent is explicit.",
+				Suggestion:    "Rerun promotion/adoption with `--project-decision create|skip` so coordination intent is explicit. `connect` is reserved until project reference support ships.",
 			})
 			continue
 		}

--- a/internal/planning/check.go
+++ b/internal/planning/check.go
@@ -237,19 +237,32 @@ func (m *Manager) checkGitHubPlanningDrift(info *workspace.Info) ([]CheckFinding
 		if displayTitle == "" {
 			displayTitle = title
 		}
-		if hasProjectDecisionForMilestone(state, number, title) {
+		decision, ok := projectDecisionForMilestone(state, number, title)
+		if !ok {
+			findings = append(findings, CheckFinding{
+				Severity:      "error",
+				Rule:          "github_planning.missing_project_decision",
+				ArtifactType:  "github_milestone",
+				ArtifactPath:  displayTitle,
+				ArtifactTitle: displayTitle,
+				Section:       "GitHub Planning",
+				Message:       fmt.Sprintf("Milestone %q has %d promoted specs but no project prompt decision record.", displayTitle, count),
+				Suggestion:    "Rerun promotion/adoption with `--project-decision create|skip|connect` so coordination intent is explicit.",
+			})
 			continue
 		}
-		findings = append(findings, CheckFinding{
-			Severity:      "error",
-			Rule:          "github_planning.missing_project_decision",
-			ArtifactType:  "github_milestone",
-			ArtifactPath:  displayTitle,
-			ArtifactTitle: displayTitle,
-			Section:       "GitHub Planning",
-			Message:       fmt.Sprintf("Milestone %q has %d promoted specs but no project prompt decision record.", displayTitle, count),
-			Suggestion:    "Rerun promotion/adoption with `--project-decision create|skip` so coordination intent is explicit.",
-		})
+		if reason := incompleteProjectDecisionReason(decision); reason != "" {
+			findings = append(findings, CheckFinding{
+				Severity:      "error",
+				Rule:          "github_planning.incomplete_project_decision",
+				ArtifactType:  "github_milestone",
+				ArtifactPath:  displayTitle,
+				ArtifactTitle: displayTitle,
+				Section:       "GitHub Planning",
+				Message:       fmt.Sprintf("Milestone %q has incomplete project decision metadata: %s.", displayTitle, reason),
+				Suggestion:    "Rerun promotion/adoption with a supported `--project-decision` value, or repair the project decision metadata before project automation continues.",
+			})
+		}
 	}
 	return findings, nil
 }
@@ -305,16 +318,32 @@ func splitMilestoneKey(key string) (int, string) {
 	return number, parts[1]
 }
 
-func hasProjectDecisionForMilestone(state *workspace.GitHubState, number int, title string) bool {
+func projectDecisionForMilestone(state *workspace.GitHubState, number int, title string) (workspace.GitHubProjectDecisionRecord, bool) {
 	for _, decision := range state.ProjectDecisions {
 		if number > 0 && decision.MilestoneNumber == number {
-			return true
+			return decision, true
 		}
 		if strings.EqualFold(strings.TrimSpace(decision.MilestoneTitle), strings.TrimSpace(title)) && strings.TrimSpace(title) != "" {
-			return true
+			return decision, true
 		}
 	}
-	return false
+	return workspace.GitHubProjectDecisionRecord{}, false
+}
+
+func incompleteProjectDecisionReason(decision workspace.GitHubProjectDecisionRecord) string {
+	switch normalizeProjectDecision(decision.Decision) {
+	case projectDecisionCreate, projectDecisionSkip:
+		return ""
+	case projectDecisionConnect:
+		if strings.TrimSpace(decision.ProjectID) == "" && decision.ProjectNumber == 0 && strings.TrimSpace(decision.ProjectURL) == "" {
+			return "connect decisions require a project id, number, or url"
+		}
+		return ""
+	case "":
+		return "decision is empty"
+	default:
+		return fmt.Sprintf("decision %q is not supported", decision.Decision)
+	}
 }
 
 func (m *Manager) readStoriesByFilter(info *workspace.Info, keep func(StoryInfo) bool) ([]*notes.Note, error) {

--- a/internal/planning/check_test.go
+++ b/internal/planning/check_test.go
@@ -357,6 +357,43 @@ func TestCheckFlagsMissingProjectDecisionForFiveSpecMilestone(t *testing.T) {
 	assertHasFinding(t, report.Findings, "github_planning.missing_project_decision", "GitHub Planning")
 }
 
+func TestCheckFlagsIncompleteProjectDecisionForFiveSpecMilestone(t *testing.T) {
+	reset := SetGitHubClientFactoryForTesting(func() GitHubClient { return checkDriftClient(nil) })
+	t.Cleanup(reset)
+	manager := setupGitHubSourceModeCheck(t)
+	state, err := manager.workspace.ReadGitHubState()
+	if err != nil {
+		t.Fatal(err)
+	}
+	for i := 0; i < 5; i++ {
+		slug := fmt.Sprintf("spec-%d", i)
+		state.Planning[slug] = workspace.GitHubPlanningRecord{
+			Slug:            slug,
+			Kind:            "spec",
+			Title:           fmt.Sprintf("Spec %d", i),
+			IssueNumber:     500 + i,
+			MilestoneNumber: 7,
+			MilestoneTitle:  "Readiness",
+		}
+	}
+	state.ProjectDecisions["readiness"] = workspace.GitHubProjectDecisionRecord{
+		Slug:            "readiness",
+		Decision:        "connect",
+		SpecCount:       5,
+		MilestoneNumber: 7,
+		MilestoneTitle:  "Readiness",
+	}
+	if err := manager.workspace.WriteGitHubState(*state); err != nil {
+		t.Fatal(err)
+	}
+
+	report, err := manager.Check(CheckInput{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	assertHasFinding(t, report.Findings, "github_planning.incomplete_project_decision", "GitHub Planning")
+}
+
 func TestCheckFlagsLabelUsedWhereMilestoneExpected(t *testing.T) {
 	client := checkDriftClient(map[int]*GitHubIssue{
 		601: {Number: 601, URL: "https://github.com/JimmyMcBride/plan/issues/601", Title: "Spec", State: "open", Labels: []string{planIssueSpecLabel, "Readiness Initiative"}},

--- a/internal/planning/collaboration.go
+++ b/internal/planning/collaboration.go
@@ -1708,10 +1708,10 @@ func validateProjectDecision(decision string, draft *PromotionDraft) error {
 	switch decision {
 	case "", projectDecisionCreate, projectDecisionSkip, projectDecisionConnect:
 	default:
-		return fmt.Errorf("unsupported project decision %q; use create, skip, or connect", decision)
+		return fmt.Errorf("unsupported project decision %q; use create or skip; connect is reserved and not yet implemented", decision)
 	}
 	if requiresProjectDecision(draft) && decision == "" {
-		return fmt.Errorf("promotion has %d specs and requires --project-decision create|skip|connect before apply", len(draft.ProposedSpecIssues))
+		return fmt.Errorf("promotion has %d specs and requires --project-decision create|skip before apply; connect is reserved and not yet implemented", len(draft.ProposedSpecIssues))
 	}
 	if decision == projectDecisionConnect {
 		return fmt.Errorf("project decision %q requires project reference support, which is not implemented yet", decision)
@@ -1849,7 +1849,7 @@ func manualFallbackAdoptCommand(draft *PromotionDraft) string {
 	}
 	args = append(args, "--issues", strings.Join(placeholders, ","))
 	if requiresProjectDecision(draft) {
-		args = append(args, "--project-decision", "<create|skip|connect>")
+		args = append(args, "--project-decision", "<create|skip>")
 	}
 	args = append(args, "--format", "json")
 	return shellCommand(args)

--- a/internal/planning/collaboration.go
+++ b/internal/planning/collaboration.go
@@ -192,6 +192,12 @@ type PromotionProjectPrompt struct {
 	Reason      string `json:"reason,omitempty"`
 }
 
+const (
+	projectDecisionCreate  = "create"
+	projectDecisionSkip    = "skip"
+	projectDecisionConnect = "connect"
+)
+
 type PromotionRefinementException struct {
 	IssueTitle               string   `json:"issue_title"`
 	Gap                      string   `json:"gap"`
@@ -1698,16 +1704,23 @@ func shouldRecommendProject(specCount int, deps []PromotionDependencyPlan) bool 
 }
 
 func validateProjectDecision(decision string, draft *PromotionDraft) error {
-	decision = strings.TrimSpace(decision)
+	decision = normalizeProjectDecision(decision)
 	switch decision {
-	case "", "create", "skip":
+	case "", projectDecisionCreate, projectDecisionSkip, projectDecisionConnect:
 	default:
-		return fmt.Errorf("unsupported project decision %q; use create or skip", decision)
+		return fmt.Errorf("unsupported project decision %q; use create, skip, or connect", decision)
 	}
 	if requiresProjectDecision(draft) && decision == "" {
-		return fmt.Errorf("promotion has %d specs and requires --project-decision create|skip before apply", len(draft.ProposedSpecIssues))
+		return fmt.Errorf("promotion has %d specs and requires --project-decision create|skip|connect before apply", len(draft.ProposedSpecIssues))
+	}
+	if decision == projectDecisionConnect {
+		return fmt.Errorf("project decision %q requires project reference support, which is not implemented yet", decision)
 	}
 	return nil
+}
+
+func normalizeProjectDecision(decision string) string {
+	return strings.ToLower(strings.TrimSpace(decision))
 }
 
 func requiresProjectDecision(draft *PromotionDraft) bool {
@@ -1716,9 +1729,11 @@ func requiresProjectDecision(draft *PromotionDraft) bool {
 
 func buildProjectDecisionRecord(draft *PromotionDraft, decision string, milestone *GitHubMilestone) workspace.GitHubProjectDecisionRecord {
 	now := time.Now().UTC().Format(time.RFC3339)
+	slug := promotionProjectDecisionSlug(draft)
 	record := workspace.GitHubProjectDecisionRecord{
-		Slug:             promotionProjectDecisionSlug(draft),
-		Decision:         strings.TrimSpace(decision),
+		Slug:             slug,
+		Decision:         normalizeProjectDecision(decision),
+		InitiativeSlug:   slug,
 		SpecCount:        len(draft.ProposedSpecIssues),
 		MilestoneNumber:  milestoneNumberOrZero(milestone),
 		MilestoneTitle:   milestoneTitle(milestone),
@@ -1834,7 +1849,7 @@ func manualFallbackAdoptCommand(draft *PromotionDraft) string {
 	}
 	args = append(args, "--issues", strings.Join(placeholders, ","))
 	if requiresProjectDecision(draft) {
-		args = append(args, "--project-decision", "<create|skip>")
+		args = append(args, "--project-decision", "<create|skip|connect>")
 	}
 	args = append(args, "--format", "json")
 	return shellCommand(args)

--- a/internal/planning/collaboration_test.go
+++ b/internal/planning/collaboration_test.go
@@ -277,8 +277,21 @@ func TestSixSpecProsePromotesAsMultiSpecWithProjectDecision(t *testing.T) {
 		Confirm:       true,
 		TargetMode:    SourceOfTruthGitHub,
 	})
-	if err == nil || !strings.Contains(err.Error(), "--project-decision create|skip") {
+	if err == nil || !strings.Contains(err.Error(), "--project-decision create|skip|connect") {
 		t.Fatalf("expected project decision gate, got %v", err)
+	}
+
+	_, err = manager.ApplyPromotionDraft(PromotionApplyInput{
+		DiscussionRef:   "88",
+		Confirm:         true,
+		TargetMode:      SourceOfTruthGitHub,
+		ProjectDecision: "connect",
+	})
+	if err == nil || !strings.Contains(err.Error(), "requires project reference support") {
+		t.Fatalf("expected connect project-reference error, got %v", err)
+	}
+	if len(client.issues) != 0 {
+		t.Fatalf("connect decision should fail before mutating GitHub issues: %+v", client.issues)
 	}
 
 	result, err := manager.ApplyPromotionDraft(PromotionApplyInput{
@@ -295,6 +308,15 @@ func TestSixSpecProsePromotesAsMultiSpecWithProjectDecision(t *testing.T) {
 	}
 	if result.ProjectDecision == nil || result.ProjectDecision.Decision != "create" {
 		t.Fatalf("expected project decision record: %+v", result.ProjectDecision)
+	}
+	if result.ProjectDecision.InitiativeSlug == "" || result.ProjectDecision.InitiativeSlug != result.ProjectDecision.Slug {
+		t.Fatalf("expected initiative slug on project decision record: %+v", result.ProjectDecision)
+	}
+	if result.ProjectDecision.MilestoneNumber != result.Milestone.Number || result.ProjectDecision.MilestoneTitle != result.Milestone.Title {
+		t.Fatalf("expected milestone identity on project decision record: %+v", result.ProjectDecision)
+	}
+	if result.ProjectDecision.ProjectOwner != "" || result.ProjectDecision.ProjectNumber != 0 || result.ProjectDecision.ProjectID != "" || result.ProjectDecision.ProjectURL != "" || len(result.ProjectDecision.FieldIDs) != 0 {
+		t.Fatalf("project identity should stay unset until project provisioning: %+v", result.ProjectDecision)
 	}
 	if !containsString(result.Initiative.Labels, planIssueInitiativeLabel) {
 		t.Fatalf("expected initiative label: %+v", result.Initiative.Labels)

--- a/internal/planning/collaboration_test.go
+++ b/internal/planning/collaboration_test.go
@@ -277,7 +277,7 @@ func TestSixSpecProsePromotesAsMultiSpecWithProjectDecision(t *testing.T) {
 		Confirm:       true,
 		TargetMode:    SourceOfTruthGitHub,
 	})
-	if err == nil || !strings.Contains(err.Error(), "--project-decision create|skip|connect") {
+	if err == nil || !strings.Contains(err.Error(), "--project-decision create|skip") {
 		t.Fatalf("expected project decision gate, got %v", err)
 	}
 

--- a/internal/workspace/workspace.go
+++ b/internal/workspace/workspace.go
@@ -75,17 +75,23 @@ type GitHubPlanningRecord struct {
 }
 
 type GitHubProjectDecisionRecord struct {
-	Slug             string `json:"slug"`
-	Decision         string `json:"decision"`
-	Reason           string `json:"reason,omitempty"`
-	SpecCount        int    `json:"spec_count,omitempty"`
-	MilestoneNumber  int    `json:"milestone_number,omitempty"`
-	MilestoneTitle   string `json:"milestone_title,omitempty"`
-	SourceMode       string `json:"source_mode,omitempty"`
-	EntryMode        string `json:"entry_mode,omitempty"`
-	DiscussionNumber int    `json:"discussion_number,omitempty"`
-	DiscussionURL    string `json:"discussion_url,omitempty"`
-	UpdatedAt        string `json:"updated_at,omitempty"`
+	Slug             string            `json:"slug"`
+	Decision         string            `json:"decision"`
+	Reason           string            `json:"reason,omitempty"`
+	InitiativeSlug   string            `json:"initiative_slug,omitempty"`
+	SpecCount        int               `json:"spec_count,omitempty"`
+	MilestoneNumber  int               `json:"milestone_number,omitempty"`
+	MilestoneTitle   string            `json:"milestone_title,omitempty"`
+	ProjectOwner     string            `json:"project_owner,omitempty"`
+	ProjectNumber    int               `json:"project_number,omitempty"`
+	ProjectID        string            `json:"project_id,omitempty"`
+	ProjectURL       string            `json:"project_url,omitempty"`
+	FieldIDs         map[string]string `json:"field_ids,omitempty"`
+	SourceMode       string            `json:"source_mode,omitempty"`
+	EntryMode        string            `json:"entry_mode,omitempty"`
+	DiscussionNumber int               `json:"discussion_number,omitempty"`
+	DiscussionURL    string            `json:"discussion_url,omitempty"`
+	UpdatedAt        string            `json:"updated_at,omitempty"`
 }
 
 type GitHubStoryRecord struct {

--- a/internal/workspace/workspace_test.go
+++ b/internal/workspace/workspace_test.go
@@ -581,6 +581,92 @@ func TestReadGitHubStateDefaultsPlanningMapInMemory(t *testing.T) {
 	}
 }
 
+func TestGitHubProjectDecisionRecordSupportsWorkspaceProjectMetadata(t *testing.T) {
+	root := t.TempDir()
+	manager := New(root)
+	if _, err := manager.Init(); err != nil {
+		t.Fatal(err)
+	}
+
+	state, err := manager.ReadGitHubState()
+	if err != nil {
+		t.Fatal(err)
+	}
+	state.ProjectDecisions["readiness"] = GitHubProjectDecisionRecord{
+		Slug:            "readiness",
+		Decision:        "connect",
+		Reason:          "Coordination spans many specs.",
+		InitiativeSlug:  "readiness",
+		SpecCount:       6,
+		MilestoneNumber: 7,
+		MilestoneTitle:  "Readiness",
+		ProjectOwner:    "JimmyMcBride",
+		ProjectNumber:   12,
+		ProjectID:       "PVT_kwExample",
+		ProjectURL:      "https://github.com/users/JimmyMcBride/projects/12",
+		FieldIDs: map[string]string{
+			"Status": "PVTSSF_status",
+			"Ready":  "PVTSSF_ready",
+		},
+		SourceMode:       "github",
+		EntryMode:        "github_collaborative",
+		DiscussionNumber: 49,
+		DiscussionURL:    "https://github.com/JimmyMcBride/plan/discussions/49",
+		UpdatedAt:        "2026-04-27T00:00:00Z",
+	}
+	if err := manager.WriteGitHubState(*state); err != nil {
+		t.Fatal(err)
+	}
+
+	roundTrip, err := manager.ReadGitHubState()
+	if err != nil {
+		t.Fatal(err)
+	}
+	record := roundTrip.ProjectDecisions["readiness"]
+	if record.Decision != "connect" || record.ProjectOwner != "JimmyMcBride" || record.ProjectNumber != 12 || record.ProjectID == "" || record.ProjectURL == "" {
+		t.Fatalf("expected project identity fields to round-trip: %+v", record)
+	}
+	if record.InitiativeSlug != "readiness" || record.FieldIDs["Status"] != "PVTSSF_status" || record.FieldIDs["Ready"] != "PVTSSF_ready" {
+		t.Fatalf("expected initiative and field ids to round-trip: %+v", record)
+	}
+}
+
+func TestReadGitHubStateKeepsLegacyProjectDecisionRecordsCompatible(t *testing.T) {
+	root := t.TempDir()
+	manager := New(root)
+	if _, err := manager.Init(); err != nil {
+		t.Fatal(err)
+	}
+
+	githubPath := filepath.Join(root, ".plan", ".meta", "github.json")
+	raw := []byte(`{
+  "last_updated_at": "2026-04-27T00:00:00Z",
+  "stories": {},
+  "planning": {},
+  "project_decisions": {
+    "legacy": {
+      "slug": "legacy",
+      "decision": "create",
+      "spec_count": 5,
+      "milestone_number": 7,
+      "milestone_title": "Legacy"
+    }
+  }
+}`)
+	if err := os.WriteFile(githubPath, raw, 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	state, err := manager.ReadGitHubState()
+	if err != nil {
+		t.Fatal(err)
+	}
+	record := state.ProjectDecisions["legacy"]
+	if record.Decision != "create" || record.ProjectNumber != 0 || record.ProjectID != "" || len(record.FieldIDs) != 0 {
+		t.Fatalf("expected legacy project decision record to remain readable: %+v", record)
+	}
+}
+
 func TestUpdateDoesNotRewriteOptionalCompatibilityDefaults(t *testing.T) {
 	root := t.TempDir()
 	manager := New(root)


### PR DESCRIPTION
## Summary

- Extended GitHub project decision metadata so future project workspace automation can store initiative/project/field identity without adding a new metadata file.
- Recognized `connect` as a reserved project decision and return a clear error until project reference wiring ships.
- Added `plan check` drift detection for incomplete project decision metadata.

## Target Branch

- Normal work targets `develop`.
- Release PRs use `release/vX.Y.Z -> main`.
- Hotfix work must be merged back into `develop`.

## Testing

- [x] `go test ./...`
- [x] `go build ./...`
- [x] Other: `go test -race ./...`; `git diff --check`; `go run . check --project .`; `go run . status --project .`

## Release Notes

- User-facing change: `--project-decision` now documents `create|skip|connect`, with `connect` reserved until project connection support lands.
- Planning or workflow impact: project decision metadata can now hold initiative slug, Project identity, and Project field ids for later automation.
- Follow-up work: implement #67 project provisioning and item field setup.

## Planning

- Related idea/planning documents: #65
- Closes #66
