### PR TITLE
docs: gate spec PRs on Brain closeout

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -15,6 +15,11 @@
 - [ ] `go build ./...`
 - [ ] Other:
 
+## Workflow Readiness
+
+- [ ] `brain session finish` completed before this PR is marked ready or merged.
+- [ ] Required Brain durable notes, docs, or contract updates are committed in this PR.
+
 ## Release Notes
 
 <!-- This section is promoted into the published GitHub release body when this PR ships. -->

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -81,4 +81,6 @@ go run . check --project .
 - Finish one slice, review it, verify it, then commit that slice.
 - Repeat until the current spec is complete.
 - Move to the next queued spec only after the current spec is done.
+- Before opening or merging the PR, run `brain session finish`; if it requires
+  durable notes, commit those notes on the same branch and retry finish.
 - Open one PR after the queued specs for the branch are complete.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -81,6 +81,6 @@ go run . check --project .
 - Finish one slice, review it, verify it, then commit that slice.
 - Repeat until the current spec is complete.
 - Move to the next queued spec only after the current spec is done.
-- Before opening or merging the PR, run `brain session finish`; if it requires
-  durable notes, commit those notes on the same branch and retry finish.
+- Before a PR is marked ready or merged, run `brain session finish`; if it
+  requires durable notes, commit those notes on the same branch and retry finish.
 - Open one PR after the queued specs for the branch are complete.

--- a/docs/project-workflows.md
+++ b/docs/project-workflows.md
@@ -26,17 +26,19 @@ Use this file for agent operating workflow inside the repo.
 3. Run the required full checks through `brain session run -- go test ./...` and `brain session run -- go build ./...`.
 4. Review the diff against the task goal and user-facing behavior.
 5. If review finds issues, patch the work and repeat the test and review steps.
-6. When the task is clean, commit it, push it, and only then move to the next task.
+6. When the task is clean, commit it and only then move to the next task.
+7. Before opening or merging the PR, run `brain session finish`; if Brain requires durable notes, apply them, commit them on the same branch, and retry finish before pushing the final PR state.
 
 ## Close-Out
 
 - Refresh or update durable notes for meaningful behavior, config, or architecture changes.
 - If `brain session finish` blocks, inspect the promotion suggestions first; run `brain distill --session --dry-run` only when you need the full review without creating a proposal note.
 - Before switching away from a working branch or back to `develop`, run `git status --short` and resolve repo-owned leftovers. If `.brain/resources/changes/*`, `.brain/`, `docs/`, or contract files belong to the task, keep them in the same branch/PR; otherwise review and intentionally remove them instead of carrying them onto `develop`, `release/*`, or `main`.
+- Treat `brain session finish` as a PR-readiness gate, not a post-merge cleanup step. Do not open, mark ready, or merge the PR until required Brain durable notes are committed in that PR branch or an explicit forced finish records why no note was kept.
 - If `skills/brain/` changed, reinstall the local Brain skill for Codex and OpenClaw with `brain skills install --scope local --agent codex --agent openclaw --project .`.
 - When opening a PR, make the title and body release-note friendly because GitHub release notes are generated from merged PR metadata.
 - Summarize shipped behavior in the PR, not just implementation steps, so future changelogs stay human-readable.
-- Finish with `brain session finish`.
+- Finish with `brain session finish` before pushing the final PR state.
 - If you must bypass enforcement, use `brain session finish --force --reason "..."` so the override is recorded.
 <!-- brain:end project-doc-workflows -->
 
@@ -52,6 +54,9 @@ Use this file for agent operating workflow inside the repo.
 - Implement one slice at a time.
 - Review and verify each slice before committing that slice.
 - Repeat until the current spec is done, then move to the next queued spec.
+- Run `brain session finish` before opening the PR; commit any required Brain
+  durable notes on the same branch and retry finish before pushing the final PR
+  state.
 - Open one PR after the queued specs for the branch are complete.
 - If legacy epic/story material is still active, archive it with `plan update --project . --archive-legacy`.
 - If GitHub story mode is enabled, run `plan update --project .` and `plan github reconcile --project . --update-visible` after merge before taking more queue work.

--- a/docs/project-workflows.md
+++ b/docs/project-workflows.md
@@ -27,18 +27,18 @@ Use this file for agent operating workflow inside the repo.
 4. Review the diff against the task goal and user-facing behavior.
 5. If review finds issues, patch the work and repeat the test and review steps.
 6. When the task is clean, commit it and only then move to the next task.
-7. Before opening or merging the PR, run `brain session finish`; if Brain requires durable notes, apply them, commit them on the same branch, and retry finish before pushing the final PR state.
+7. If an early PR helps collaboration, push and open it as draft or not-ready. Before the PR is marked ready or merged, run `brain session finish`; if Brain requires durable notes, apply them, commit them on the same branch, retry finish, and include that commit in the final pushed PR state.
 
 ## Close-Out
 
 - Refresh or update durable notes for meaningful behavior, config, or architecture changes.
 - If `brain session finish` blocks, inspect the promotion suggestions first; run `brain distill --session --dry-run` only when you need the full review without creating a proposal note.
 - Before switching away from a working branch or back to `develop`, run `git status --short` and resolve repo-owned leftovers. If `.brain/resources/changes/*`, `.brain/`, `docs/`, or contract files belong to the task, keep them in the same branch/PR; otherwise review and intentionally remove them instead of carrying them onto `develop`, `release/*`, or `main`.
-- Treat `brain session finish` as a PR-readiness gate, not a post-merge cleanup step. Do not open, mark ready, or merge the PR until required Brain durable notes are committed in that PR branch or an explicit forced finish records why no note was kept.
+- Treat `brain session finish` as a PR-readiness gate, not a post-merge cleanup step. Do not mark ready or merge the PR until required Brain durable notes are committed in that PR branch or an explicit forced finish records why no note was kept.
 - If `skills/brain/` changed, reinstall the local Brain skill for Codex and OpenClaw with `brain skills install --scope local --agent codex --agent openclaw --project .`.
 - When opening a PR, make the title and body release-note friendly because GitHub release notes are generated from merged PR metadata.
 - Summarize shipped behavior in the PR, not just implementation steps, so future changelogs stay human-readable.
-- Finish with `brain session finish` before pushing the final PR state.
+- Finish with `brain session finish` before marking the PR ready, before merging it, and before the final push that makes the PR ready.
 - If you must bypass enforcement, use `brain session finish --force --reason "..."` so the override is recorded.
 <!-- brain:end project-doc-workflows -->
 
@@ -54,9 +54,9 @@ Use this file for agent operating workflow inside the repo.
 - Implement one slice at a time.
 - Review and verify each slice before committing that slice.
 - Repeat until the current spec is done, then move to the next queued spec.
-- Run `brain session finish` before opening the PR; commit any required Brain
-  durable notes on the same branch and retry finish before pushing the final PR
-  state.
+- Run `brain session finish` before the PR is marked ready or merged; commit any
+  required Brain durable notes on the same branch and retry finish before pushing
+  the final PR state.
 - Open one PR after the queued specs for the branch are complete.
 - If legacy epic/story material is still active, archive it with `plan update --project . --archive-legacy`.
 - If GitHub story mode is enabled, run `plan update --project .` and `plan github reconcile --project . --update-visible` after merge before taking more queue work.

--- a/skills/plan-execute/SKILL.md
+++ b/skills/plan-execute/SKILL.md
@@ -73,12 +73,13 @@ Use this sequence unless repo instructions require a stricter flow:
    - stage only intentional changes
    - use a clear message referencing the spec when useful
 9. Brain pre-PR closeout:
-   - run `brain session finish` before opening, marking ready, or merging the PR
-     when a Brain session is active
+   - run `brain session finish` before the PR is marked ready or merged when a
+     Brain session is active
    - if Brain requires durable notes, apply them, commit them on the same branch,
      and retry `brain session finish`
-   - do not leave `.brain/`, docs, or contract note changes behind on the
-     integration branch after merge
+   - do not leave `.brain/`, docs, or contract note changes uncommitted when
+     switching back to the integration branch, and do not commit them directly
+     on the integration branch outside the PR
 10. Push and PR:
    - push `codex/<spec-slug>`
    - open a ready PR to the repo's integration branch

--- a/skills/plan-execute/SKILL.md
+++ b/skills/plan-execute/SKILL.md
@@ -72,13 +72,19 @@ Use this sequence unless repo instructions require a stricter flow:
 8. Commit:
    - stage only intentional changes
    - use a clear message referencing the spec when useful
-9. Push and PR:
+9. Brain pre-PR closeout:
+   - run `brain session finish` before opening, marking ready, or merging the PR
+     when a Brain session is active
+   - if Brain requires durable notes, apply them, commit them on the same branch,
+     and retry `brain session finish`
+   - do not leave `.brain/`, docs, or contract note changes behind on the
+     integration branch after merge
+10. Push and PR:
    - push `codex/<spec-slug>`
    - open a ready PR to the repo's integration branch
    - include summary, spec link, slice list, tests run, migration/seed notes,
      manual QA, and screenshots when relevant
-10. Finish:
-   - finish the Brain session when one is active
+11. Finish:
    - report PR URL, tests, and any documented risk
 
 ## Stop Conditions


### PR DESCRIPTION
## Summary

- Makes Brain closeout a pre-PR readiness gate for spec execution work.
- Updates the bundled plan-execute skill, project workflow docs, AGENTS local workflow notes, and PR template so required Brain durable notes are committed in the same PR branch.

## Target Branch

- Normal work targets `develop`.

## Testing

- [x] `git diff --check`
- [x] `go test ./...`
- [x] `go build ./...`
- [ ] Other: not needed; docs and workflow guidance only.

## Workflow Readiness

- [x] `brain session finish` completed before this PR is marked ready or merged.
- [x] Required Brain durable notes, docs, or contract updates are committed in this PR.

## Release Notes

- User-facing change: none.
- Planning or workflow impact: spec PRs now explicitly require Brain closeout before PR readiness/merge so durable notes land in the same branch.
- Follow-up work: none.

## Planning

- Related idea/planning documents: none; follow-up workflow hardening from PR #71 closeout.
