### PR TITLE
release: v0.1.27

### DIFF
--- a/.brain/context/current-state.md
+++ b/.brain/context/current-state.md
@@ -1,5 +1,5 @@
 ---
-updated: "2026-04-27T06:17:17Z"
+updated: "2026-04-27T15:44:41Z"
 ---
 # Current State
 
@@ -38,3 +38,4 @@ Add repo-specific notes here. `brain context refresh` preserves content outside 
 - On April 25, 2026, GitHub promotion became fail-closed: explicit multi-spec sources that parse as fewer than two specs now return `needs_source_repair`, `plan discuss repair` owns canonical `## Specs` repair, promotion drafts include hard agent policy and fallback gating, 5+ spec apply/adopt requires `--project-decision`, `plan github adopt` recovers manual issue sets, and `plan check` detects Plan-labeled GitHub planning drift.
 - On April 25, 2026, PR `#62` review comments tightened the fail-closed promotion branch: GitHub issue listing now raises on 1000-item truncation instead of silently missing Plan-labeled issues, `github adopt` validates output format before mutation, drift findings are deterministic and preserve milestone display casing, label ensuring only touches Plan-owned `plan:*` labels, and shell command quoting reuses a package-level regex.
 - On April 27, 2026, Plan skill installation expanded from one bundled skill to two: `plan skills install` now installs both the base `plan` planning skill and the companion `plan-execute` execution rail skill, with manifests recording the installed skill name.
+- On April 27, 2026, PR `#71` merged GitHub project workspace provisioning and item field setup into `develop`; review follow-up touched `internal/planning/collaboration.go`, `internal/planning/collaboration_test.go`, `internal/planning/github_client.go`, `internal/planning/github_client_test.go`, and `internal/planning/github_project_workspace.go` to require explicit project decisions for project references, accept `www.github.com` project URLs with trailing view paths, and cache issue node IDs from CLI issue payloads before falling back to GraphQL lookups.

--- a/.brain/resources/changes/resolve-pr-71-comments-and-merge.md
+++ b/.brain/resources/changes/resolve-pr-71-comments-and-merge.md
@@ -1,0 +1,17 @@
+---
+title: Resolve PR 71 Comments And Merge
+updated: "2026-04-27T15:45:06Z"
+---
+# Resolve PR 71 Comments And Merge
+
+## Outcome
+
+PR `#71` resolved Copilot review comments for GitHub project workspace provisioning and merged into `develop`.
+
+## Verification
+
+- `git diff --check`
+- `go build ./...`
+- `go run . check --project .`
+- `go test -race ./...`
+- `go test ./...`

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -15,6 +15,11 @@
 - [ ] `go build ./...`
 - [ ] Other:
 
+## Workflow Readiness
+
+- [ ] `brain session finish` completed before this PR is marked ready or merged.
+- [ ] Required Brain durable notes, docs, or contract updates are committed in this PR.
+
 ## Release Notes
 
 <!-- This section is promoted into the published GitHub release body when this PR ships. -->

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -81,4 +81,6 @@ go run . check --project .
 - Finish one slice, review it, verify it, then commit that slice.
 - Repeat until the current spec is complete.
 - Move to the next queued spec only after the current spec is done.
+- Before opening or merging the PR, run `brain session finish`; if it requires
+  durable notes, commit those notes on the same branch and retry finish.
 - Open one PR after the queued specs for the branch are complete.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -81,6 +81,6 @@ go run . check --project .
 - Finish one slice, review it, verify it, then commit that slice.
 - Repeat until the current spec is complete.
 - Move to the next queued spec only after the current spec is done.
-- Before opening or merging the PR, run `brain session finish`; if it requires
-  durable notes, commit those notes on the same branch and retry finish.
+- Before a PR is marked ready or merged, run `brain session finish`; if it
+  requires durable notes, commit those notes on the same branch and retry finish.
 - Open one PR after the queued specs for the branch are complete.

--- a/cmd/discuss.go
+++ b/cmd/discuss.go
@@ -90,7 +90,7 @@ func newDiscussCommand() *cobra.Command {
 	promote.Flags().BoolVar(&promoteApply, "apply", false, "create the promoted GitHub issue set after review")
 	promote.Flags().BoolVar(&promoteConfirm, "confirm", false, "required acknowledgement before apply mutates GitHub")
 	promote.Flags().StringVar(&promoteTarget, "target", "", "promotion ownership target: local, github, or hybrid")
-	promote.Flags().StringVar(&promoteProjectDecision, "project-decision", "", "project prompt decision for 5+ spec promotions: create, skip, or connect")
+	promote.Flags().StringVar(&promoteProjectDecision, "project-decision", "", "project prompt decision for 5+ spec promotions: create or skip; connect is reserved and not yet implemented")
 
 	var (
 		repairBrainstorm string

--- a/cmd/discuss.go
+++ b/cmd/discuss.go
@@ -90,7 +90,7 @@ func newDiscussCommand() *cobra.Command {
 	promote.Flags().BoolVar(&promoteApply, "apply", false, "create the promoted GitHub issue set after review")
 	promote.Flags().BoolVar(&promoteConfirm, "confirm", false, "required acknowledgement before apply mutates GitHub")
 	promote.Flags().StringVar(&promoteTarget, "target", "", "promotion ownership target: local, github, or hybrid")
-	promote.Flags().StringVar(&promoteProjectDecision, "project-decision", "", "project prompt decision for 5+ spec promotions: create or skip")
+	promote.Flags().StringVar(&promoteProjectDecision, "project-decision", "", "project prompt decision for 5+ spec promotions: create, skip, or connect")
 
 	var (
 		repairBrainstorm string

--- a/cmd/discuss.go
+++ b/cmd/discuss.go
@@ -49,6 +49,10 @@ func newDiscussCommand() *cobra.Command {
 		promoteConfirm         bool
 		promoteTarget          string
 		promoteProjectDecision string
+		promoteProjectOwner    string
+		promoteProjectNumber   int
+		promoteProjectID       string
+		promoteProjectURL      string
 	)
 	promote := &cobra.Command{
 		Use:   "promote",
@@ -71,6 +75,10 @@ func newDiscussCommand() *cobra.Command {
 				Confirm:         promoteConfirm,
 				TargetMode:      planning.SourceOfTruthMode(strings.TrimSpace(promoteTarget)),
 				ProjectDecision: strings.TrimSpace(promoteProjectDecision),
+				ProjectOwner:    strings.TrimSpace(promoteProjectOwner),
+				ProjectNumber:   promoteProjectNumber,
+				ProjectID:       strings.TrimSpace(promoteProjectID),
+				ProjectURL:      strings.TrimSpace(promoteProjectURL),
 			})
 			if err != nil {
 				var fallback *planning.PromotionApplyManualFallbackError
@@ -90,7 +98,11 @@ func newDiscussCommand() *cobra.Command {
 	promote.Flags().BoolVar(&promoteApply, "apply", false, "create the promoted GitHub issue set after review")
 	promote.Flags().BoolVar(&promoteConfirm, "confirm", false, "required acknowledgement before apply mutates GitHub")
 	promote.Flags().StringVar(&promoteTarget, "target", "", "promotion ownership target: local, github, or hybrid")
-	promote.Flags().StringVar(&promoteProjectDecision, "project-decision", "", "project prompt decision for 5+ spec promotions: create or skip; connect is reserved and not yet implemented")
+	promote.Flags().StringVar(&promoteProjectDecision, "project-decision", "", "project prompt decision for 5+ spec promotions: create, skip, or connect")
+	promote.Flags().StringVar(&promoteProjectOwner, "project-owner", "", "GitHub Project owner for create/connect; defaults to repo owner for create")
+	promote.Flags().IntVar(&promoteProjectNumber, "project-number", 0, "existing GitHub Project number when --project-decision connect")
+	promote.Flags().StringVar(&promoteProjectID, "project-id", "", "existing GitHub Project node id when --project-decision connect")
+	promote.Flags().StringVar(&promoteProjectURL, "project-url", "", "existing GitHub Project URL when --project-decision connect")
 
 	var (
 		repairBrainstorm string

--- a/cmd/github.go
+++ b/cmd/github.go
@@ -67,6 +67,10 @@ func newGitHubCommand() *cobra.Command {
 		adoptIssues          []string
 		adoptFormat          string
 		adoptProjectDecision string
+		adoptProjectOwner    string
+		adoptProjectNumber   int
+		adoptProjectID       string
+		adoptProjectURL      string
 	)
 	adopt := &cobra.Command{
 		Use:   "adopt",
@@ -85,6 +89,10 @@ func newGitHubCommand() *cobra.Command {
 				DiscussionRef:   adoptDiscussion,
 				IssueNumbers:    issueNumbers,
 				ProjectDecision: strings.TrimSpace(adoptProjectDecision),
+				ProjectOwner:    strings.TrimSpace(adoptProjectOwner),
+				ProjectNumber:   adoptProjectNumber,
+				ProjectID:       strings.TrimSpace(adoptProjectID),
+				ProjectURL:      strings.TrimSpace(adoptProjectURL),
 			})
 			if err != nil {
 				return err
@@ -98,7 +106,11 @@ func newGitHubCommand() *cobra.Command {
 	adopt.Flags().StringVar(&adoptDiscussion, "discussion", "", "GitHub Discussion number or URL that produced the promotion draft")
 	adopt.Flags().StringSliceVar(&adoptIssues, "issues", nil, "GitHub issue numbers in draft order, comma-separated or repeated")
 	adopt.Flags().StringVar(&adoptFormat, "format", "json", "output format: json")
-	adopt.Flags().StringVar(&adoptProjectDecision, "project-decision", "", "project prompt decision for 5+ spec promotions: create or skip; connect is reserved and not yet implemented")
+	adopt.Flags().StringVar(&adoptProjectDecision, "project-decision", "", "project prompt decision for 5+ spec promotions: create, skip, or connect")
+	adopt.Flags().StringVar(&adoptProjectOwner, "project-owner", "", "GitHub Project owner for create/connect; defaults to repo owner for create")
+	adopt.Flags().IntVar(&adoptProjectNumber, "project-number", 0, "existing GitHub Project number when --project-decision connect")
+	adopt.Flags().StringVar(&adoptProjectID, "project-id", "", "existing GitHub Project node id when --project-decision connect")
+	adopt.Flags().StringVar(&adoptProjectURL, "project-url", "", "existing GitHub Project URL when --project-decision connect")
 
 	cmd.AddCommand(enable, reconcile, adopt)
 	return cmd

--- a/cmd/github.go
+++ b/cmd/github.go
@@ -98,7 +98,7 @@ func newGitHubCommand() *cobra.Command {
 	adopt.Flags().StringVar(&adoptDiscussion, "discussion", "", "GitHub Discussion number or URL that produced the promotion draft")
 	adopt.Flags().StringSliceVar(&adoptIssues, "issues", nil, "GitHub issue numbers in draft order, comma-separated or repeated")
 	adopt.Flags().StringVar(&adoptFormat, "format", "json", "output format: json")
-	adopt.Flags().StringVar(&adoptProjectDecision, "project-decision", "", "project prompt decision for 5+ spec promotions: create, skip, or connect")
+	adopt.Flags().StringVar(&adoptProjectDecision, "project-decision", "", "project prompt decision for 5+ spec promotions: create or skip; connect is reserved and not yet implemented")
 
 	cmd.AddCommand(enable, reconcile, adopt)
 	return cmd

--- a/cmd/github.go
+++ b/cmd/github.go
@@ -98,7 +98,7 @@ func newGitHubCommand() *cobra.Command {
 	adopt.Flags().StringVar(&adoptDiscussion, "discussion", "", "GitHub Discussion number or URL that produced the promotion draft")
 	adopt.Flags().StringSliceVar(&adoptIssues, "issues", nil, "GitHub issue numbers in draft order, comma-separated or repeated")
 	adopt.Flags().StringVar(&adoptFormat, "format", "json", "output format: json")
-	adopt.Flags().StringVar(&adoptProjectDecision, "project-decision", "", "project prompt decision for 5+ spec promotions: create or skip")
+	adopt.Flags().StringVar(&adoptProjectDecision, "project-decision", "", "project prompt decision for 5+ spec promotions: create, skip, or connect")
 
 	cmd.AddCommand(enable, reconcile, adopt)
 	return cmd

--- a/cmd/github_test.go
+++ b/cmd/github_test.go
@@ -70,6 +70,26 @@ func (s *stubGitHubEnableClient) AddBlockedBy(projectDir, repo string, issueNumb
 	panic("unexpected AddBlockedBy call")
 }
 
+func (s *stubGitHubEnableClient) CreateProjectWorkspace(projectDir, repo string, input planning.GitHubProjectWorkspaceInput) (*planning.GitHubProjectWorkspace, error) {
+	panic("unexpected CreateProjectWorkspace call")
+}
+
+func (s *stubGitHubEnableClient) GetProjectWorkspace(projectDir, repo string, ref planning.GitHubProjectReference) (*planning.GitHubProjectWorkspace, error) {
+	panic("unexpected GetProjectWorkspace call")
+}
+
+func (s *stubGitHubEnableClient) EnsureProjectField(projectDir string, project planning.GitHubProjectWorkspace, input planning.GitHubProjectFieldInput) (*planning.GitHubProjectField, error) {
+	panic("unexpected EnsureProjectField call")
+}
+
+func (s *stubGitHubEnableClient) AddProjectItemByIssue(projectDir, repo, projectID string, issueNumber int) (*planning.GitHubProjectItem, error) {
+	panic("unexpected AddProjectItemByIssue call")
+}
+
+func (s *stubGitHubEnableClient) SetProjectItemField(projectDir, projectID, itemID string, field planning.GitHubProjectField, value string) error {
+	panic("unexpected SetProjectItemField call")
+}
+
 func TestGitHubEnableCommandPrintsBackendSummary(t *testing.T) {
 	reset := planning.SetGitHubClientFactoryForTesting(func() planning.GitHubClient {
 		return &stubGitHubEnableClient{

--- a/cmd/guide_test.go
+++ b/cmd/guide_test.go
@@ -482,3 +482,23 @@ func (s *stubGuideGitHubClient) AddSubIssue(projectDir, repo string, issueNumber
 func (s *stubGuideGitHubClient) AddBlockedBy(projectDir, repo string, issueNumber, blockingIssueNumber int) error {
 	return nil
 }
+
+func (s *stubGuideGitHubClient) CreateProjectWorkspace(projectDir, repo string, input planning.GitHubProjectWorkspaceInput) (*planning.GitHubProjectWorkspace, error) {
+	return nil, nil
+}
+
+func (s *stubGuideGitHubClient) GetProjectWorkspace(projectDir, repo string, ref planning.GitHubProjectReference) (*planning.GitHubProjectWorkspace, error) {
+	return nil, nil
+}
+
+func (s *stubGuideGitHubClient) EnsureProjectField(projectDir string, project planning.GitHubProjectWorkspace, input planning.GitHubProjectFieldInput) (*planning.GitHubProjectField, error) {
+	return nil, nil
+}
+
+func (s *stubGuideGitHubClient) AddProjectItemByIssue(projectDir, repo, projectID string, issueNumber int) (*planning.GitHubProjectItem, error) {
+	return nil, nil
+}
+
+func (s *stubGuideGitHubClient) SetProjectItemField(projectDir, projectID, itemID string, field planning.GitHubProjectField, value string) error {
+	return nil
+}

--- a/cmd/story_github_test.go
+++ b/cmd/story_github_test.go
@@ -108,6 +108,26 @@ func (s *stubGitHubStoryClient) AddBlockedBy(projectDir, repo string, issueNumbe
 	return nil
 }
 
+func (s *stubGitHubStoryClient) CreateProjectWorkspace(projectDir, repo string, input planning.GitHubProjectWorkspaceInput) (*planning.GitHubProjectWorkspace, error) {
+	return nil, fmt.Errorf("unexpected CreateProjectWorkspace call")
+}
+
+func (s *stubGitHubStoryClient) GetProjectWorkspace(projectDir, repo string, ref planning.GitHubProjectReference) (*planning.GitHubProjectWorkspace, error) {
+	return nil, fmt.Errorf("unexpected GetProjectWorkspace call")
+}
+
+func (s *stubGitHubStoryClient) EnsureProjectField(projectDir string, project planning.GitHubProjectWorkspace, input planning.GitHubProjectFieldInput) (*planning.GitHubProjectField, error) {
+	return nil, fmt.Errorf("unexpected EnsureProjectField call")
+}
+
+func (s *stubGitHubStoryClient) AddProjectItemByIssue(projectDir, repo, projectID string, issueNumber int) (*planning.GitHubProjectItem, error) {
+	return nil, fmt.Errorf("unexpected AddProjectItemByIssue call")
+}
+
+func (s *stubGitHubStoryClient) SetProjectItemField(projectDir, projectID, itemID string, field planning.GitHubProjectField, value string) error {
+	return fmt.Errorf("unexpected SetProjectItemField call")
+}
+
 func TestStoryCommandsSupportGitHubBackedStories(t *testing.T) {
 	client := &stubGitHubStoryClient{
 		preflight: &planning.GitHubRepoInfo{

--- a/docs/project-workflows.md
+++ b/docs/project-workflows.md
@@ -26,17 +26,19 @@ Use this file for agent operating workflow inside the repo.
 3. Run the required full checks through `brain session run -- go test ./...` and `brain session run -- go build ./...`.
 4. Review the diff against the task goal and user-facing behavior.
 5. If review finds issues, patch the work and repeat the test and review steps.
-6. When the task is clean, commit it, push it, and only then move to the next task.
+6. When the task is clean, commit it and only then move to the next task.
+7. Before opening or merging the PR, run `brain session finish`; if Brain requires durable notes, apply them, commit them on the same branch, and retry finish before pushing the final PR state.
 
 ## Close-Out
 
 - Refresh or update durable notes for meaningful behavior, config, or architecture changes.
 - If `brain session finish` blocks, inspect the promotion suggestions first; run `brain distill --session --dry-run` only when you need the full review without creating a proposal note.
 - Before switching away from a working branch or back to `develop`, run `git status --short` and resolve repo-owned leftovers. If `.brain/resources/changes/*`, `.brain/`, `docs/`, or contract files belong to the task, keep them in the same branch/PR; otherwise review and intentionally remove them instead of carrying them onto `develop`, `release/*`, or `main`.
+- Treat `brain session finish` as a PR-readiness gate, not a post-merge cleanup step. Do not open, mark ready, or merge the PR until required Brain durable notes are committed in that PR branch or an explicit forced finish records why no note was kept.
 - If `skills/brain/` changed, reinstall the local Brain skill for Codex and OpenClaw with `brain skills install --scope local --agent codex --agent openclaw --project .`.
 - When opening a PR, make the title and body release-note friendly because GitHub release notes are generated from merged PR metadata.
 - Summarize shipped behavior in the PR, not just implementation steps, so future changelogs stay human-readable.
-- Finish with `brain session finish`.
+- Finish with `brain session finish` before pushing the final PR state.
 - If you must bypass enforcement, use `brain session finish --force --reason "..."` so the override is recorded.
 <!-- brain:end project-doc-workflows -->
 
@@ -52,6 +54,9 @@ Use this file for agent operating workflow inside the repo.
 - Implement one slice at a time.
 - Review and verify each slice before committing that slice.
 - Repeat until the current spec is done, then move to the next queued spec.
+- Run `brain session finish` before opening the PR; commit any required Brain
+  durable notes on the same branch and retry finish before pushing the final PR
+  state.
 - Open one PR after the queued specs for the branch are complete.
 - If legacy epic/story material is still active, archive it with `plan update --project . --archive-legacy`.
 - If GitHub story mode is enabled, run `plan update --project .` and `plan github reconcile --project . --update-visible` after merge before taking more queue work.

--- a/docs/project-workflows.md
+++ b/docs/project-workflows.md
@@ -27,18 +27,18 @@ Use this file for agent operating workflow inside the repo.
 4. Review the diff against the task goal and user-facing behavior.
 5. If review finds issues, patch the work and repeat the test and review steps.
 6. When the task is clean, commit it and only then move to the next task.
-7. Before opening or merging the PR, run `brain session finish`; if Brain requires durable notes, apply them, commit them on the same branch, and retry finish before pushing the final PR state.
+7. If an early PR helps collaboration, push and open it as draft or not-ready. Before the PR is marked ready or merged, run `brain session finish`; if Brain requires durable notes, apply them, commit them on the same branch, retry finish, and include that commit in the final pushed PR state.
 
 ## Close-Out
 
 - Refresh or update durable notes for meaningful behavior, config, or architecture changes.
 - If `brain session finish` blocks, inspect the promotion suggestions first; run `brain distill --session --dry-run` only when you need the full review without creating a proposal note.
 - Before switching away from a working branch or back to `develop`, run `git status --short` and resolve repo-owned leftovers. If `.brain/resources/changes/*`, `.brain/`, `docs/`, or contract files belong to the task, keep them in the same branch/PR; otherwise review and intentionally remove them instead of carrying them onto `develop`, `release/*`, or `main`.
-- Treat `brain session finish` as a PR-readiness gate, not a post-merge cleanup step. Do not open, mark ready, or merge the PR until required Brain durable notes are committed in that PR branch or an explicit forced finish records why no note was kept.
+- Treat `brain session finish` as a PR-readiness gate, not a post-merge cleanup step. Do not mark ready or merge the PR until required Brain durable notes are committed in that PR branch or an explicit forced finish records why no note was kept.
 - If `skills/brain/` changed, reinstall the local Brain skill for Codex and OpenClaw with `brain skills install --scope local --agent codex --agent openclaw --project .`.
 - When opening a PR, make the title and body release-note friendly because GitHub release notes are generated from merged PR metadata.
 - Summarize shipped behavior in the PR, not just implementation steps, so future changelogs stay human-readable.
-- Finish with `brain session finish` before pushing the final PR state.
+- Finish with `brain session finish` before marking the PR ready, before merging it, and before the final push that makes the PR ready.
 - If you must bypass enforcement, use `brain session finish --force --reason "..."` so the override is recorded.
 <!-- brain:end project-doc-workflows -->
 
@@ -54,9 +54,9 @@ Use this file for agent operating workflow inside the repo.
 - Implement one slice at a time.
 - Review and verify each slice before committing that slice.
 - Repeat until the current spec is done, then move to the next queued spec.
-- Run `brain session finish` before opening the PR; commit any required Brain
-  durable notes on the same branch and retry finish before pushing the final PR
-  state.
+- Run `brain session finish` before the PR is marked ready or merged; commit any
+  required Brain durable notes on the same branch and retry finish before pushing
+  the final PR state.
 - Open one PR after the queued specs for the branch are complete.
 - If legacy epic/story material is still active, archive it with `plan update --project . --archive-legacy`.
 - If GitHub story mode is enabled, run `plan update --project .` and `plan github reconcile --project . --update-visible` after merge before taking more queue work.

--- a/docs/using-plan.md
+++ b/docs/using-plan.md
@@ -386,11 +386,20 @@ Current shipped boundary:
 - the promoted issue body becomes the canonical distilled planning artifact
 - the original GitHub Discussion stays linked as collaboration history
 - promotions with 5+ specs require an explicit project decision so project
-  tracking is never silently skipped; supported values today are
-  `--project-decision create|skip`
-- `connect` is a reserved project decision until project-reference wiring ships;
-  Plan recognizes it but returns a clear error instead of guessing which Project
-  to use
+  tracking is never silently skipped: `--project-decision create|skip|connect`
+- `create` creates one GitHub Project for the initiative and links it to the
+  repository when GitHub accepts the repository link during project creation
+- `connect` requires an existing Project reference with `--project-owner` and
+  `--project-number`, `--project-url`, or `--project-id`
+- Project provisioning adds the initiative/spec issues to the Project, ensures
+  the `Type`, `Stage`, `Ready`, `Status`, and `Area` fields exist, sets initial
+  field values, stores Project metadata in `.plan/.meta/github.json`, and prints
+  manual saved-view setup instructions
+- If an existing single-select field is present but missing required options,
+  Plan fails closed instead of editing options because GitHub can regenerate
+  option ids and clear existing selections
+- Plan does not create saved views; create Workspace, Execution, and
+  Ideas/Tracking views manually in GitHub after provisioning
 - if a valid apply path fails on the GitHub API, Plan emits
   `manual_fallback_allowed=true`; only then may an agent use manual `gh`
   commands, followed by `plan github adopt`
@@ -403,7 +412,8 @@ When a multi-spec promotion is applied, `plan` will:
 - wire the initiative as parent of the spec issues
 - add `blocked by` relationships only where the dependency plan says they are
   real
-- mirror the created issue/milestone metadata into `.plan/.meta/github.json`
+- mirror the created issue/milestone/project metadata into
+  `.plan/.meta/github.json`
 
 By default, new spec issues are `ready`. A spec starts as `needs-refinement`
 only when the draft identified a concrete execution gap.

--- a/docs/using-plan.md
+++ b/docs/using-plan.md
@@ -385,10 +385,12 @@ Current shipped boundary:
   compatibility path to create the local spec file today
 - the promoted issue body becomes the canonical distilled planning artifact
 - the original GitHub Discussion stays linked as collaboration history
-- promotions with 5+ specs require `--project-decision create|skip|connect`
-  so project tracking is never silently skipped
+- promotions with 5+ specs require an explicit project decision so project
+  tracking is never silently skipped; supported values today are
+  `--project-decision create|skip`
 - `connect` is a reserved project decision until project-reference wiring ships;
-  it returns a clear error instead of guessing which Project to use
+  Plan recognizes it but returns a clear error instead of guessing which Project
+  to use
 - if a valid apply path fails on the GitHub API, Plan emits
   `manual_fallback_allowed=true`; only then may an agent use manual `gh`
   commands, followed by `plan github adopt`

--- a/docs/using-plan.md
+++ b/docs/using-plan.md
@@ -385,8 +385,10 @@ Current shipped boundary:
   compatibility path to create the local spec file today
 - the promoted issue body becomes the canonical distilled planning artifact
 - the original GitHub Discussion stays linked as collaboration history
-- promotions with 5+ specs require `--project-decision create|skip` so project
-  tracking is never silently skipped
+- promotions with 5+ specs require `--project-decision create|skip|connect`
+  so project tracking is never silently skipped
+- `connect` is a reserved project decision until project-reference wiring ships;
+  it returns a clear error instead of guessing which Project to use
 - if a valid apply path fails on the GitHub API, Plan emits
   `manual_fallback_allowed=true`; only then may an agent use manual `gh`
   commands, followed by `plan github adopt`

--- a/internal/planning/check.go
+++ b/internal/planning/check.go
@@ -247,7 +247,7 @@ func (m *Manager) checkGitHubPlanningDrift(info *workspace.Info) ([]CheckFinding
 				ArtifactTitle: displayTitle,
 				Section:       "GitHub Planning",
 				Message:       fmt.Sprintf("Milestone %q has %d promoted specs but no project prompt decision record.", displayTitle, count),
-				Suggestion:    "Rerun promotion/adoption with `--project-decision create|skip|connect` so coordination intent is explicit.",
+				Suggestion:    "Rerun promotion/adoption with `--project-decision create|skip` so coordination intent is explicit. `connect` is reserved until project reference support ships.",
 			})
 			continue
 		}

--- a/internal/planning/check.go
+++ b/internal/planning/check.go
@@ -237,19 +237,32 @@ func (m *Manager) checkGitHubPlanningDrift(info *workspace.Info) ([]CheckFinding
 		if displayTitle == "" {
 			displayTitle = title
 		}
-		if hasProjectDecisionForMilestone(state, number, title) {
+		decision, ok := projectDecisionForMilestone(state, number, title)
+		if !ok {
+			findings = append(findings, CheckFinding{
+				Severity:      "error",
+				Rule:          "github_planning.missing_project_decision",
+				ArtifactType:  "github_milestone",
+				ArtifactPath:  displayTitle,
+				ArtifactTitle: displayTitle,
+				Section:       "GitHub Planning",
+				Message:       fmt.Sprintf("Milestone %q has %d promoted specs but no project prompt decision record.", displayTitle, count),
+				Suggestion:    "Rerun promotion/adoption with `--project-decision create|skip|connect` so coordination intent is explicit.",
+			})
 			continue
 		}
-		findings = append(findings, CheckFinding{
-			Severity:      "error",
-			Rule:          "github_planning.missing_project_decision",
-			ArtifactType:  "github_milestone",
-			ArtifactPath:  displayTitle,
-			ArtifactTitle: displayTitle,
-			Section:       "GitHub Planning",
-			Message:       fmt.Sprintf("Milestone %q has %d promoted specs but no project prompt decision record.", displayTitle, count),
-			Suggestion:    "Rerun promotion/adoption with `--project-decision create|skip` so coordination intent is explicit.",
-		})
+		if reason := incompleteProjectDecisionReason(decision); reason != "" {
+			findings = append(findings, CheckFinding{
+				Severity:      "error",
+				Rule:          "github_planning.incomplete_project_decision",
+				ArtifactType:  "github_milestone",
+				ArtifactPath:  displayTitle,
+				ArtifactTitle: displayTitle,
+				Section:       "GitHub Planning",
+				Message:       fmt.Sprintf("Milestone %q has incomplete project decision metadata: %s.", displayTitle, reason),
+				Suggestion:    "Rerun promotion/adoption with a supported `--project-decision` value, or repair the project decision metadata before project automation continues.",
+			})
+		}
 	}
 	return findings, nil
 }
@@ -305,16 +318,32 @@ func splitMilestoneKey(key string) (int, string) {
 	return number, parts[1]
 }
 
-func hasProjectDecisionForMilestone(state *workspace.GitHubState, number int, title string) bool {
+func projectDecisionForMilestone(state *workspace.GitHubState, number int, title string) (workspace.GitHubProjectDecisionRecord, bool) {
 	for _, decision := range state.ProjectDecisions {
 		if number > 0 && decision.MilestoneNumber == number {
-			return true
+			return decision, true
 		}
 		if strings.EqualFold(strings.TrimSpace(decision.MilestoneTitle), strings.TrimSpace(title)) && strings.TrimSpace(title) != "" {
-			return true
+			return decision, true
 		}
 	}
-	return false
+	return workspace.GitHubProjectDecisionRecord{}, false
+}
+
+func incompleteProjectDecisionReason(decision workspace.GitHubProjectDecisionRecord) string {
+	switch normalizeProjectDecision(decision.Decision) {
+	case projectDecisionCreate, projectDecisionSkip:
+		return ""
+	case projectDecisionConnect:
+		if strings.TrimSpace(decision.ProjectID) == "" && decision.ProjectNumber == 0 && strings.TrimSpace(decision.ProjectURL) == "" {
+			return "connect decisions require a project id, number, or url"
+		}
+		return ""
+	case "":
+		return "decision is empty"
+	default:
+		return fmt.Sprintf("decision %q is not supported", decision.Decision)
+	}
 }
 
 func (m *Manager) readStoriesByFilter(info *workspace.Info, keep func(StoryInfo) bool) ([]*notes.Note, error) {

--- a/internal/planning/check.go
+++ b/internal/planning/check.go
@@ -247,7 +247,7 @@ func (m *Manager) checkGitHubPlanningDrift(info *workspace.Info) ([]CheckFinding
 				ArtifactTitle: displayTitle,
 				Section:       "GitHub Planning",
 				Message:       fmt.Sprintf("Milestone %q has %d promoted specs but no project prompt decision record.", displayTitle, count),
-				Suggestion:    "Rerun promotion/adoption with `--project-decision create|skip` so coordination intent is explicit. `connect` is reserved until project reference support ships.",
+				Suggestion:    "Rerun promotion/adoption with `--project-decision create|skip|connect` so coordination intent is explicit.",
 			})
 			continue
 		}
@@ -332,11 +332,16 @@ func projectDecisionForMilestone(state *workspace.GitHubState, number int, title
 
 func incompleteProjectDecisionReason(decision workspace.GitHubProjectDecisionRecord) string {
 	switch normalizeProjectDecision(decision.Decision) {
-	case projectDecisionCreate, projectDecisionSkip:
+	case projectDecisionSkip:
 		return ""
-	case projectDecisionConnect:
+	case projectDecisionCreate, projectDecisionConnect:
 		if strings.TrimSpace(decision.ProjectID) == "" && decision.ProjectNumber == 0 && strings.TrimSpace(decision.ProjectURL) == "" {
-			return "connect decisions require a project id, number, or url"
+			return fmt.Sprintf("%s decisions require a project id, number, or url", normalizeProjectDecision(decision.Decision))
+		}
+		for _, field := range projectWorkspaceFieldInputs() {
+			if strings.TrimSpace(decision.FieldIDs[field.Name]) == "" {
+				return fmt.Sprintf("%s decisions require project field id %q", normalizeProjectDecision(decision.Decision), field.Name)
+			}
 		}
 		return ""
 	case "":

--- a/internal/planning/check_test.go
+++ b/internal/planning/check_test.go
@@ -357,6 +357,43 @@ func TestCheckFlagsMissingProjectDecisionForFiveSpecMilestone(t *testing.T) {
 	assertHasFinding(t, report.Findings, "github_planning.missing_project_decision", "GitHub Planning")
 }
 
+func TestCheckFlagsIncompleteProjectDecisionForFiveSpecMilestone(t *testing.T) {
+	reset := SetGitHubClientFactoryForTesting(func() GitHubClient { return checkDriftClient(nil) })
+	t.Cleanup(reset)
+	manager := setupGitHubSourceModeCheck(t)
+	state, err := manager.workspace.ReadGitHubState()
+	if err != nil {
+		t.Fatal(err)
+	}
+	for i := 0; i < 5; i++ {
+		slug := fmt.Sprintf("spec-%d", i)
+		state.Planning[slug] = workspace.GitHubPlanningRecord{
+			Slug:            slug,
+			Kind:            "spec",
+			Title:           fmt.Sprintf("Spec %d", i),
+			IssueNumber:     500 + i,
+			MilestoneNumber: 7,
+			MilestoneTitle:  "Readiness",
+		}
+	}
+	state.ProjectDecisions["readiness"] = workspace.GitHubProjectDecisionRecord{
+		Slug:            "readiness",
+		Decision:        "connect",
+		SpecCount:       5,
+		MilestoneNumber: 7,
+		MilestoneTitle:  "Readiness",
+	}
+	if err := manager.workspace.WriteGitHubState(*state); err != nil {
+		t.Fatal(err)
+	}
+
+	report, err := manager.Check(CheckInput{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	assertHasFinding(t, report.Findings, "github_planning.incomplete_project_decision", "GitHub Planning")
+}
+
 func TestCheckFlagsLabelUsedWhereMilestoneExpected(t *testing.T) {
 	client := checkDriftClient(map[int]*GitHubIssue{
 		601: {Number: 601, URL: "https://github.com/JimmyMcBride/plan/issues/601", Title: "Spec", State: "open", Labels: []string{planIssueSpecLabel, "Readiness Initiative"}},

--- a/internal/planning/check_test.go
+++ b/internal/planning/check_test.go
@@ -394,6 +394,46 @@ func TestCheckFlagsIncompleteProjectDecisionForFiveSpecMilestone(t *testing.T) {
 	assertHasFinding(t, report.Findings, "github_planning.incomplete_project_decision", "GitHub Planning")
 }
 
+func TestCheckFlagsProjectDecisionMissingFieldIDs(t *testing.T) {
+	reset := SetGitHubClientFactoryForTesting(func() GitHubClient { return checkDriftClient(nil) })
+	t.Cleanup(reset)
+	manager := setupGitHubSourceModeCheck(t)
+	state, err := manager.workspace.ReadGitHubState()
+	if err != nil {
+		t.Fatal(err)
+	}
+	for i := 0; i < 5; i++ {
+		slug := fmt.Sprintf("spec-%d", i)
+		state.Planning[slug] = workspace.GitHubPlanningRecord{
+			Slug:            slug,
+			Kind:            "spec",
+			Title:           fmt.Sprintf("Spec %d", i),
+			IssueNumber:     500 + i,
+			MilestoneNumber: 7,
+			MilestoneTitle:  "Readiness",
+		}
+	}
+	state.ProjectDecisions["readiness"] = workspace.GitHubProjectDecisionRecord{
+		Slug:            "readiness",
+		Decision:        "create",
+		SpecCount:       5,
+		MilestoneNumber: 7,
+		MilestoneTitle:  "Readiness",
+		ProjectID:       "PVT_ready",
+		ProjectNumber:   8,
+		ProjectURL:      "https://github.com/users/JimmyMcBride/projects/8",
+	}
+	if err := manager.workspace.WriteGitHubState(*state); err != nil {
+		t.Fatal(err)
+	}
+
+	report, err := manager.Check(CheckInput{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	assertHasFinding(t, report.Findings, "github_planning.incomplete_project_decision", "GitHub Planning")
+}
+
 func TestCheckFlagsLabelUsedWhereMilestoneExpected(t *testing.T) {
 	client := checkDriftClient(map[int]*GitHubIssue{
 		601: {Number: 601, URL: "https://github.com/JimmyMcBride/plan/issues/601", Title: "Spec", State: "open", Labels: []string{planIssueSpecLabel, "Readiness Initiative"}},

--- a/internal/planning/collaboration.go
+++ b/internal/planning/collaboration.go
@@ -1708,10 +1708,10 @@ func validateProjectDecision(decision string, draft *PromotionDraft) error {
 	switch decision {
 	case "", projectDecisionCreate, projectDecisionSkip, projectDecisionConnect:
 	default:
-		return fmt.Errorf("unsupported project decision %q; use create, skip, or connect", decision)
+		return fmt.Errorf("unsupported project decision %q; use create or skip; connect is reserved and not yet implemented", decision)
 	}
 	if requiresProjectDecision(draft) && decision == "" {
-		return fmt.Errorf("promotion has %d specs and requires --project-decision create|skip|connect before apply", len(draft.ProposedSpecIssues))
+		return fmt.Errorf("promotion has %d specs and requires --project-decision create|skip before apply; connect is reserved and not yet implemented", len(draft.ProposedSpecIssues))
 	}
 	if decision == projectDecisionConnect {
 		return fmt.Errorf("project decision %q requires project reference support, which is not implemented yet", decision)
@@ -1849,7 +1849,7 @@ func manualFallbackAdoptCommand(draft *PromotionDraft) string {
 	}
 	args = append(args, "--issues", strings.Join(placeholders, ","))
 	if requiresProjectDecision(draft) {
-		args = append(args, "--project-decision", "<create|skip|connect>")
+		args = append(args, "--project-decision", "<create|skip>")
 	}
 	args = append(args, "--format", "json")
 	return shellCommand(args)

--- a/internal/planning/collaboration.go
+++ b/internal/planning/collaboration.go
@@ -1773,9 +1773,14 @@ func validateProjectDecision(decision string, draft *PromotionDraft, ref GitHubP
 	if requiresProjectDecision(draft) && decision == "" {
 		return fmt.Errorf("promotion has %d specs and requires --project-decision create|skip|connect before apply", len(draft.ProposedSpecIssues))
 	}
+	if decision == "" {
+		if strings.TrimSpace(ref.Owner) != "" || ref.Number != 0 || strings.TrimSpace(ref.ID) != "" || strings.TrimSpace(ref.URL) != "" {
+			return fmt.Errorf("project reference flags require --project-decision connect or create explicitly")
+		}
+	}
 	if decision == projectDecisionConnect {
 		if strings.TrimSpace(ref.ID) == "" && (strings.TrimSpace(ref.Owner) == "" || ref.Number <= 0) {
-			return fmt.Errorf("project decision %q requires --project-owner and --project-number, --project-url, or --project-id", decision)
+			return fmt.Errorf("project decision %q requires either --project-owner and --project-number, or --project-url, or --project-id", decision)
 		}
 	}
 	if decision == projectDecisionCreate {

--- a/internal/planning/collaboration.go
+++ b/internal/planning/collaboration.go
@@ -192,6 +192,12 @@ type PromotionProjectPrompt struct {
 	Reason      string `json:"reason,omitempty"`
 }
 
+const (
+	projectDecisionCreate  = "create"
+	projectDecisionSkip    = "skip"
+	projectDecisionConnect = "connect"
+)
+
 type PromotionRefinementException struct {
 	IssueTitle               string   `json:"issue_title"`
 	Gap                      string   `json:"gap"`
@@ -1698,16 +1704,23 @@ func shouldRecommendProject(specCount int, deps []PromotionDependencyPlan) bool 
 }
 
 func validateProjectDecision(decision string, draft *PromotionDraft) error {
-	decision = strings.TrimSpace(decision)
+	decision = normalizeProjectDecision(decision)
 	switch decision {
-	case "", "create", "skip":
+	case "", projectDecisionCreate, projectDecisionSkip, projectDecisionConnect:
 	default:
-		return fmt.Errorf("unsupported project decision %q; use create or skip", decision)
+		return fmt.Errorf("unsupported project decision %q; use create, skip, or connect", decision)
 	}
 	if requiresProjectDecision(draft) && decision == "" {
-		return fmt.Errorf("promotion has %d specs and requires --project-decision create|skip before apply", len(draft.ProposedSpecIssues))
+		return fmt.Errorf("promotion has %d specs and requires --project-decision create|skip|connect before apply", len(draft.ProposedSpecIssues))
+	}
+	if decision == projectDecisionConnect {
+		return fmt.Errorf("project decision %q requires project reference support, which is not implemented yet", decision)
 	}
 	return nil
+}
+
+func normalizeProjectDecision(decision string) string {
+	return strings.ToLower(strings.TrimSpace(decision))
 }
 
 func requiresProjectDecision(draft *PromotionDraft) bool {
@@ -1716,9 +1729,11 @@ func requiresProjectDecision(draft *PromotionDraft) bool {
 
 func buildProjectDecisionRecord(draft *PromotionDraft, decision string, milestone *GitHubMilestone) workspace.GitHubProjectDecisionRecord {
 	now := time.Now().UTC().Format(time.RFC3339)
+	slug := promotionProjectDecisionSlug(draft)
 	record := workspace.GitHubProjectDecisionRecord{
-		Slug:             promotionProjectDecisionSlug(draft),
-		Decision:         strings.TrimSpace(decision),
+		Slug:             slug,
+		Decision:         normalizeProjectDecision(decision),
+		InitiativeSlug:   slug,
 		SpecCount:        len(draft.ProposedSpecIssues),
 		MilestoneNumber:  milestoneNumberOrZero(milestone),
 		MilestoneTitle:   milestoneTitle(milestone),
@@ -1834,7 +1849,7 @@ func manualFallbackAdoptCommand(draft *PromotionDraft) string {
 	}
 	args = append(args, "--issues", strings.Join(placeholders, ","))
 	if requiresProjectDecision(draft) {
-		args = append(args, "--project-decision", "<create|skip>")
+		args = append(args, "--project-decision", "<create|skip|connect>")
 	}
 	args = append(args, "--format", "json")
 	return shellCommand(args)

--- a/internal/planning/collaboration.go
+++ b/internal/planning/collaboration.go
@@ -230,6 +230,10 @@ type PromotionApplyInput struct {
 	Confirm         bool
 	TargetMode      SourceOfTruthMode
 	ProjectDecision string
+	ProjectOwner    string
+	ProjectNumber   int
+	ProjectID       string
+	ProjectURL      string
 }
 
 type PromotionApplyResult struct {
@@ -239,6 +243,7 @@ type PromotionApplyResult struct {
 	Milestone             *GitHubMilestone                       `json:"milestone,omitempty"`
 	ParentIssue           int                                    `json:"parent_issue,omitempty"`
 	ProjectDecision       *workspace.GitHubProjectDecisionRecord `json:"project_decision,omitempty"`
+	ProjectWorkspace      *GitHubProjectWorkspaceResult          `json:"project_workspace,omitempty"`
 	ManualFallbackAllowed bool                                   `json:"manual_fallback_allowed"`
 	ManualFallbackReason  string                                 `json:"manual_fallback_reason,omitempty"`
 	NextCommand           string                                 `json:"next_command,omitempty"`
@@ -286,15 +291,20 @@ type GitHubAdoptInput struct {
 	DiscussionRef   string
 	IssueNumbers    []int
 	ProjectDecision string
+	ProjectOwner    string
+	ProjectNumber   int
+	ProjectID       string
+	ProjectURL      string
 }
 
 type GitHubAdoptResult struct {
-	Draft           *PromotionDraft                        `json:"draft"`
-	Initiative      *GitHubIssue                           `json:"initiative,omitempty"`
-	Specs           []GitHubIssue                          `json:"specs,omitempty"`
-	Milestone       *GitHubMilestone                       `json:"milestone,omitempty"`
-	ProjectDecision *workspace.GitHubProjectDecisionRecord `json:"project_decision,omitempty"`
-	Adopted         []workspace.GitHubPlanningRecord       `json:"adopted"`
+	Draft            *PromotionDraft                        `json:"draft"`
+	Initiative       *GitHubIssue                           `json:"initiative,omitempty"`
+	Specs            []GitHubIssue                          `json:"specs,omitempty"`
+	Milestone        *GitHubMilestone                       `json:"milestone,omitempty"`
+	ProjectDecision  *workspace.GitHubProjectDecisionRecord `json:"project_decision,omitempty"`
+	ProjectWorkspace *GitHubProjectWorkspaceResult          `json:"project_workspace,omitempty"`
+	Adopted          []workspace.GitHubPlanningRecord       `json:"adopted"`
 }
 
 type collaborationSourceData struct {
@@ -492,7 +502,11 @@ func (m *Manager) ApplyPromotionDraft(input PromotionApplyInput) (*PromotionAppl
 		}
 		return nil, fmt.Errorf("source is not ready for promotion")
 	}
-	if err := validateProjectDecision(input.ProjectDecision, draft); err != nil {
+	projectRef, err := normalizeProjectReference(input.ProjectOwner, input.ProjectNumber, input.ProjectID, input.ProjectURL)
+	if err != nil {
+		return nil, err
+	}
+	if err := validateProjectDecision(input.ProjectDecision, draft, projectRef); err != nil {
 		return nil, err
 	}
 	mode := input.TargetMode
@@ -556,10 +570,20 @@ func (m *Manager) ApplyPromotionDraft(input PromotionApplyInput) (*PromotionAppl
 		}
 		result.Milestone = milestone
 	}
+	var projectRecord *workspace.GitHubProjectDecisionRecord
+	var preparedProject *preparedProjectWorkspace
 	if strings.TrimSpace(input.ProjectDecision) != "" {
-		record := buildProjectDecisionRecord(draft, input.ProjectDecision, milestone)
+		record := buildProjectDecisionRecord(draft, input.ProjectDecision, milestone, projectRef)
+		preparedProject, record, err = m.prepareProjectWorkspace(info.ProjectDir, state.Repo, draft, record)
+		if err != nil {
+			return fallback(err)
+		}
 		state.ProjectDecisions[record.Slug] = record
 		result.ProjectDecision = &record
+		projectRecord = &record
+		if preparedProject != nil {
+			result.ProjectWorkspace = preparedProject.result
+		}
 	}
 	var initiativeIssue *GitHubIssue
 	if draft.ProposedInitiativeIssue != nil {
@@ -635,6 +659,17 @@ func (m *Manager) ApplyPromotionDraft(input PromotionApplyInput) (*PromotionAppl
 			}
 		}
 	}
+	if preparedProject != nil {
+		if err := m.populateProjectWorkspaceItems(info.ProjectDir, state.Repo, preparedProject, initiativeIssue, specIssuesBySlug, draft.ProposedSpecIssues); err != nil {
+			return fallback(err)
+		}
+		if projectRecord != nil {
+			projectRecord.UpdatedAt = time.Now().UTC().Format(time.RFC3339)
+			state.ProjectDecisions[projectRecord.Slug] = *projectRecord
+			result.ProjectDecision = projectRecord
+		}
+		result.ProjectWorkspace = preparedProject.result
+	}
 	for slug, specIssue := range specIssuesBySlug {
 		specDraft := specDraftsBySlug[slug]
 		readiness := string(specDraft.Readiness)
@@ -680,7 +715,11 @@ func (m *Manager) AdoptGitHubPromotion(input GitHubAdoptInput) (*GitHubAdoptResu
 		}
 		return nil, fmt.Errorf("source is not ready for adoption")
 	}
-	if err := validateProjectDecision(input.ProjectDecision, draft); err != nil {
+	projectRef, err := normalizeProjectReference(input.ProjectOwner, input.ProjectNumber, input.ProjectID, input.ProjectURL)
+	if err != nil {
+		return nil, err
+	}
+	if err := validateProjectDecision(input.ProjectDecision, draft, projectRef); err != nil {
 		return nil, err
 	}
 	expected := len(draft.ProposedSpecIssues)
@@ -741,10 +780,20 @@ func (m *Manager) AdoptGitHubPromotion(input GitHubAdoptInput) (*GitHubAdoptResu
 		}
 	}
 	result := &GitHubAdoptResult{Draft: draft, Milestone: milestone}
+	var projectRecord *workspace.GitHubProjectDecisionRecord
+	var preparedProject *preparedProjectWorkspace
 	if strings.TrimSpace(input.ProjectDecision) != "" {
-		record := buildProjectDecisionRecord(draft, input.ProjectDecision, milestone)
+		record := buildProjectDecisionRecord(draft, input.ProjectDecision, milestone, projectRef)
+		preparedProject, record, err = m.prepareProjectWorkspace(info.ProjectDir, state.Repo, draft, record)
+		if err != nil {
+			return nil, err
+		}
 		state.ProjectDecisions[record.Slug] = record
 		result.ProjectDecision = &record
+		projectRecord = &record
+		if preparedProject != nil {
+			result.ProjectWorkspace = preparedProject.result
+		}
 	}
 
 	index := 0
@@ -806,6 +855,17 @@ func (m *Manager) AdoptGitHubPromotion(input GitHubAdoptInput) (*GitHubAdoptResu
 				return nil, err
 			}
 		}
+	}
+	if preparedProject != nil {
+		if err := m.populateProjectWorkspaceItems(info.ProjectDir, state.Repo, preparedProject, initiativeIssue, specIssuesBySlug, draft.ProposedSpecIssues); err != nil {
+			return nil, err
+		}
+		if projectRecord != nil {
+			projectRecord.UpdatedAt = time.Now().UTC().Format(time.RFC3339)
+			state.ProjectDecisions[projectRecord.Slug] = *projectRecord
+			result.ProjectDecision = projectRecord
+		}
+		result.ProjectWorkspace = preparedProject.result
 	}
 	for slug, specIssue := range specIssuesBySlug {
 		specDraft := specDraftsBySlug[slug]
@@ -1703,18 +1763,30 @@ func shouldRecommendProject(specCount int, deps []PromotionDependencyPlan) bool 
 	return false
 }
 
-func validateProjectDecision(decision string, draft *PromotionDraft) error {
+func validateProjectDecision(decision string, draft *PromotionDraft, ref GitHubProjectReference) error {
 	decision = normalizeProjectDecision(decision)
 	switch decision {
 	case "", projectDecisionCreate, projectDecisionSkip, projectDecisionConnect:
 	default:
-		return fmt.Errorf("unsupported project decision %q; use create or skip; connect is reserved and not yet implemented", decision)
+		return fmt.Errorf("unsupported project decision %q; use create, skip, or connect", decision)
 	}
 	if requiresProjectDecision(draft) && decision == "" {
-		return fmt.Errorf("promotion has %d specs and requires --project-decision create|skip before apply; connect is reserved and not yet implemented", len(draft.ProposedSpecIssues))
+		return fmt.Errorf("promotion has %d specs and requires --project-decision create|skip|connect before apply", len(draft.ProposedSpecIssues))
 	}
 	if decision == projectDecisionConnect {
-		return fmt.Errorf("project decision %q requires project reference support, which is not implemented yet", decision)
+		if strings.TrimSpace(ref.ID) == "" && (strings.TrimSpace(ref.Owner) == "" || ref.Number <= 0) {
+			return fmt.Errorf("project decision %q requires --project-owner and --project-number, --project-url, or --project-id", decision)
+		}
+	}
+	if decision == projectDecisionCreate {
+		if ref.Number != 0 || strings.TrimSpace(ref.ID) != "" || strings.TrimSpace(ref.URL) != "" {
+			return fmt.Errorf("project decision %q creates a new Project; omit existing project number, id, and url", decision)
+		}
+	}
+	if decision == projectDecisionSkip {
+		if strings.TrimSpace(ref.Owner) != "" || ref.Number != 0 || strings.TrimSpace(ref.ID) != "" || strings.TrimSpace(ref.URL) != "" {
+			return fmt.Errorf("project decision %q skips Project provisioning; omit project reference flags", decision)
+		}
 	}
 	return nil
 }
@@ -1727,7 +1799,7 @@ func requiresProjectDecision(draft *PromotionDraft) bool {
 	return draft != nil && len(draft.ProposedSpecIssues) >= 5
 }
 
-func buildProjectDecisionRecord(draft *PromotionDraft, decision string, milestone *GitHubMilestone) workspace.GitHubProjectDecisionRecord {
+func buildProjectDecisionRecord(draft *PromotionDraft, decision string, milestone *GitHubMilestone, ref GitHubProjectReference) workspace.GitHubProjectDecisionRecord {
 	now := time.Now().UTC().Format(time.RFC3339)
 	slug := promotionProjectDecisionSlug(draft)
 	record := workspace.GitHubProjectDecisionRecord{
@@ -1737,6 +1809,10 @@ func buildProjectDecisionRecord(draft *PromotionDraft, decision string, mileston
 		SpecCount:        len(draft.ProposedSpecIssues),
 		MilestoneNumber:  milestoneNumberOrZero(milestone),
 		MilestoneTitle:   milestoneTitle(milestone),
+		ProjectOwner:     ref.Owner,
+		ProjectNumber:    ref.Number,
+		ProjectID:        ref.ID,
+		ProjectURL:       ref.URL,
 		SourceMode:       string(draft.Source.Mode),
 		EntryMode:        string(draft.Source.EntryMode),
 		DiscussionNumber: discussionNumber(draft.Source.Discussion),
@@ -1849,7 +1925,7 @@ func manualFallbackAdoptCommand(draft *PromotionDraft) string {
 	}
 	args = append(args, "--issues", strings.Join(placeholders, ","))
 	if requiresProjectDecision(draft) {
-		args = append(args, "--project-decision", "<create|skip>")
+		args = append(args, "--project-decision", "<create|skip|connect>")
 	}
 	args = append(args, "--format", "json")
 	return shellCommand(args)

--- a/internal/planning/collaboration_test.go
+++ b/internal/planning/collaboration_test.go
@@ -277,8 +277,21 @@ func TestSixSpecProsePromotesAsMultiSpecWithProjectDecision(t *testing.T) {
 		Confirm:       true,
 		TargetMode:    SourceOfTruthGitHub,
 	})
-	if err == nil || !strings.Contains(err.Error(), "--project-decision create|skip") {
+	if err == nil || !strings.Contains(err.Error(), "--project-decision create|skip|connect") {
 		t.Fatalf("expected project decision gate, got %v", err)
+	}
+
+	_, err = manager.ApplyPromotionDraft(PromotionApplyInput{
+		DiscussionRef:   "88",
+		Confirm:         true,
+		TargetMode:      SourceOfTruthGitHub,
+		ProjectDecision: "connect",
+	})
+	if err == nil || !strings.Contains(err.Error(), "requires project reference support") {
+		t.Fatalf("expected connect project-reference error, got %v", err)
+	}
+	if len(client.issues) != 0 {
+		t.Fatalf("connect decision should fail before mutating GitHub issues: %+v", client.issues)
 	}
 
 	result, err := manager.ApplyPromotionDraft(PromotionApplyInput{
@@ -295,6 +308,15 @@ func TestSixSpecProsePromotesAsMultiSpecWithProjectDecision(t *testing.T) {
 	}
 	if result.ProjectDecision == nil || result.ProjectDecision.Decision != "create" {
 		t.Fatalf("expected project decision record: %+v", result.ProjectDecision)
+	}
+	if result.ProjectDecision.InitiativeSlug == "" || result.ProjectDecision.InitiativeSlug != result.ProjectDecision.Slug {
+		t.Fatalf("expected initiative slug on project decision record: %+v", result.ProjectDecision)
+	}
+	if result.ProjectDecision.MilestoneNumber != result.Milestone.Number || result.ProjectDecision.MilestoneTitle != result.Milestone.Title {
+		t.Fatalf("expected milestone identity on project decision record: %+v", result.ProjectDecision)
+	}
+	if result.ProjectDecision.ProjectOwner != "" || result.ProjectDecision.ProjectNumber != 0 || result.ProjectDecision.ProjectID != "" || result.ProjectDecision.ProjectURL != "" || len(result.ProjectDecision.FieldIDs) != 0 {
+		t.Fatalf("project identity should stay unset until project provisioning: %+v", result.ProjectDecision)
 	}
 	if !containsString(result.Initiative.Labels, planIssueInitiativeLabel) {
 		t.Fatalf("expected initiative label: %+v", result.Initiative.Labels)

--- a/internal/planning/collaboration_test.go
+++ b/internal/planning/collaboration_test.go
@@ -3,6 +3,7 @@ package planning
 import (
 	"encoding/json"
 	"errors"
+	"strconv"
 	"strings"
 	"testing"
 
@@ -277,7 +278,7 @@ func TestSixSpecProsePromotesAsMultiSpecWithProjectDecision(t *testing.T) {
 		Confirm:       true,
 		TargetMode:    SourceOfTruthGitHub,
 	})
-	if err == nil || !strings.Contains(err.Error(), "--project-decision create|skip") {
+	if err == nil || !strings.Contains(err.Error(), "--project-decision create|skip|connect") {
 		t.Fatalf("expected project decision gate, got %v", err)
 	}
 
@@ -287,7 +288,7 @@ func TestSixSpecProsePromotesAsMultiSpecWithProjectDecision(t *testing.T) {
 		TargetMode:      SourceOfTruthGitHub,
 		ProjectDecision: "connect",
 	})
-	if err == nil || !strings.Contains(err.Error(), "requires project reference support") {
+	if err == nil || !strings.Contains(err.Error(), "requires --project-owner and --project-number") {
 		t.Fatalf("expected connect project-reference error, got %v", err)
 	}
 	if len(client.issues) != 0 {
@@ -315,8 +316,23 @@ func TestSixSpecProsePromotesAsMultiSpecWithProjectDecision(t *testing.T) {
 	if result.ProjectDecision.MilestoneNumber != result.Milestone.Number || result.ProjectDecision.MilestoneTitle != result.Milestone.Title {
 		t.Fatalf("expected milestone identity on project decision record: %+v", result.ProjectDecision)
 	}
-	if result.ProjectDecision.ProjectOwner != "" || result.ProjectDecision.ProjectNumber != 0 || result.ProjectDecision.ProjectID != "" || result.ProjectDecision.ProjectURL != "" || len(result.ProjectDecision.FieldIDs) != 0 {
-		t.Fatalf("project identity should stay unset until project provisioning: %+v", result.ProjectDecision)
+	if result.ProjectDecision.ProjectOwner != "JimmyMcBride" || result.ProjectDecision.ProjectNumber == 0 || result.ProjectDecision.ProjectID == "" || result.ProjectDecision.ProjectURL == "" || len(result.ProjectDecision.FieldIDs) != 5 {
+		t.Fatalf("expected project identity after provisioning: %+v", result.ProjectDecision)
+	}
+	if result.ProjectWorkspace == nil || len(result.ProjectWorkspace.Items) != 7 || len(result.ProjectWorkspace.SavedViewInstructions) == 0 {
+		t.Fatalf("expected project workspace provisioning result: %+v", result.ProjectWorkspace)
+	}
+	if len(client.createdProjects) != 1 || client.createdProjects[0].Title != "Pre-planning Center Product Readiness" {
+		t.Fatalf("expected one created project: %+v", client.createdProjects)
+	}
+	if len(client.projectItems) != 7 {
+		t.Fatalf("expected initiative plus spec project items: %+v", client.projectItems)
+	}
+	if !stubHasProjectValue(client.projectValues, result.Initiative.Number, projectFieldType, projectValueTracking) {
+		t.Fatalf("expected initiative type tracking value: %+v", client.projectValues)
+	}
+	if !stubHasProjectValue(client.projectValues, result.Specs[0].Number, projectFieldReady, projectValueYes) {
+		t.Fatalf("expected ready spec value: %+v", client.projectValues)
 	}
 	if !containsString(result.Initiative.Labels, planIssueInitiativeLabel) {
 		t.Fatalf("expected initiative label: %+v", result.Initiative.Labels)
@@ -335,6 +351,108 @@ func TestSixSpecProsePromotesAsMultiSpecWithProjectDecision(t *testing.T) {
 	}
 	if len(state.ProjectDecisions) != 1 {
 		t.Fatalf("expected project decision metadata: %+v", state.ProjectDecisions)
+	}
+}
+
+func TestApplyPromotionDraftConnectsExistingProjectWorkspace(t *testing.T) {
+	client := &stubGitHubClient{
+		preflight: &GitHubRepoInfo{
+			Repo:          "JimmyMcBride/plan",
+			RepoURL:       "https://github.com/JimmyMcBride/plan",
+			DefaultBranch: "develop",
+		},
+		context: &GitHubContext{
+			Repo: GitHubRepoInfo{
+				Repo:          "JimmyMcBride/plan",
+				RepoURL:       "https://github.com/JimmyMcBride/plan",
+				DefaultBranch: "develop",
+			},
+			CurrentBranch: "develop",
+			CurrentSHA:    "abc123",
+		},
+		projects: map[int]*GitHubProjectWorkspace{
+			12: {
+				Owner:  "JimmyMcBride",
+				Number: 12,
+				ID:     "PVT_existing",
+				URL:    "https://github.com/users/JimmyMcBride/projects/12",
+				Title:  "Existing Workspace",
+			},
+		},
+		discussions: map[int]*GitHubDiscussion{
+			90: {
+				Number: 90,
+				URL:    "https://github.com/JimmyMcBride/plan/discussions/90",
+				Title:  "Connected Workspace",
+				Body: strings.Join([]string{
+					"## Problem",
+					"Existing project workspaces need Plan-managed cards.",
+					"",
+					"## Goals",
+					"Connect existing projects and seed initiative/spec items.",
+					"",
+					"## Non-Goals",
+					"Do not create saved views.",
+					"",
+					"## Constraints",
+					"Keep field setup deterministic.",
+					"",
+					"## Proposed Shape",
+					"Use a connected GitHub Project and add issue items.",
+					"",
+					"## Spec Split",
+					"- Project connect schema",
+					"- Project item values",
+					"",
+					"Project item values depends on Project connect schema.",
+				}, "\n"),
+			},
+		},
+	}
+	reset := SetGitHubClientFactoryForTesting(func() GitHubClient { return client })
+	t.Cleanup(reset)
+
+	root := t.TempDir()
+	ws := workspace.New(root)
+	if _, err := ws.Init(); err != nil {
+		t.Fatal(err)
+	}
+	manager := New(ws)
+
+	result, err := manager.ApplyPromotionDraft(PromotionApplyInput{
+		DiscussionRef:   "90",
+		Confirm:         true,
+		TargetMode:      SourceOfTruthGitHub,
+		ProjectDecision: "connect",
+		ProjectOwner:    "JimmyMcBride",
+		ProjectNumber:   12,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(client.createdProjects) != 0 {
+		t.Fatalf("connect should not create a project: %+v", client.createdProjects)
+	}
+	if result.ProjectDecision == nil || result.ProjectDecision.Decision != "connect" || result.ProjectDecision.ProjectID != "PVT_existing" || result.ProjectDecision.ProjectNumber != 12 {
+		t.Fatalf("expected connected project decision metadata: %+v", result.ProjectDecision)
+	}
+	if result.ProjectWorkspace == nil || len(result.ProjectWorkspace.Items) != 3 || len(result.ProjectWorkspace.SavedViewInstructions) != 3 {
+		t.Fatalf("expected project workspace output: %+v", result.ProjectWorkspace)
+	}
+	if !stubHasProjectValue(client.projectValues, result.Specs[0].Number, projectFieldReady, projectValueYes) {
+		t.Fatalf("expected first spec to be ready: %+v", client.projectValues)
+	}
+	if !stubHasProjectValue(client.projectValues, result.Specs[1].Number, projectFieldReady, projectValueNo) {
+		t.Fatalf("expected blocked spec to be not ready: %+v", client.projectValues)
+	}
+
+	state, err := ws.ReadGitHubState()
+	if err != nil {
+		t.Fatal(err)
+	}
+	record := state.ProjectDecisions["connected-workspace"]
+	if record.ProjectID != "PVT_existing" || len(record.FieldIDs) != 5 {
+		t.Fatalf("expected persisted project metadata: %+v", record)
 	}
 }
 
@@ -569,6 +687,16 @@ func createReadyCollaborationBrainstormForTest(t *testing.T, manager *Manager, s
 	}); err != nil {
 		t.Fatal(err)
 	}
+}
+
+func stubHasProjectValue(values []stubProjectValue, issueNumber int, field, value string) bool {
+	itemID := "PVTI_" + strconv.Itoa(issueNumber)
+	for _, current := range values {
+		if current.ItemID == itemID && current.Field == field && current.Value == value {
+			return true
+		}
+	}
+	return false
 }
 
 func TestApplyPromotionDraftWiresBlockedByAfterAllIssuesExist(t *testing.T) {

--- a/internal/planning/collaboration_test.go
+++ b/internal/planning/collaboration_test.go
@@ -288,7 +288,7 @@ func TestSixSpecProsePromotesAsMultiSpecWithProjectDecision(t *testing.T) {
 		TargetMode:      SourceOfTruthGitHub,
 		ProjectDecision: "connect",
 	})
-	if err == nil || !strings.Contains(err.Error(), "requires --project-owner and --project-number") {
+	if err == nil || !strings.Contains(err.Error(), "requires either --project-owner and --project-number") {
 		t.Fatalf("expected connect project-reference error, got %v", err)
 	}
 	if len(client.issues) != 0 {
@@ -658,6 +658,18 @@ func TestBuildPromotionDraftNotReadyUsesEmptySpecSliceInJSON(t *testing.T) {
 	}
 	if !strings.Contains(string(raw), `"proposed_spec_issues":[]`) {
 		t.Fatalf("expected stable empty array in json output: %s", string(raw))
+	}
+}
+
+func TestValidateProjectDecisionRejectsReferenceFlagsWithoutDecision(t *testing.T) {
+	draft := &PromotionDraft{
+		ProposedSpecIssues: []PromotionIssueDraft{
+			{Title: "Small spec", Slug: "small-spec"},
+		},
+	}
+	err := validateProjectDecision("", draft, GitHubProjectReference{Owner: "JimmyMcBride", Number: 12})
+	if err == nil || !strings.Contains(err.Error(), "project reference flags require --project-decision") {
+		t.Fatalf("expected project reference flag validation error, got %v", err)
 	}
 }
 

--- a/internal/planning/collaboration_test.go
+++ b/internal/planning/collaboration_test.go
@@ -277,7 +277,7 @@ func TestSixSpecProsePromotesAsMultiSpecWithProjectDecision(t *testing.T) {
 		Confirm:       true,
 		TargetMode:    SourceOfTruthGitHub,
 	})
-	if err == nil || !strings.Contains(err.Error(), "--project-decision create|skip|connect") {
+	if err == nil || !strings.Contains(err.Error(), "--project-decision create|skip") {
 		t.Fatalf("expected project decision gate, got %v", err)
 	}
 

--- a/internal/planning/github_backend_test.go
+++ b/internal/planning/github_backend_test.go
@@ -22,11 +22,22 @@ type stubGitHubClient struct {
 	discussions      map[int]*GitHubDiscussion
 	subIssues        [][2]int
 	blockedByEdges   [][2]int
+	projects         map[int]*GitHubProjectWorkspace
+	createdProjects  []GitHubProjectWorkspaceInput
+	projectItems     []GitHubProjectItemResult
+	projectValues    []stubProjectValue
 	nextIssue        int
+	nextProject      int
 	lastCreate       GitHubIssueInput
 	lastUpdate       GitHubIssueInput
 	createIssueErr   error
 	ensureLabelErr   error
+}
+
+type stubProjectValue struct {
+	ItemID string
+	Field  string
+	Value  string
 }
 
 func (s *stubGitHubClient) Preflight(projectDir string) (*GitHubRepoInfo, error) {
@@ -204,6 +215,112 @@ func (s *stubGitHubClient) AddSubIssue(projectDir, repo string, issueNumber, sub
 func (s *stubGitHubClient) AddBlockedBy(projectDir, repo string, issueNumber, blockingIssueNumber int) error {
 	s.blockedByEdges = append(s.blockedByEdges, [2]int{issueNumber, blockingIssueNumber})
 	return nil
+}
+
+func (s *stubGitHubClient) CreateProjectWorkspace(projectDir, repo string, input GitHubProjectWorkspaceInput) (*GitHubProjectWorkspace, error) {
+	s.createdProjects = append(s.createdProjects, input)
+	if s.projects == nil {
+		s.projects = map[int]*GitHubProjectWorkspace{}
+	}
+	if s.nextProject == 0 {
+		s.nextProject = 1
+	}
+	owner := strings.TrimSpace(input.Owner)
+	if owner == "" {
+		owner = strings.Split(repo, "/")[0]
+	}
+	project := &GitHubProjectWorkspace{
+		Owner:  owner,
+		Number: s.nextProject,
+		ID:     fmt.Sprintf("PVT_%d", s.nextProject),
+		URL:    fmt.Sprintf("https://github.com/users/%s/projects/%d", owner, s.nextProject),
+		Title:  input.Title,
+	}
+	s.projects[project.Number] = project
+	s.nextProject++
+	copy := copyStubProject(project)
+	return copy, nil
+}
+
+func (s *stubGitHubClient) GetProjectWorkspace(projectDir, repo string, ref GitHubProjectReference) (*GitHubProjectWorkspace, error) {
+	if s.projects == nil {
+		return nil, fmt.Errorf("project not found")
+	}
+	for _, project := range s.projects {
+		if strings.TrimSpace(ref.ID) != "" && project.ID == ref.ID {
+			return copyStubProject(project), nil
+		}
+		if strings.EqualFold(project.Owner, ref.Owner) && project.Number == ref.Number {
+			return copyStubProject(project), nil
+		}
+	}
+	return nil, fmt.Errorf("project not found")
+}
+
+func (s *stubGitHubClient) EnsureProjectField(projectDir string, project GitHubProjectWorkspace, input GitHubProjectFieldInput) (*GitHubProjectField, error) {
+	stored := s.projects[project.Number]
+	if stored == nil {
+		stored = &project
+		if s.projects == nil {
+			s.projects = map[int]*GitHubProjectWorkspace{}
+		}
+		s.projects[project.Number] = stored
+	}
+	for _, field := range stored.Fields {
+		if strings.EqualFold(field.Name, input.Name) {
+			copy := field
+			copy.Options = copyStringMap(field.Options)
+			return &copy, nil
+		}
+	}
+	field := GitHubProjectField{
+		ID:       fmt.Sprintf("PVTF_%s", slugify(input.Name)),
+		Name:     input.Name,
+		DataType: input.DataType,
+	}
+	if len(input.Options) > 0 {
+		field.Options = map[string]string{}
+		for _, option := range input.Options {
+			field.Options[option] = fmt.Sprintf("PVTO_%s_%s", slugify(input.Name), slugify(option))
+		}
+	}
+	stored.Fields = append(stored.Fields, field)
+	copy := field
+	copy.Options = copyStringMap(field.Options)
+	return &copy, nil
+}
+
+func (s *stubGitHubClient) AddProjectItemByIssue(projectDir, repo, projectID string, issueNumber int) (*GitHubProjectItem, error) {
+	item := GitHubProjectItem{
+		ID:          fmt.Sprintf("PVTI_%d", issueNumber),
+		IssueNumber: issueNumber,
+	}
+	s.projectItems = append(s.projectItems, GitHubProjectItemResult{
+		IssueNumber: issueNumber,
+		ItemID:      item.ID,
+	})
+	return &item, nil
+}
+
+func (s *stubGitHubClient) SetProjectItemField(projectDir, projectID, itemID string, field GitHubProjectField, value string) error {
+	s.projectValues = append(s.projectValues, stubProjectValue{
+		ItemID: itemID,
+		Field:  field.Name,
+		Value:  value,
+	})
+	return nil
+}
+
+func copyStubProject(project *GitHubProjectWorkspace) *GitHubProjectWorkspace {
+	if project == nil {
+		return nil
+	}
+	copy := *project
+	copy.Fields = append([]GitHubProjectField(nil), project.Fields...)
+	for i := range copy.Fields {
+		copy.Fields[i].Options = copyStringMap(project.Fields[i].Options)
+	}
+	return &copy
 }
 
 func TestEnableGitHubBackendPersistsRepoConfigAfterPreflight(t *testing.T) {

--- a/internal/planning/github_client.go
+++ b/internal/planning/github_client.go
@@ -68,6 +68,7 @@ type GitHubIssueInput struct {
 
 type GitHubIssue struct {
 	Number    int
+	NodeID    string
 	URL       string
 	Title     string
 	Body      string
@@ -155,7 +156,9 @@ func SetGitHubClientFactoryForTesting(factory func() GitHubClient) func() {
 	}
 }
 
-type cliGitHubClient struct{}
+type cliGitHubClient struct {
+	issueNodeIDs map[string]string
+}
 
 const gitHubIssueListLimit = 1000
 
@@ -292,7 +295,12 @@ func (c *cliGitHubClient) upsertIssue(projectDir, apiPath string, input GitHubIs
 	if err != nil {
 		return nil, err
 	}
-	return parseGitHubIssue(out)
+	issue, err := parseGitHubIssue(out)
+	if err != nil {
+		return nil, err
+	}
+	c.cacheIssueNodeID(repoFromIssueAPIPath(apiPath), issue)
+	return issue, nil
 }
 
 func (c *cliGitHubClient) GetIssue(projectDir, repo string, issueNumber int) (*GitHubIssue, error) {
@@ -300,11 +308,16 @@ func (c *cliGitHubClient) GetIssue(projectDir, repo string, issueNumber int) (*G
 	if err != nil {
 		return nil, err
 	}
-	return parseGitHubIssue(out)
+	issue, err := parseGitHubIssue(out)
+	if err != nil {
+		return nil, err
+	}
+	c.cacheIssueNodeID(repo, issue)
+	return issue, nil
 }
 
 func (c *cliGitHubClient) ListIssuesByLabel(projectDir, repo string, labels []string) ([]GitHubIssue, error) {
-	args := []string{"issue", "list", "--repo", repo, "--state", "all", "--limit", strconv.Itoa(gitHubIssueListLimit), "--json", "number,url,title,body,state,labels,milestone"}
+	args := []string{"issue", "list", "--repo", repo, "--state", "all", "--limit", strconv.Itoa(gitHubIssueListLimit), "--json", "id,number,url,title,body,state,labels,milestone"}
 	for _, label := range labels {
 		if strings.TrimSpace(label) == "" {
 			continue
@@ -321,6 +334,9 @@ func (c *cliGitHubClient) ListIssuesByLabel(projectDir, repo string, labels []st
 	}
 	if len(issues) >= gitHubIssueListLimit {
 		return nil, fmt.Errorf("GitHub issue listing for labels %s reached the %d issue safety limit; rerun with a narrower Plan label or add pagination before relying on drift checks", strings.Join(labels, ","), gitHubIssueListLimit)
+	}
+	for i := range issues {
+		c.cacheIssueNodeID(repo, &issues[i])
 	}
 	return issues, nil
 }
@@ -840,9 +856,14 @@ func (c *cliGitHubClient) EnsureProjectField(projectDir string, project GitHubPr
 }
 
 func (c *cliGitHubClient) AddProjectItemByIssue(projectDir, repo, projectID string, issueNumber int) (*GitHubProjectItem, error) {
-	issueID, err := c.issueID(projectDir, repo, issueNumber)
-	if err != nil {
-		return nil, err
+	issueID := c.cachedIssueNodeID(repo, issueNumber)
+	if strings.TrimSpace(issueID) == "" {
+		var err error
+		issueID, err = c.issueID(projectDir, repo, issueNumber)
+		if err != nil {
+			return nil, err
+		}
+		c.cacheIssueNodeIDValue(repo, issueNumber, issueID)
 	}
 	payload := map[string]any{
 		"query": `mutation($projectId:ID!, $contentId:ID!) {
@@ -1159,6 +1180,45 @@ func (c *cliGitHubClient) issueID(projectDir, repo string, issueNumber int) (str
 	return response.Data.Repository.Issue.ID, nil
 }
 
+func (c *cliGitHubClient) cacheIssueNodeID(repo string, issue *GitHubIssue) {
+	if issue == nil {
+		return
+	}
+	c.cacheIssueNodeIDValue(repo, issue.Number, issue.NodeID)
+}
+
+func (c *cliGitHubClient) cacheIssueNodeIDValue(repo string, issueNumber int, nodeID string) {
+	repo = strings.TrimSpace(repo)
+	nodeID = strings.TrimSpace(nodeID)
+	if repo == "" || issueNumber <= 0 || nodeID == "" {
+		return
+	}
+	if c.issueNodeIDs == nil {
+		c.issueNodeIDs = map[string]string{}
+	}
+	c.issueNodeIDs[issueNodeCacheKey(repo, issueNumber)] = nodeID
+}
+
+func (c *cliGitHubClient) cachedIssueNodeID(repo string, issueNumber int) string {
+	if c.issueNodeIDs == nil {
+		return ""
+	}
+	return c.issueNodeIDs[issueNodeCacheKey(repo, issueNumber)]
+}
+
+func issueNodeCacheKey(repo string, issueNumber int) string {
+	return fmt.Sprintf("%s#%d", strings.TrimSpace(repo), issueNumber)
+}
+
+func repoFromIssueAPIPath(apiPath string) string {
+	trimmed := strings.TrimPrefix(strings.TrimSpace(apiPath), "repos/")
+	parts := strings.Split(trimmed, "/")
+	if len(parts) < 3 || parts[0] == "" || parts[1] == "" || parts[2] != "issues" {
+		return ""
+	}
+	return parts[0] + "/" + parts[1]
+}
+
 func (c *cliGitHubClient) issueIDs(projectDir, repo string, issueNumber, otherIssueNumber int) (string, string, error) {
 	owner, name, err := splitRepo(repo)
 	if err != nil {
@@ -1261,6 +1321,7 @@ func parseGitHubIssue(raw []byte) (*GitHubIssue, error) {
 	}
 	type payload struct {
 		Number    int     `json:"number"`
+		NodeID    string  `json:"node_id"`
 		URL       string  `json:"html_url"`
 		Title     string  `json:"title"`
 		Body      string  `json:"body"`
@@ -1277,6 +1338,7 @@ func parseGitHubIssue(raw []byte) (*GitHubIssue, error) {
 	}
 	issue := &GitHubIssue{
 		Number: item.Number,
+		NodeID: item.NodeID,
 		URL:    item.URL,
 		Title:  item.Title,
 		Body:   item.Body,
@@ -1303,6 +1365,7 @@ func parseGitHubIssueList(raw []byte) ([]GitHubIssue, error) {
 	}
 	type payload struct {
 		Number    int     `json:"number"`
+		NodeID    string  `json:"id"`
 		URL       string  `json:"url"`
 		Title     string  `json:"title"`
 		Body      string  `json:"body"`
@@ -1321,6 +1384,7 @@ func parseGitHubIssueList(raw []byte) ([]GitHubIssue, error) {
 	for _, item := range items {
 		issue := GitHubIssue{
 			Number: item.Number,
+			NodeID: item.NodeID,
 			URL:    item.URL,
 			Title:  item.Title,
 			Body:   item.Body,

--- a/internal/planning/github_client.go
+++ b/internal/planning/github_client.go
@@ -24,6 +24,11 @@ type GitHubClient interface {
 	UpdateDiscussionBody(projectDir, repo string, number int, body string) (*GitHubDiscussion, error)
 	AddSubIssue(projectDir, repo string, issueNumber, subIssueNumber int) error
 	AddBlockedBy(projectDir, repo string, issueNumber, blockingIssueNumber int) error
+	CreateProjectWorkspace(projectDir, repo string, input GitHubProjectWorkspaceInput) (*GitHubProjectWorkspace, error)
+	GetProjectWorkspace(projectDir, repo string, ref GitHubProjectReference) (*GitHubProjectWorkspace, error)
+	EnsureProjectField(projectDir string, project GitHubProjectWorkspace, input GitHubProjectFieldInput) (*GitHubProjectField, error)
+	AddProjectItemByIssue(projectDir, repo, projectID string, issueNumber int) (*GitHubProjectItem, error)
+	SetProjectItemField(projectDir, projectID, itemID string, field GitHubProjectField, value string) error
 }
 
 type GitHubRepoInfo struct {
@@ -97,6 +102,45 @@ type GitHubDiscussion struct {
 
 type GitHubDiscussionComment struct {
 	Body string
+}
+
+type GitHubProjectReference struct {
+	Owner  string
+	Number int
+	ID     string
+	URL    string
+}
+
+type GitHubProjectWorkspaceInput struct {
+	Owner string
+	Title string
+}
+
+type GitHubProjectWorkspace struct {
+	Owner  string
+	Number int
+	ID     string
+	URL    string
+	Title  string
+	Fields []GitHubProjectField
+}
+
+type GitHubProjectFieldInput struct {
+	Name     string
+	DataType string
+	Options  []string
+}
+
+type GitHubProjectField struct {
+	ID       string
+	Name     string
+	DataType string
+	Options  map[string]string
+}
+
+type GitHubProjectItem struct {
+	ID          string
+	IssueNumber int
 }
 
 var newGitHubClient = func() GitHubClient {
@@ -546,6 +590,401 @@ func (c *cliGitHubClient) AddBlockedBy(projectDir, repo string, issueNumber, blo
 	return c.graphql(projectDir, payload, nil)
 }
 
+func (c *cliGitHubClient) CreateProjectWorkspace(projectDir, repo string, input GitHubProjectWorkspaceInput) (*GitHubProjectWorkspace, error) {
+	owner := strings.TrimSpace(input.Owner)
+	if owner == "" {
+		repoOwner, _, err := splitRepo(repo)
+		if err != nil {
+			return nil, err
+		}
+		owner = repoOwner
+	}
+	title := strings.TrimSpace(input.Title)
+	if title == "" {
+		return nil, fmt.Errorf("project title is required")
+	}
+	ownerID, repoID, err := c.projectOwnerAndRepositoryIDs(projectDir, repo, owner)
+	if err != nil {
+		return nil, err
+	}
+	payload := map[string]any{
+		"query": `mutation($ownerId:ID!, $repositoryId:ID!, $title:String!) {
+  createProjectV2(input:{ownerId:$ownerId, repositoryId:$repositoryId, title:$title}) {
+    projectV2 {
+      id
+      number
+      url
+      title
+      fields(first:100) {
+        nodes {
+          __typename
+          ... on ProjectV2Field {
+            id
+            name
+            dataType
+          }
+          ... on ProjectV2SingleSelectField {
+            id
+            name
+            dataType
+            options {
+              id
+              name
+            }
+          }
+        }
+      }
+    }
+  }
+}`,
+		"variables": map[string]any{
+			"ownerId":      ownerID,
+			"repositoryId": repoID,
+			"title":        title,
+		},
+	}
+	var response struct {
+		Data struct {
+			CreateProjectV2 struct {
+				ProjectV2 projectV2Payload `json:"projectV2"`
+			} `json:"createProjectV2"`
+		} `json:"data"`
+	}
+	if err := c.graphql(projectDir, payload, &response); err != nil {
+		return nil, err
+	}
+	project := projectWorkspaceFromPayload(owner, response.Data.CreateProjectV2.ProjectV2)
+	if strings.TrimSpace(project.ID) == "" {
+		return nil, fmt.Errorf("created GitHub Project did not include an id")
+	}
+	return project, nil
+}
+
+func (c *cliGitHubClient) GetProjectWorkspace(projectDir, repo string, ref GitHubProjectReference) (*GitHubProjectWorkspace, error) {
+	if strings.TrimSpace(ref.ID) != "" {
+		return c.getProjectWorkspaceByID(projectDir, strings.TrimSpace(ref.ID), strings.TrimSpace(ref.Owner))
+	}
+	owner := strings.TrimSpace(ref.Owner)
+	if owner == "" {
+		return nil, fmt.Errorf("project owner is required to connect an existing GitHub Project")
+	}
+	if ref.Number <= 0 {
+		return nil, fmt.Errorf("project number is required to connect an existing GitHub Project")
+	}
+	payload := map[string]any{
+		"query": `query($owner:String!, $number:Int!) {
+  repositoryOwner(login:$owner) {
+    login
+    ... on User {
+      projectV2(number:$number) {
+        id
+        number
+        url
+        title
+        fields(first:100) {
+          nodes {
+            __typename
+            ... on ProjectV2Field {
+              id
+              name
+              dataType
+            }
+            ... on ProjectV2SingleSelectField {
+              id
+              name
+              dataType
+              options {
+                id
+                name
+              }
+            }
+          }
+        }
+      }
+    }
+    ... on Organization {
+      projectV2(number:$number) {
+        id
+        number
+        url
+        title
+        fields(first:100) {
+          nodes {
+            __typename
+            ... on ProjectV2Field {
+              id
+              name
+              dataType
+            }
+            ... on ProjectV2SingleSelectField {
+              id
+              name
+              dataType
+              options {
+                id
+                name
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}`,
+		"variables": map[string]any{
+			"owner":  owner,
+			"number": ref.Number,
+		},
+	}
+	var response struct {
+		Data struct {
+			RepositoryOwner *struct {
+				Login   string           `json:"login"`
+				Project projectV2Payload `json:"projectV2"`
+			} `json:"repositoryOwner"`
+		} `json:"data"`
+	}
+	if err := c.graphql(projectDir, payload, &response); err != nil {
+		return nil, err
+	}
+	if response.Data.RepositoryOwner == nil {
+		return nil, fmt.Errorf("GitHub Project owner %q not found", owner)
+	}
+	project := projectWorkspaceFromPayload(owner, response.Data.RepositoryOwner.Project)
+	if strings.TrimSpace(project.ID) == "" {
+		return nil, fmt.Errorf("GitHub Project %s/%d not found", owner, ref.Number)
+	}
+	return project, nil
+}
+
+func (c *cliGitHubClient) EnsureProjectField(projectDir string, project GitHubProjectWorkspace, input GitHubProjectFieldInput) (*GitHubProjectField, error) {
+	name := strings.TrimSpace(input.Name)
+	dataType := strings.TrimSpace(input.DataType)
+	if name == "" || dataType == "" {
+		return nil, fmt.Errorf("project field name and data type are required")
+	}
+	for _, field := range project.Fields {
+		if !strings.EqualFold(strings.TrimSpace(field.Name), name) {
+			continue
+		}
+		if !strings.EqualFold(strings.TrimSpace(field.DataType), dataType) {
+			return nil, fmt.Errorf("GitHub Project field %q has type %q; expected %q", field.Name, field.DataType, dataType)
+		}
+		missing := missingProjectFieldOptions(field, input.Options)
+		if len(missing) > 0 {
+			return nil, fmt.Errorf("GitHub Project field %q is missing options %s; add them manually or use a new Project because Plan does not edit existing single-select options without restoring affected item selections", field.Name, strings.Join(missing, ", "))
+		}
+		copy := field
+		copy.Options = copyStringMap(field.Options)
+		return &copy, nil
+	}
+	variables := map[string]any{
+		"projectId": project.ID,
+		"name":      name,
+		"dataType":  dataType,
+	}
+	if strings.EqualFold(dataType, "SINGLE_SELECT") {
+		options := make([]map[string]string, 0, len(input.Options))
+		for _, option := range input.Options {
+			option = strings.TrimSpace(option)
+			if option == "" {
+				continue
+			}
+			options = append(options, map[string]string{
+				"name":        option,
+				"color":       "GRAY",
+				"description": "",
+			})
+		}
+		variables["singleSelectOptions"] = options
+	}
+	payload := map[string]any{
+		"query": `mutation($projectId:ID!, $name:String!, $dataType:ProjectV2CustomFieldType!, $singleSelectOptions:[ProjectV2SingleSelectFieldOptionInput!]) {
+  createProjectV2Field(input:{projectId:$projectId, name:$name, dataType:$dataType, singleSelectOptions:$singleSelectOptions}) {
+    projectV2Field {
+      __typename
+      ... on ProjectV2Field {
+        id
+        name
+        dataType
+      }
+      ... on ProjectV2SingleSelectField {
+        id
+        name
+        dataType
+        options {
+          id
+          name
+        }
+      }
+    }
+  }
+}`,
+		"variables": variables,
+	}
+	var response struct {
+		Data struct {
+			CreateProjectV2Field struct {
+				ProjectV2Field projectV2FieldPayload `json:"projectV2Field"`
+			} `json:"createProjectV2Field"`
+		} `json:"data"`
+	}
+	if err := c.graphql(projectDir, payload, &response); err != nil {
+		return nil, err
+	}
+	field := projectFieldFromPayload(response.Data.CreateProjectV2Field.ProjectV2Field)
+	if strings.TrimSpace(field.ID) == "" {
+		return nil, fmt.Errorf("created GitHub Project field %q did not include an id", name)
+	}
+	return &field, nil
+}
+
+func (c *cliGitHubClient) AddProjectItemByIssue(projectDir, repo, projectID string, issueNumber int) (*GitHubProjectItem, error) {
+	issueID, err := c.issueID(projectDir, repo, issueNumber)
+	if err != nil {
+		return nil, err
+	}
+	payload := map[string]any{
+		"query": `mutation($projectId:ID!, $contentId:ID!) {
+  addProjectV2ItemById(input:{projectId:$projectId, contentId:$contentId}) {
+    item {
+      id
+    }
+  }
+}`,
+		"variables": map[string]any{
+			"projectId": projectID,
+			"contentId": issueID,
+		},
+	}
+	var response struct {
+		Data struct {
+			AddProjectV2ItemByID struct {
+				Item struct {
+					ID string `json:"id"`
+				} `json:"item"`
+			} `json:"addProjectV2ItemById"`
+		} `json:"data"`
+	}
+	if err := c.graphql(projectDir, payload, &response); err != nil {
+		return nil, err
+	}
+	if strings.TrimSpace(response.Data.AddProjectV2ItemByID.Item.ID) == "" {
+		return nil, fmt.Errorf("GitHub Project item for issue #%d did not include an id", issueNumber)
+	}
+	return &GitHubProjectItem{ID: response.Data.AddProjectV2ItemByID.Item.ID, IssueNumber: issueNumber}, nil
+}
+
+func (c *cliGitHubClient) SetProjectItemField(projectDir, projectID, itemID string, field GitHubProjectField, value string) error {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return nil
+	}
+	fieldValue := map[string]any{}
+	switch strings.ToUpper(strings.TrimSpace(field.DataType)) {
+	case "SINGLE_SELECT":
+		optionID := field.Options[value]
+		if strings.TrimSpace(optionID) == "" {
+			return fmt.Errorf("GitHub Project field %q does not have option %q", field.Name, value)
+		}
+		fieldValue["singleSelectOptionId"] = optionID
+	case "TEXT":
+		fieldValue["text"] = value
+	default:
+		return fmt.Errorf("unsupported GitHub Project field type %q for field %q", field.DataType, field.Name)
+	}
+	payload := map[string]any{
+		"query": `mutation($projectId:ID!, $itemId:ID!, $fieldId:ID!, $value:ProjectV2FieldValue!) {
+  updateProjectV2ItemFieldValue(input:{projectId:$projectId, itemId:$itemId, fieldId:$fieldId, value:$value}) {
+    projectV2Item {
+      id
+    }
+  }
+}`,
+		"variables": map[string]any{
+			"projectId": projectID,
+			"itemId":    itemID,
+			"fieldId":   field.ID,
+			"value":     fieldValue,
+		},
+	}
+	return c.graphql(projectDir, payload, nil)
+}
+
+type projectV2Payload struct {
+	ID     string `json:"id"`
+	Number int    `json:"number"`
+	URL    string `json:"url"`
+	Title  string `json:"title"`
+	Fields struct {
+		Nodes []projectV2FieldPayload `json:"nodes"`
+	} `json:"fields"`
+}
+
+type projectV2FieldPayload struct {
+	Typename string `json:"__typename"`
+	ID       string `json:"id"`
+	Name     string `json:"name"`
+	DataType string `json:"dataType"`
+	Options  []struct {
+		ID   string `json:"id"`
+		Name string `json:"name"`
+	} `json:"options"`
+}
+
+func projectWorkspaceFromPayload(owner string, payload projectV2Payload) *GitHubProjectWorkspace {
+	project := &GitHubProjectWorkspace{
+		Owner:  strings.TrimSpace(owner),
+		Number: payload.Number,
+		ID:     payload.ID,
+		URL:    payload.URL,
+		Title:  payload.Title,
+	}
+	for _, node := range payload.Fields.Nodes {
+		field := projectFieldFromPayload(node)
+		if strings.TrimSpace(field.ID) == "" {
+			continue
+		}
+		project.Fields = append(project.Fields, field)
+	}
+	return project
+}
+
+func projectFieldFromPayload(payload projectV2FieldPayload) GitHubProjectField {
+	field := GitHubProjectField{
+		ID:       payload.ID,
+		Name:     payload.Name,
+		DataType: payload.DataType,
+	}
+	if len(payload.Options) > 0 {
+		field.Options = map[string]string{}
+		for _, option := range payload.Options {
+			if strings.TrimSpace(option.Name) == "" || strings.TrimSpace(option.ID) == "" {
+				continue
+			}
+			field.Options[option.Name] = option.ID
+		}
+	}
+	return field
+}
+
+func missingProjectFieldOptions(field GitHubProjectField, required []string) []string {
+	if len(required) == 0 {
+		return nil
+	}
+	var missing []string
+	for _, option := range required {
+		option = strings.TrimSpace(option)
+		if option == "" {
+			continue
+		}
+		if strings.TrimSpace(field.Options[option]) == "" {
+			missing = append(missing, option)
+		}
+	}
+	return missing
+}
+
 func (c *cliGitHubClient) api(projectDir, method, apiPath string, payload any) ([]byte, error) {
 	args := []string{"api", "--method", method, apiPath}
 	var stdin []byte
@@ -573,6 +1012,151 @@ func (c *cliGitHubClient) graphql(projectDir string, payload any, target any) er
 		return err
 	}
 	return nil
+}
+
+func (c *cliGitHubClient) projectOwnerAndRepositoryIDs(projectDir, repo, projectOwner string) (string, string, error) {
+	repoOwner, repoName, err := splitRepo(repo)
+	if err != nil {
+		return "", "", err
+	}
+	payload := map[string]any{
+		"query": `query($projectOwner:String!, $repoOwner:String!, $repoName:String!) {
+  owner: repositoryOwner(login:$projectOwner) {
+    id
+  }
+  repository(owner:$repoOwner, name:$repoName) {
+    id
+  }
+}`,
+		"variables": map[string]any{
+			"projectOwner": projectOwner,
+			"repoOwner":    repoOwner,
+			"repoName":     repoName,
+		},
+	}
+	var response struct {
+		Data struct {
+			Owner *struct {
+				ID string `json:"id"`
+			} `json:"owner"`
+			Repository *struct {
+				ID string `json:"id"`
+			} `json:"repository"`
+		} `json:"data"`
+	}
+	if err := c.graphql(projectDir, payload, &response); err != nil {
+		return "", "", err
+	}
+	if response.Data.Owner == nil || strings.TrimSpace(response.Data.Owner.ID) == "" {
+		return "", "", fmt.Errorf("GitHub Project owner %q not found", projectOwner)
+	}
+	if response.Data.Repository == nil || strings.TrimSpace(response.Data.Repository.ID) == "" {
+		return "", "", fmt.Errorf("repository %q not found", repo)
+	}
+	return response.Data.Owner.ID, response.Data.Repository.ID, nil
+}
+
+func (c *cliGitHubClient) getProjectWorkspaceByID(projectDir, projectID, fallbackOwner string) (*GitHubProjectWorkspace, error) {
+	payload := map[string]any{
+		"query": `query($projectId:ID!) {
+  node(id:$projectId) {
+    ... on ProjectV2 {
+      id
+      number
+      url
+      title
+      owner {
+        ... on User {
+          login
+        }
+        ... on Organization {
+          login
+        }
+      }
+      fields(first:100) {
+        nodes {
+          __typename
+          ... on ProjectV2Field {
+            id
+            name
+            dataType
+          }
+          ... on ProjectV2SingleSelectField {
+            id
+            name
+            dataType
+            options {
+              id
+              name
+            }
+          }
+        }
+      }
+    }
+  }
+}`,
+		"variables": map[string]any{
+			"projectId": projectID,
+		},
+	}
+	var response struct {
+		Data struct {
+			Node *struct {
+				projectV2Payload
+				Owner struct {
+					Login string `json:"login"`
+				} `json:"owner"`
+			} `json:"node"`
+		} `json:"data"`
+	}
+	if err := c.graphql(projectDir, payload, &response); err != nil {
+		return nil, err
+	}
+	if response.Data.Node == nil || strings.TrimSpace(response.Data.Node.ID) == "" {
+		return nil, fmt.Errorf("GitHub Project id %q not found", projectID)
+	}
+	owner := strings.TrimSpace(response.Data.Node.Owner.Login)
+	if owner == "" {
+		owner = fallbackOwner
+	}
+	return projectWorkspaceFromPayload(owner, response.Data.Node.projectV2Payload), nil
+}
+
+func (c *cliGitHubClient) issueID(projectDir, repo string, issueNumber int) (string, error) {
+	owner, name, err := splitRepo(repo)
+	if err != nil {
+		return "", err
+	}
+	payload := map[string]any{
+		"query": `query($owner:String!, $name:String!, $issueNumber:Int!) {
+  repository(owner:$owner, name:$name) {
+    issue(number:$issueNumber) {
+      id
+    }
+  }
+}`,
+		"variables": map[string]any{
+			"owner":       owner,
+			"name":        name,
+			"issueNumber": issueNumber,
+		},
+	}
+	var response struct {
+		Data struct {
+			Repository struct {
+				Issue struct {
+					ID string `json:"id"`
+				} `json:"issue"`
+			} `json:"repository"`
+		} `json:"data"`
+	}
+	if err := c.graphql(projectDir, payload, &response); err != nil {
+		return "", err
+	}
+	if strings.TrimSpace(response.Data.Repository.Issue.ID) == "" {
+		return "", fmt.Errorf("could not resolve issue node id for #%d", issueNumber)
+	}
+	return response.Data.Repository.Issue.ID, nil
 }
 
 func (c *cliGitHubClient) issueIDs(projectDir, repo string, issueNumber, otherIssueNumber int) (string, string, error) {

--- a/internal/planning/github_client_test.go
+++ b/internal/planning/github_client_test.go
@@ -20,3 +20,57 @@ func TestDecodeGraphQLResponseAllowsNilTarget(t *testing.T) {
 		t.Fatalf("expected nil target to succeed: %v", err)
 	}
 }
+
+func TestParseGitHubIssueKeepsNodeID(t *testing.T) {
+	issue, err := parseGitHubIssue([]byte(`{
+		"number": 42,
+		"node_id": "I_kwExample",
+		"html_url": "https://github.com/JimmyMcBride/plan/issues/42",
+		"title": "Project item",
+		"body": "body",
+		"state": "open",
+		"labels": []
+	}`))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if issue.NodeID != "I_kwExample" {
+		t.Fatalf("expected node id to round-trip: %+v", issue)
+	}
+}
+
+func TestParseGitHubIssueListKeepsNodeID(t *testing.T) {
+	issues, err := parseGitHubIssueList([]byte(`[{
+		"number": 43,
+		"id": "I_kwList",
+		"url": "https://github.com/JimmyMcBride/plan/issues/43",
+		"title": "Listed project item",
+		"body": "body",
+		"state": "open",
+		"labels": []
+	}]`))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(issues) != 1 || issues[0].NodeID != "I_kwList" {
+		t.Fatalf("expected list node id to round-trip: %+v", issues)
+	}
+}
+
+func TestIssueNodeIDCache(t *testing.T) {
+	client := &cliGitHubClient{}
+	client.cacheIssueNodeID("JimmyMcBride/plan", &GitHubIssue{Number: 44, NodeID: "I_kwCached"})
+	if got := client.cachedIssueNodeID("JimmyMcBride/plan", 44); got != "I_kwCached" {
+		t.Fatalf("expected cached issue node id, got %q", got)
+	}
+}
+
+func TestParseGitHubProjectURLAllowsViewsAndWWW(t *testing.T) {
+	ref, err := parseGitHubProjectURL("https://www.github.com/users/JimmyMcBride/projects/12/views/3")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if ref.Owner != "JimmyMcBride" || ref.Number != 12 {
+		t.Fatalf("unexpected project ref: %+v", ref)
+	}
+}

--- a/internal/planning/github_project_workspace.go
+++ b/internal/planning/github_project_workspace.go
@@ -1,0 +1,281 @@
+package planning
+
+import (
+	"fmt"
+	"net/url"
+	"strconv"
+	"strings"
+	"time"
+
+	"plan/internal/workspace"
+)
+
+const (
+	projectFieldType   = "Type"
+	projectFieldStage  = "Stage"
+	projectFieldReady  = "Ready"
+	projectFieldStatus = "Status"
+	projectFieldArea   = "Area"
+
+	projectValueTracking = "Tracking"
+	projectValueSpec     = "Spec"
+	projectValueApproved = "Approved"
+	projectValueYes      = "Yes"
+	projectValueNo       = "No"
+	projectValueTodo     = "Todo"
+)
+
+type GitHubProjectWorkspaceResult struct {
+	Decision              string                    `json:"decision"`
+	ProjectOwner          string                    `json:"project_owner"`
+	ProjectNumber         int                       `json:"project_number"`
+	ProjectID             string                    `json:"project_id"`
+	ProjectURL            string                    `json:"project_url"`
+	FieldIDs              map[string]string         `json:"field_ids"`
+	Items                 []GitHubProjectItemResult `json:"items"`
+	SavedViewInstructions []string                  `json:"saved_view_instructions"`
+}
+
+type GitHubProjectItemResult struct {
+	IssueNumber int               `json:"issue_number"`
+	Kind        string            `json:"kind"`
+	ItemID      string            `json:"item_id"`
+	Values      map[string]string `json:"values"`
+}
+
+type preparedProjectWorkspace struct {
+	project *GitHubProjectWorkspace
+	fields  map[string]GitHubProjectField
+	result  *GitHubProjectWorkspaceResult
+	area    string
+}
+
+func (m *Manager) prepareProjectWorkspace(projectDir, repo string, draft *PromotionDraft, record workspace.GitHubProjectDecisionRecord) (*preparedProjectWorkspace, workspace.GitHubProjectDecisionRecord, error) {
+	decision := normalizeProjectDecision(record.Decision)
+	if decision == "" || decision == projectDecisionSkip {
+		return nil, record, nil
+	}
+	ref := GitHubProjectReference{
+		Owner:  record.ProjectOwner,
+		Number: record.ProjectNumber,
+		ID:     record.ProjectID,
+		URL:    record.ProjectURL,
+	}
+	if ref.Owner == "" && decision == projectDecisionCreate {
+		owner, _, err := splitRepo(repo)
+		if err != nil {
+			return nil, record, err
+		}
+		ref.Owner = owner
+	}
+	title := record.MilestoneTitle
+	if strings.TrimSpace(title) == "" && draft != nil && draft.ProposedInitiativeIssue != nil {
+		title = draft.ProposedInitiativeIssue.Title
+	}
+	if strings.TrimSpace(title) == "" && draft != nil && len(draft.ProposedSpecIssues) > 0 {
+		title = draft.ProposedSpecIssues[0].Title
+	}
+	if strings.TrimSpace(title) == "" {
+		title = record.Slug
+	}
+
+	var (
+		project *GitHubProjectWorkspace
+		err     error
+	)
+	switch decision {
+	case projectDecisionCreate:
+		project, err = m.github.CreateProjectWorkspace(projectDir, repo, GitHubProjectWorkspaceInput{
+			Owner: ref.Owner,
+			Title: title,
+		})
+	case projectDecisionConnect:
+		project, err = m.github.GetProjectWorkspace(projectDir, repo, ref)
+	default:
+		return nil, record, fmt.Errorf("unsupported project decision %q", record.Decision)
+	}
+	if err != nil {
+		return nil, record, err
+	}
+	fields := map[string]GitHubProjectField{}
+	fieldIDs := map[string]string{}
+	for _, fieldInput := range projectWorkspaceFieldInputs() {
+		field, err := m.github.EnsureProjectField(projectDir, *project, fieldInput)
+		if err != nil {
+			return nil, record, err
+		}
+		fields[fieldInput.Name] = *field
+		fieldIDs[fieldInput.Name] = field.ID
+		project.Fields = upsertProjectField(project.Fields, *field)
+	}
+	record.ProjectOwner = project.Owner
+	record.ProjectNumber = project.Number
+	record.ProjectID = project.ID
+	record.ProjectURL = project.URL
+	record.FieldIDs = fieldIDs
+	record.UpdatedAt = time.Now().UTC().Format(time.RFC3339)
+	return &preparedProjectWorkspace{
+		project: project,
+		fields:  fields,
+		area:    defaultString(record.InitiativeSlug, record.Slug),
+		result: &GitHubProjectWorkspaceResult{
+			Decision:              decision,
+			ProjectOwner:          project.Owner,
+			ProjectNumber:         project.Number,
+			ProjectID:             project.ID,
+			ProjectURL:            project.URL,
+			FieldIDs:              fieldIDs,
+			SavedViewInstructions: projectSavedViewInstructions(project.URL),
+		},
+	}, record, nil
+}
+
+func (m *Manager) populateProjectWorkspaceItems(projectDir, repo string, prepared *preparedProjectWorkspace, initiativeIssue *GitHubIssue, specIssuesBySlug map[string]*GitHubIssue, specDrafts []PromotionIssueDraft) error {
+	if prepared == nil || prepared.project == nil {
+		return nil
+	}
+	area := defaultString(prepared.area, slugify(prepared.project.Title))
+	if initiativeIssue != nil {
+		values := map[string]string{
+			projectFieldType:  projectValueTracking,
+			projectFieldStage: projectValueApproved,
+			projectFieldReady: projectValueNo,
+			projectFieldArea:  area,
+		}
+		item, err := m.addProjectIssueItem(projectDir, repo, prepared, initiativeIssue.Number, "initiative", values)
+		if err != nil {
+			return err
+		}
+		prepared.result.Items = append(prepared.result.Items, *item)
+	}
+	for _, draft := range specDrafts {
+		issue := specIssuesBySlug[draft.Slug]
+		if issue == nil {
+			return fmt.Errorf("spec issue for %q was not available for project provisioning", draft.Title)
+		}
+		ready := projectValueYes
+		if draft.Readiness != ReadinessReady || len(draft.BlockedBy) > 0 {
+			ready = projectValueNo
+		}
+		values := map[string]string{
+			projectFieldType:   projectValueSpec,
+			projectFieldStage:  projectValueApproved,
+			projectFieldReady:  ready,
+			projectFieldStatus: projectValueTodo,
+			projectFieldArea:   area,
+		}
+		item, err := m.addProjectIssueItem(projectDir, repo, prepared, issue.Number, "spec", values)
+		if err != nil {
+			return err
+		}
+		prepared.result.Items = append(prepared.result.Items, *item)
+	}
+	return nil
+}
+
+func (m *Manager) addProjectIssueItem(projectDir, repo string, prepared *preparedProjectWorkspace, issueNumber int, kind string, values map[string]string) (*GitHubProjectItemResult, error) {
+	item, err := m.github.AddProjectItemByIssue(projectDir, repo, prepared.project.ID, issueNumber)
+	if err != nil {
+		return nil, err
+	}
+	for _, fieldInput := range projectWorkspaceFieldInputs() {
+		value := values[fieldInput.Name]
+		if strings.TrimSpace(value) == "" {
+			continue
+		}
+		field, ok := prepared.fields[fieldInput.Name]
+		if !ok {
+			return nil, fmt.Errorf("project field %q was not prepared", fieldInput.Name)
+		}
+		if err := m.github.SetProjectItemField(projectDir, prepared.project.ID, item.ID, field, value); err != nil {
+			return nil, err
+		}
+	}
+	return &GitHubProjectItemResult{
+		IssueNumber: issueNumber,
+		Kind:        kind,
+		ItemID:      item.ID,
+		Values:      values,
+	}, nil
+}
+
+func projectWorkspaceFieldInputs() []GitHubProjectFieldInput {
+	return []GitHubProjectFieldInput{
+		{Name: projectFieldType, DataType: "SINGLE_SELECT", Options: []string{projectValueTracking, projectValueSpec}},
+		{Name: projectFieldStage, DataType: "SINGLE_SELECT", Options: []string{projectValueApproved}},
+		{Name: projectFieldReady, DataType: "SINGLE_SELECT", Options: []string{projectValueYes, projectValueNo}},
+		{Name: projectFieldStatus, DataType: "SINGLE_SELECT", Options: []string{projectValueTodo}},
+		{Name: projectFieldArea, DataType: "TEXT"},
+	}
+}
+
+func upsertProjectField(fields []GitHubProjectField, field GitHubProjectField) []GitHubProjectField {
+	for i := range fields {
+		if strings.EqualFold(fields[i].Name, field.Name) {
+			fields[i] = field
+			return fields
+		}
+	}
+	return append(fields, field)
+}
+
+func projectSavedViewInstructions(projectURL string) []string {
+	prefix := "Open the provisioned GitHub Project"
+	if strings.TrimSpace(projectURL) != "" {
+		prefix = "Open " + strings.TrimSpace(projectURL)
+	}
+	return []string{
+		prefix + " and create a Workspace table view for all initiative items.",
+		"Create an Execution board filtered to Ready:Yes or execution statuses.",
+		"Create an Ideas / Tracking table filtered to Type:Tracking.",
+	}
+}
+
+func normalizeProjectReference(owner string, number int, projectID, projectURL string) (GitHubProjectReference, error) {
+	ref := GitHubProjectReference{
+		Owner:  strings.TrimSpace(owner),
+		Number: number,
+		ID:     strings.TrimSpace(projectID),
+		URL:    strings.TrimSpace(projectURL),
+	}
+	if ref.URL != "" {
+		parsed, err := parseGitHubProjectURL(ref.URL)
+		if err != nil {
+			return GitHubProjectReference{}, err
+		}
+		if ref.Owner == "" {
+			ref.Owner = parsed.Owner
+		} else if !strings.EqualFold(ref.Owner, parsed.Owner) {
+			return GitHubProjectReference{}, fmt.Errorf("project owner %q does not match project URL owner %q", ref.Owner, parsed.Owner)
+		}
+		if ref.Number == 0 {
+			ref.Number = parsed.Number
+		} else if ref.Number != parsed.Number {
+			return GitHubProjectReference{}, fmt.Errorf("project number %d does not match project URL number %d", ref.Number, parsed.Number)
+		}
+	}
+	return ref, nil
+}
+
+func parseGitHubProjectURL(raw string) (GitHubProjectReference, error) {
+	parsed, err := url.Parse(strings.TrimSpace(raw))
+	if err != nil {
+		return GitHubProjectReference{}, fmt.Errorf("parse GitHub Project URL: %w", err)
+	}
+	if !strings.EqualFold(parsed.Host, "github.com") {
+		return GitHubProjectReference{}, fmt.Errorf("GitHub Project URL must use github.com")
+	}
+	parts := strings.Split(strings.Trim(parsed.Path, "/"), "/")
+	if len(parts) != 4 || (parts[0] != "users" && parts[0] != "orgs") || parts[2] != "projects" {
+		return GitHubProjectReference{}, fmt.Errorf("GitHub Project URL must look like https://github.com/users/<owner>/projects/<number> or https://github.com/orgs/<owner>/projects/<number>")
+	}
+	number, err := strconv.Atoi(parts[3])
+	if err != nil || number <= 0 {
+		return GitHubProjectReference{}, fmt.Errorf("GitHub Project URL has invalid project number %q", parts[3])
+	}
+	return GitHubProjectReference{
+		Owner:  parts[1],
+		Number: number,
+		URL:    strings.TrimSpace(raw),
+	}, nil
+}

--- a/internal/planning/github_project_workspace.go
+++ b/internal/planning/github_project_workspace.go
@@ -262,12 +262,12 @@ func parseGitHubProjectURL(raw string) (GitHubProjectReference, error) {
 	if err != nil {
 		return GitHubProjectReference{}, fmt.Errorf("parse GitHub Project URL: %w", err)
 	}
-	if !strings.EqualFold(parsed.Host, "github.com") {
+	if !strings.EqualFold(parsed.Host, "github.com") && !strings.EqualFold(parsed.Host, "www.github.com") {
 		return GitHubProjectReference{}, fmt.Errorf("GitHub Project URL must use github.com")
 	}
 	parts := strings.Split(strings.Trim(parsed.Path, "/"), "/")
-	if len(parts) != 4 || (parts[0] != "users" && parts[0] != "orgs") || parts[2] != "projects" {
-		return GitHubProjectReference{}, fmt.Errorf("GitHub Project URL must look like https://github.com/users/<owner>/projects/<number> or https://github.com/orgs/<owner>/projects/<number>")
+	if len(parts) < 4 || (parts[0] != "users" && parts[0] != "orgs") || parts[1] == "" || parts[2] != "projects" {
+		return GitHubProjectReference{}, fmt.Errorf("GitHub Project URL must look like https://github.com/users/<owner>/projects/<number> or https://github.com/orgs/<owner>/projects/<number>, with optional trailing path segments")
 	}
 	number, err := strconv.Atoi(parts[3])
 	if err != nil || number <= 0 {

--- a/internal/workspace/workspace.go
+++ b/internal/workspace/workspace.go
@@ -75,17 +75,23 @@ type GitHubPlanningRecord struct {
 }
 
 type GitHubProjectDecisionRecord struct {
-	Slug             string `json:"slug"`
-	Decision         string `json:"decision"`
-	Reason           string `json:"reason,omitempty"`
-	SpecCount        int    `json:"spec_count,omitempty"`
-	MilestoneNumber  int    `json:"milestone_number,omitempty"`
-	MilestoneTitle   string `json:"milestone_title,omitempty"`
-	SourceMode       string `json:"source_mode,omitempty"`
-	EntryMode        string `json:"entry_mode,omitempty"`
-	DiscussionNumber int    `json:"discussion_number,omitempty"`
-	DiscussionURL    string `json:"discussion_url,omitempty"`
-	UpdatedAt        string `json:"updated_at,omitempty"`
+	Slug             string            `json:"slug"`
+	Decision         string            `json:"decision"`
+	Reason           string            `json:"reason,omitempty"`
+	InitiativeSlug   string            `json:"initiative_slug,omitempty"`
+	SpecCount        int               `json:"spec_count,omitempty"`
+	MilestoneNumber  int               `json:"milestone_number,omitempty"`
+	MilestoneTitle   string            `json:"milestone_title,omitempty"`
+	ProjectOwner     string            `json:"project_owner,omitempty"`
+	ProjectNumber    int               `json:"project_number,omitempty"`
+	ProjectID        string            `json:"project_id,omitempty"`
+	ProjectURL       string            `json:"project_url,omitempty"`
+	FieldIDs         map[string]string `json:"field_ids,omitempty"`
+	SourceMode       string            `json:"source_mode,omitempty"`
+	EntryMode        string            `json:"entry_mode,omitempty"`
+	DiscussionNumber int               `json:"discussion_number,omitempty"`
+	DiscussionURL    string            `json:"discussion_url,omitempty"`
+	UpdatedAt        string            `json:"updated_at,omitempty"`
 }
 
 type GitHubStoryRecord struct {

--- a/internal/workspace/workspace_test.go
+++ b/internal/workspace/workspace_test.go
@@ -581,6 +581,92 @@ func TestReadGitHubStateDefaultsPlanningMapInMemory(t *testing.T) {
 	}
 }
 
+func TestGitHubProjectDecisionRecordSupportsWorkspaceProjectMetadata(t *testing.T) {
+	root := t.TempDir()
+	manager := New(root)
+	if _, err := manager.Init(); err != nil {
+		t.Fatal(err)
+	}
+
+	state, err := manager.ReadGitHubState()
+	if err != nil {
+		t.Fatal(err)
+	}
+	state.ProjectDecisions["readiness"] = GitHubProjectDecisionRecord{
+		Slug:            "readiness",
+		Decision:        "connect",
+		Reason:          "Coordination spans many specs.",
+		InitiativeSlug:  "readiness",
+		SpecCount:       6,
+		MilestoneNumber: 7,
+		MilestoneTitle:  "Readiness",
+		ProjectOwner:    "JimmyMcBride",
+		ProjectNumber:   12,
+		ProjectID:       "PVT_kwExample",
+		ProjectURL:      "https://github.com/users/JimmyMcBride/projects/12",
+		FieldIDs: map[string]string{
+			"Status": "PVTSSF_status",
+			"Ready":  "PVTSSF_ready",
+		},
+		SourceMode:       "github",
+		EntryMode:        "github_collaborative",
+		DiscussionNumber: 49,
+		DiscussionURL:    "https://github.com/JimmyMcBride/plan/discussions/49",
+		UpdatedAt:        "2026-04-27T00:00:00Z",
+	}
+	if err := manager.WriteGitHubState(*state); err != nil {
+		t.Fatal(err)
+	}
+
+	roundTrip, err := manager.ReadGitHubState()
+	if err != nil {
+		t.Fatal(err)
+	}
+	record := roundTrip.ProjectDecisions["readiness"]
+	if record.Decision != "connect" || record.ProjectOwner != "JimmyMcBride" || record.ProjectNumber != 12 || record.ProjectID == "" || record.ProjectURL == "" {
+		t.Fatalf("expected project identity fields to round-trip: %+v", record)
+	}
+	if record.InitiativeSlug != "readiness" || record.FieldIDs["Status"] != "PVTSSF_status" || record.FieldIDs["Ready"] != "PVTSSF_ready" {
+		t.Fatalf("expected initiative and field ids to round-trip: %+v", record)
+	}
+}
+
+func TestReadGitHubStateKeepsLegacyProjectDecisionRecordsCompatible(t *testing.T) {
+	root := t.TempDir()
+	manager := New(root)
+	if _, err := manager.Init(); err != nil {
+		t.Fatal(err)
+	}
+
+	githubPath := filepath.Join(root, ".plan", ".meta", "github.json")
+	raw := []byte(`{
+  "last_updated_at": "2026-04-27T00:00:00Z",
+  "stories": {},
+  "planning": {},
+  "project_decisions": {
+    "legacy": {
+      "slug": "legacy",
+      "decision": "create",
+      "spec_count": 5,
+      "milestone_number": 7,
+      "milestone_title": "Legacy"
+    }
+  }
+}`)
+	if err := os.WriteFile(githubPath, raw, 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	state, err := manager.ReadGitHubState()
+	if err != nil {
+		t.Fatal(err)
+	}
+	record := state.ProjectDecisions["legacy"]
+	if record.Decision != "create" || record.ProjectNumber != 0 || record.ProjectID != "" || len(record.FieldIDs) != 0 {
+		t.Fatalf("expected legacy project decision record to remain readable: %+v", record)
+	}
+}
+
 func TestUpdateDoesNotRewriteOptionalCompatibilityDefaults(t *testing.T) {
 	root := t.TempDir()
 	manager := New(root)

--- a/skills/plan-execute/SKILL.md
+++ b/skills/plan-execute/SKILL.md
@@ -73,12 +73,13 @@ Use this sequence unless repo instructions require a stricter flow:
    - stage only intentional changes
    - use a clear message referencing the spec when useful
 9. Brain pre-PR closeout:
-   - run `brain session finish` before opening, marking ready, or merging the PR
-     when a Brain session is active
+   - run `brain session finish` before the PR is marked ready or merged when a
+     Brain session is active
    - if Brain requires durable notes, apply them, commit them on the same branch,
      and retry `brain session finish`
-   - do not leave `.brain/`, docs, or contract note changes behind on the
-     integration branch after merge
+   - do not leave `.brain/`, docs, or contract note changes uncommitted when
+     switching back to the integration branch, and do not commit them directly
+     on the integration branch outside the PR
 10. Push and PR:
    - push `codex/<spec-slug>`
    - open a ready PR to the repo's integration branch

--- a/skills/plan-execute/SKILL.md
+++ b/skills/plan-execute/SKILL.md
@@ -72,13 +72,19 @@ Use this sequence unless repo instructions require a stricter flow:
 8. Commit:
    - stage only intentional changes
    - use a clear message referencing the spec when useful
-9. Push and PR:
+9. Brain pre-PR closeout:
+   - run `brain session finish` before opening, marking ready, or merging the PR
+     when a Brain session is active
+   - if Brain requires durable notes, apply them, commit them on the same branch,
+     and retry `brain session finish`
+   - do not leave `.brain/`, docs, or contract note changes behind on the
+     integration branch after merge
+10. Push and PR:
    - push `codex/<spec-slug>`
    - open a ready PR to the repo's integration branch
    - include summary, spec link, slice list, tests run, migration/seed notes,
      manual QA, and screenshots when relevant
-10. Finish:
-   - finish the Brain session when one is active
+11. Finish:
    - report PR URL, tests, and any documented risk
 
 ## Stop Conditions


### PR DESCRIPTION
## Summary

Release v0.1.27 from current develop into main.

Included changes:
- #70: GitHub project decision metadata.
- #71: GitHub project workspace provisioning and item field setup.
- #72: Brain closeout notes for PR #71.
- #73: Brain closeout pre-PR workflow guardrails.

## Target Branch

- Release PR: `release/v0.1.27 -> main`.

## Testing

- [x] CI passed on included develop PRs.
- [ ] Release PR CI pending.
- [ ] Other: not needed.

## Release Notes

- User-facing change: GitHub project workspace provisioning support and project decision metadata are available.
- Planning or workflow impact: Brain closeout is now documented as a PR-readiness gate so required durable notes land in the same PR branch.
- Follow-up work: none.

## Planning

- Related idea/planning documents: release from develop.
