### PR TITLE
fix: reconcile GitHub discussion promotion

### DIFF
--- a/.brain/resources/changes/github-discussion-promotion-reconciliation.md
+++ b/.brain/resources/changes/github-discussion-promotion-reconciliation.md
@@ -1,0 +1,11 @@
+---
+title: GitHub Discussion Promotion Reconciliation
+updated: "2026-07-26T08:32:45Z"
+---
+## Changes
+
+- GitHub Discussion promotion preview now reconciles existing Plan-managed initiatives, specs, milestones, parent/sub-issue relationships, and blocked-by dependencies before proposing creation.
+- Identity precedence favors exact Plan metadata and Discussion source identity, then stable slugs and established parent/repository metadata; equal candidates block preview.
+- Structured Promotion map briefs render per-spec purpose or problem, scope, acceptance criteria, verification, dependencies, and readiness instead of copying global Discussion sections.
+- Preview remains read-only. Confirmed apply creates, updates, reuses, or leaves artifacts unchanged and skips existing relationships, making repeated apply idempotent.
+- The Volt Discussion #1 fixture resolves initiative #2, milestone #1, specs #3 through #6, and the existing dependency graph without new planning artifacts.

--- a/README.md
+++ b/README.md
@@ -156,6 +156,13 @@ plan discuss promote --project . --discussion 49 --format json
 plan discuss promote --project . --discussion 49 --apply --confirm --target github --format json
 ```
 
+Promotion preview reconciles existing Plan-managed Issues and Milestones before
+classifying every artifact and relationship as `create`, `update`, `reuse`, or
+`unchanged`. Exact Plan/source metadata wins over titles; ambiguous identity
+blocks. Preview is non-mutating, and repeated confirmed apply is idempotent.
+Structured `## Promotion map` spec briefs keep their own scope, acceptance
+criteria, verification, readiness, and dependencies.
+
 If Plan says the source needs repair, use the emitted repair command before
 promotion. In GitHub or hybrid source mode, do not create planning issues,
 labels, or milestones manually unless Plan emitted `manual_fallback_allowed=true`;

--- a/docs/using-plan.md
+++ b/docs/using-plan.md
@@ -349,7 +349,8 @@ The draft tells you:
 - the proposed spec issues
 - parent/sub-issue grouping
 - `blocked by` dependency suggestions
-- whether a milestone should be created
+- whether the initiative, specs, relationships, and milestone will be created,
+  updated, reused, or left unchanged
 - whether a project should be recommended
 - whether any spec should start with `needs-refinement`
 - the agent policy that forbids manual GitHub planning mutations unless Plan
@@ -357,11 +358,43 @@ The draft tells you:
 
 Rules:
 
-- single-spec promotion creates one spec issue and no initiative issue
-- multi-spec promotion creates an initiative issue plus spec issues
-- multi-spec promotion always creates a milestone
+- single-spec promotion creates or reconciles one spec issue and no initiative
+  issue
+- multi-spec promotion creates or reconciles an initiative issue plus spec
+  issues
+- multi-spec promotion uses one milestone, preferring the source's target
+  milestone and the established initiative milestone over the Discussion title
 - the project prompt appears at `5+` specs or earlier when coordination is
   clearly messy
+- preview is read-only: it may inspect Plan metadata, Plan-labeled Issues,
+  Milestones, sub-issues, and dependencies, but it never mutates GitHub or local
+  planning metadata
+- identity precedence is exact `.plan/.meta/github.json` source metadata,
+  Discussion source links, stable slugs, parent/sub-issue grouping, and then
+  other Plan-managed repository metadata; title similarity only disambiguates
+  stronger identity signals
+- if two existing artifacts remain equally plausible, preview fails with an
+  ambiguity error instead of choosing one
+
+The additive JSON reconciliation fields are:
+
+- `proposed_initiative_issue.action` and each
+  `proposed_spec_issues[].action`: `create`, `update`, or `unchanged`
+- `issue_number`, `issue_url`, and `identity` when an existing Issue is
+  resolved
+- `milestone_plan.action`: `create` or `reuse`, plus `number`, `url`, and
+  `identity` when Plan reuses a Milestone
+- `relationship_plan[]`: one explicit `parent_sub_issue` or `blocked_by`
+  action, classified as `create` or `reuse`
+- `create` remains on `milestone_plan` for compatibility; it is `false` when
+  the action is `reuse`
+
+For structured multi-spec Discussions, `## Promotion map` may contain
+`### Spec N — Title` briefs. Each brief is parsed independently. Supported
+brief fields are problem or purpose, scope, acceptance criteria, verification,
+dependencies, and readiness or approval note. If verification is omitted, the
+spec's own acceptance criteria become its verification checklist; global
+Discussion sections are not copied into every spec.
 
 ### 7. Apply Promotion To GitHub Or Hybrid Ownership
 
@@ -406,14 +439,17 @@ Current shipped boundary:
 
 When a multi-spec promotion is applied, `plan` will:
 
-- create the initiative issue
-- create the spec issues immediately
-- create the milestone
-- wire the initiative as parent of the spec issues
-- add `blocked by` relationships only where the dependency plan says they are
-  real
-- mirror the created issue/milestone/project metadata into
+- create missing initiative/spec Issues and update resolved Plan-managed Issues
+- create a missing milestone or reuse the milestone already established by the
+  source/initiative
+- add only missing parent/sub-issue and `blocked by` relationships
+- leave already-matching Issues and relationships unchanged
+- mirror the resolved issue/milestone/project metadata into
   `.plan/.meta/github.json`
+
+Apply remains gated by both `--apply` and `--confirm`. Repeating the same apply
+is idempotent: it does not create duplicate Issues, Milestones, labels,
+sub-issue relationships, or dependency relationships.
 
 By default, new spec issues are `ready`. A spec starts as `needs-refinement`
 only when the draft identified a concrete execution gap.

--- a/internal/planning/collaboration.go
+++ b/internal/planning/collaboration.go
@@ -68,6 +68,15 @@ const (
 	PromotionMultiSpec  PromotionPath = "multi_spec"
 )
 
+type PromotionAction string
+
+const (
+	PromotionActionCreate    PromotionAction = "create"
+	PromotionActionUpdate    PromotionAction = "update"
+	PromotionActionReuse     PromotionAction = "reuse"
+	PromotionActionUnchanged PromotionAction = "unchanged"
+)
+
 type ReadinessState string
 
 const (
@@ -151,6 +160,7 @@ type PromotionDraft struct {
 	ProposedSpecIssues        []PromotionIssueDraft          `json:"proposed_spec_issues"`
 	ParentSubIssuePlan        []string                       `json:"parent_sub_issue_plan,omitempty"`
 	DependencyPlan            []PromotionDependencyPlan      `json:"dependency_plan,omitempty"`
+	RelationshipPlan          []PromotionRelationshipPlan    `json:"relationship_plan,omitempty"`
 	MilestonePlan             *PromotionMilestonePlan        `json:"milestone_plan,omitempty"`
 	ProjectPrompt             *PromotionProjectPrompt        `json:"project_prompt,omitempty"`
 	AgentPolicy               PromotionAgentPolicy           `json:"agent_policy"`
@@ -166,15 +176,20 @@ type PromotionAgentPolicy struct {
 }
 
 type PromotionIssueDraft struct {
-	Kind           string         `json:"kind"`
-	Title          string         `json:"title"`
-	Body           string         `json:"body"`
-	Slug           string         `json:"slug"`
-	Readiness      ReadinessState `json:"readiness"`
-	Labels         []string       `json:"labels,omitempty"`
-	SourceLinks    []string       `json:"source_links,omitempty"`
-	BlockedBy      []string       `json:"blocked_by,omitempty"`
-	ReadyByDefault bool           `json:"ready_by_default"`
+	Kind           string          `json:"kind"`
+	Title          string          `json:"title"`
+	Body           string          `json:"body"`
+	Slug           string          `json:"slug"`
+	Action         PromotionAction `json:"action"`
+	IssueNumber    int             `json:"issue_number,omitempty"`
+	IssueURL       string          `json:"issue_url,omitempty"`
+	Identity       string          `json:"identity,omitempty"`
+	Readiness      ReadinessState  `json:"readiness"`
+	Labels         []string        `json:"labels,omitempty"`
+	SourceLinks    []string        `json:"source_links,omitempty"`
+	BlockedBy      []string        `json:"blocked_by,omitempty"`
+	ReadyByDefault bool            `json:"ready_by_default"`
+	existing       *GitHubIssue
 }
 
 type PromotionDependencyPlan struct {
@@ -183,9 +198,23 @@ type PromotionDependencyPlan struct {
 }
 
 type PromotionMilestonePlan struct {
-	Create bool   `json:"create"`
-	Title  string `json:"title,omitempty"`
-	Why    string `json:"why,omitempty"`
+	Create   bool            `json:"create"`
+	Action   PromotionAction `json:"action"`
+	Title    string          `json:"title,omitempty"`
+	Number   int             `json:"number,omitempty"`
+	URL      string          `json:"url,omitempty"`
+	Identity string          `json:"identity,omitempty"`
+	Why      string          `json:"why,omitempty"`
+	existing *GitHubMilestone
+}
+
+type PromotionRelationshipPlan struct {
+	Kind               string          `json:"kind"`
+	Action             PromotionAction `json:"action"`
+	IssueTitle         string          `json:"issue_title"`
+	IssueNumber        int             `json:"issue_number,omitempty"`
+	RelatedTitle       string          `json:"related_title"`
+	RelatedIssueNumber int             `json:"related_issue_number,omitempty"`
 }
 
 type PromotionProjectPrompt struct {
@@ -320,6 +349,8 @@ type collaborationSourceData struct {
 	openQs                  string
 	suggested               []string
 	deps                    []MaturityDependencyGuess
+	specBriefs              map[string]promotionSpecBrief
+	milestoneTitle          string
 	explicitMultiSpecIntent bool
 	repairCandidates        []string
 }
@@ -373,6 +404,9 @@ func (m *Manager) BuildPromotionDraft(input PromotionDraftInput) (*PromotionDraf
 			draft.NeedsRefinementExceptions = append(draft.NeedsRefinementExceptions, exception)
 		}
 		draft.ProposedSpecIssues = []PromotionIssueDraft{specDraft}
+		if err := m.reconcilePromotionDraft(data, draft); err != nil {
+			return nil, err
+		}
 		return draft, nil
 	}
 	initiativeTitle := strings.TrimSpace(decision.SuggestedTitles.Initiative)
@@ -400,10 +434,12 @@ func (m *Manager) BuildPromotionDraft(input PromotionDraftInput) (*PromotionDraf
 			draft.NeedsRefinementExceptions = append(draft.NeedsRefinementExceptions, exception)
 		}
 	}
+	milestoneTitle := defaultString(data.milestoneTitle, initiativeTitle)
 	draft.MilestonePlan = &PromotionMilestonePlan{
 		Create: true,
-		Title:  initiativeTitle,
-		Why:    "Multi-spec promotion always gets a milestone.",
+		Action: PromotionActionCreate,
+		Title:  milestoneTitle,
+		Why:    "Multi-spec promotion gets one milestone; source and existing initiative metadata take precedence over the Discussion title.",
 	}
 	if shouldRecommendProject(len(specTitles), draft.DependencyPlan) {
 		draft.ProjectPrompt = &PromotionProjectPrompt{
@@ -415,6 +451,9 @@ func (m *Manager) BuildPromotionDraft(input PromotionDraftInput) (*PromotionDraf
 			Recommended: false,
 			Reason:      "Milestone tracking is enough for this spec count and dependency shape.",
 		}
+	}
+	if err := m.reconcilePromotionDraft(data, draft); err != nil {
+		return nil, err
 	}
 	return draft, nil
 }
@@ -570,10 +609,17 @@ func (m *Manager) ApplyPromotionDraft(input PromotionApplyInput) (*PromotionAppl
 		return fallback(err)
 	}
 	var milestone *GitHubMilestone
-	if draft.MilestonePlan != nil && draft.MilestonePlan.Create {
-		milestone, err = m.ensureMilestone(info.ProjectDir, state.Repo, draft.MilestonePlan.Title)
-		if err != nil {
-			return fallback(err)
+	if draft.MilestonePlan != nil {
+		switch draft.MilestonePlan.Action {
+		case PromotionActionReuse, PromotionActionUnchanged:
+			milestone = draft.MilestonePlan.existing
+		default:
+			if draft.MilestonePlan.Create {
+				milestone, err = m.ensureMilestone(info.ProjectDir, state.Repo, draft.MilestonePlan.Title)
+				if err != nil {
+					return fallback(err)
+				}
+			}
 		}
 		result.Milestone = milestone
 	}
@@ -594,16 +640,7 @@ func (m *Manager) ApplyPromotionDraft(input PromotionApplyInput) (*PromotionAppl
 	}
 	var initiativeIssue *GitHubIssue
 	if draft.ProposedInitiativeIssue != nil {
-		initInput := GitHubIssueInput{
-			Title:  draft.ProposedInitiativeIssue.Title,
-			Body:   draft.ProposedInitiativeIssue.Body,
-			State:  "open",
-			Labels: append([]string(nil), draft.ProposedInitiativeIssue.Labels...),
-		}
-		if milestone != nil {
-			initInput.Milestone = &milestone.Number
-		}
-		initIssue, err := m.github.CreateIssue(info.ProjectDir, state.Repo, initInput)
+		initIssue, err := m.applyPromotionIssue(info.ProjectDir, state.Repo, draft.ProposedInitiativeIssue, milestone)
 		if err != nil {
 			return fallback(err)
 		}
@@ -632,34 +669,38 @@ func (m *Manager) ApplyPromotionDraft(input PromotionApplyInput) (*PromotionAppl
 	specIssuesBySlug := make(map[string]*GitHubIssue, len(draft.ProposedSpecIssues))
 	specDraftsBySlug := make(map[string]PromotionIssueDraft, len(draft.ProposedSpecIssues))
 	for _, specDraft := range draft.ProposedSpecIssues {
-		specInput := GitHubIssueInput{
-			Title:  specDraft.Title,
-			Body:   specDraft.Body,
-			State:  "open",
-			Labels: append([]string(nil), specDraft.Labels...),
-		}
-		if milestone != nil {
-			specInput.Milestone = &milestone.Number
-		}
-		specIssue, err := m.github.CreateIssue(info.ProjectDir, state.Repo, specInput)
+		specIssue, err := m.applyPromotionIssue(info.ProjectDir, state.Repo, &specDraft, milestone)
 		if err != nil {
 			return fallback(err)
-		}
-		if initiativeIssue != nil {
-			if err := m.github.AddSubIssue(info.ProjectDir, state.Repo, initiativeIssue.Number, specIssue.Number); err != nil {
-				return fallback(err)
-			}
 		}
 		specIssuesBySlug[specDraft.Slug] = specIssue
 		specDraftsBySlug[specDraft.Slug] = specDraft
 		result.Specs = append(result.Specs, *specIssue)
 	}
-	for slug, specIssue := range specIssuesBySlug {
-		specDraft := specDraftsBySlug[slug]
-		for _, dep := range specDraft.BlockedBy {
-			depIssue, ok := specIssuesBySlug[slugify(dep)]
+	for _, relationship := range draft.RelationshipPlan {
+		if relationship.Action != PromotionActionCreate {
+			continue
+		}
+		switch relationship.Kind {
+		case "parent_sub_issue":
+			if initiativeIssue == nil {
+				return nil, fmt.Errorf("promotion parent relationship for %q has no initiative issue", relationship.RelatedTitle)
+			}
+			specIssue, ok := specIssuesBySlug[slugify(relationship.RelatedTitle)]
 			if !ok {
-				return nil, fmt.Errorf("promotion dependency %q for %q was not created in this promotion set", dep, specDraft.Title)
+				return nil, fmt.Errorf("promotion sub-issue %q was not resolved in this promotion set", relationship.RelatedTitle)
+			}
+			if err := m.github.AddSubIssue(info.ProjectDir, state.Repo, initiativeIssue.Number, specIssue.Number); err != nil {
+				return fallback(err)
+			}
+		case "blocked_by":
+			specIssue, ok := specIssuesBySlug[slugify(relationship.IssueTitle)]
+			if !ok {
+				return nil, fmt.Errorf("promotion dependency target %q was not resolved in this promotion set", relationship.IssueTitle)
+			}
+			depIssue, ok := specIssuesBySlug[slugify(relationship.RelatedTitle)]
+			if !ok {
+				return nil, fmt.Errorf("promotion dependency %q for %q was not resolved in this promotion set", relationship.RelatedTitle, relationship.IssueTitle)
 			}
 			if err := m.github.AddBlockedBy(info.ProjectDir, state.Repo, specIssue.Number, depIssue.Number); err != nil {
 				return fallback(err)
@@ -1016,6 +1057,16 @@ func (m *Manager) loadLocalBrainstormSource(info *workspace.Info, slug string) (
 		CanonicalSource: "local_brainstorm",
 	}
 	specParse := extractSpecCandidateParse(content)
+	specBriefs, briefTitles, milestoneTitle := parsePromotionMap(content)
+	if len(briefTitles) > 0 {
+		specParse.Titles = briefTitles
+		specParse.RepairCandidates = briefTitles
+		specParse.ExplicitMultiSpecIntent = len(briefTitles) > 1
+	}
+	deps := buildDependencyGuess(specParse.Titles, content)
+	if len(specBriefs) > 0 {
+		deps = promotionBriefDependencyGuesses(specParse.Titles, specBriefs)
+	}
 	return &collaborationSourceData{
 		source:                  source,
 		title:                   defaultString(title, slugify(slug)),
@@ -1027,7 +1078,9 @@ func (m *Manager) loadLocalBrainstormSource(info *workspace.Info, slug string) (
 		shape:                   firstNonEmpty(refinement.DecisionSnapshot, refinement.CandidateApproaches, challenge.SimplerAlternative),
 		openQs:                  firstNonEmpty(refinement.RemainingOpenQuestions, notes.ExtractSection(content, "Open Questions")),
 		suggested:               specParse.Titles,
-		deps:                    buildDependencyGuess(specParse.Titles, content),
+		deps:                    deps,
+		specBriefs:              specBriefs,
+		milestoneTitle:          milestoneTitle,
 		explicitMultiSpecIntent: specParse.ExplicitMultiSpecIntent,
 		repairCandidates:        specParse.RepairCandidates,
 	}, nil
@@ -1065,6 +1118,16 @@ func (m *Manager) loadGitHubDiscussionSource(info *workspace.Info, discussionRef
 		CanonicalSource: "github_discussion",
 	}
 	specParse := extractSpecCandidateParse(content)
+	specBriefs, briefTitles, milestoneTitle := parsePromotionMap(content)
+	if len(briefTitles) > 0 {
+		specParse.Titles = briefTitles
+		specParse.RepairCandidates = briefTitles
+		specParse.ExplicitMultiSpecIntent = len(briefTitles) > 1
+	}
+	deps := buildDependencyGuess(specParse.Titles, content)
+	if len(specBriefs) > 0 {
+		deps = promotionBriefDependencyGuesses(specParse.Titles, specBriefs)
+	}
 	return &collaborationSourceData{
 		source:                  source,
 		title:                   discussion.Title,
@@ -1076,7 +1139,9 @@ func (m *Manager) loadGitHubDiscussionSource(info *workspace.Info, discussionRef
 		shape:                   firstNonEmpty(firstSectionOrKeyword(content, "Proposed Shape", "shape"), firstSectionOrKeyword(content, "Decision Snapshot", "decision"), firstSectionOrKeyword(content, "Candidate Approaches", "approach")),
 		openQs:                  firstNonEmpty(firstSectionOrKeyword(content, "Open Questions", "open question"), firstSectionOrKeyword(content, "Remaining Open Questions", "remaining open question")),
 		suggested:               specParse.Titles,
-		deps:                    buildDependencyGuess(specParse.Titles, content),
+		deps:                    deps,
+		specBriefs:              specBriefs,
+		milestoneTitle:          milestoneTitle,
 		explicitMultiSpecIntent: specParse.ExplicitMultiSpecIntent,
 		repairCandidates:        specParse.RepairCandidates,
 	}, nil
@@ -1165,6 +1230,7 @@ func assessCollaborationData(data *collaborationSourceData) CollaborationMaturit
 }
 
 func buildPromotionInitiativeDraft(data *collaborationSourceData, title string, specs []string) PromotionIssueDraft {
+	milestoneTitle := defaultString(data.milestoneTitle, title)
 	lines := []string{
 		"## Initiative",
 		data.problem,
@@ -1190,7 +1256,7 @@ func buildPromotionInitiativeDraft(data *collaborationSourceData, title string, 
 		"- Follow the promoted spec dependency plan.",
 		"",
 		"## Milestone",
-		"- "+title,
+		"- "+milestoneTitle,
 		"",
 		"## Source",
 	)
@@ -1202,6 +1268,7 @@ func buildPromotionInitiativeDraft(data *collaborationSourceData, title string, 
 		Title:          title,
 		Body:           strings.TrimSpace(strings.Join(lines, "\n")),
 		Slug:           slugify(title),
+		Action:         PromotionActionCreate,
 		Readiness:      ReadinessReady,
 		Labels:         []string{"enhancement", planIssueInitiativeLabel},
 		SourceLinks:    append([]string(nil), data.source.SourceLinks...),
@@ -1217,8 +1284,12 @@ func buildPromotionSpecDraft(data *collaborationSourceData, title string, blocke
 	body := renderPromotionSpecBody(title, data, blockedBy, exceptionPtr)
 	readiness := ReadinessReady
 	labels := []string{"enhancement", planIssueSpecLabel, planIssueReadyLabel}
+	brief, hasBrief := data.specBriefs[normalizePromotionTitle(title)]
 	if exceptionPtr != nil {
 		readiness = ReadinessNeedsRefinement
+		labels = []string{"enhancement", planIssueSpecLabel}
+	} else if hasBrief && (brief.Readiness == ReadinessNeedsRefinement || brief.Readiness == ReadinessClarifying) {
+		readiness = brief.Readiness
 		labels = []string{"enhancement", planIssueSpecLabel}
 	} else if len(blockedBy) > 0 {
 		readiness = ReadinessBlocked
@@ -1229,11 +1300,12 @@ func buildPromotionSpecDraft(data *collaborationSourceData, title string, blocke
 		Title:          title,
 		Body:           body,
 		Slug:           slugify(title),
+		Action:         PromotionActionCreate,
 		Readiness:      readiness,
 		Labels:         labels,
 		SourceLinks:    append([]string(nil), data.source.SourceLinks...),
 		BlockedBy:      append([]string(nil), blockedBy...),
-		ReadyByDefault: len(blockedBy) == 0 && exceptionPtr == nil,
+		ReadyByDefault: readiness == ReadinessReady,
 	}
 }
 
@@ -1277,6 +1349,9 @@ func buildRefinementExceptions(data *collaborationSourceData, specTitles []strin
 }
 
 func renderPromotionSpecBody(title string, data *collaborationSourceData, blockedBy []string, exception *PromotionRefinementException) string {
+	if brief, ok := data.specBriefs[normalizePromotionTitle(title)]; ok {
+		return renderPromotionSpecBriefBody(brief, data.source.SourceLinks, blockedBy, exception)
+	}
 	lines := []string{
 		"## Spec",
 		defaultString(data.problem, title),
@@ -1341,6 +1416,103 @@ func renderPromotionSpecBody(title string, data *collaborationSourceData, blocke
 		"## Source",
 	)
 	for _, link := range data.source.SourceLinks {
+		lines = append(lines, "- "+link)
+	}
+	return strings.TrimSpace(strings.Join(lines, "\n"))
+}
+
+func renderPromotionSpecBriefBody(brief promotionSpecBrief, sourceLinks, blockedBy []string, exception *PromotionRefinementException) string {
+	lines := []string{
+		"## Spec",
+		brief.Title,
+		"",
+	}
+	if strings.TrimSpace(brief.Problem) != "" {
+		lines = append(lines,
+			"## Problem",
+			brief.Problem,
+			"",
+		)
+	} else {
+		lines = append(lines,
+			"## Purpose",
+			defaultString(brief.Purpose, brief.Title),
+			"",
+		)
+	}
+	lines = append(lines,
+		"## Scope",
+		defaultString(brief.Scope, brief.Purpose),
+		"",
+		"## Acceptance Criteria",
+	)
+	if len(brief.AcceptanceCriteria) == 0 {
+		lines = append(lines, "- Clarify acceptance criteria before execution.")
+	} else {
+		for _, item := range brief.AcceptanceCriteria {
+			lines = append(lines, "- "+item)
+		}
+	}
+	lines = append(lines,
+		"",
+		"## Verification",
+	)
+	if len(brief.Verification) == 0 {
+		lines = append(lines, "- Verify every acceptance criterion above.")
+	} else {
+		for _, item := range brief.Verification {
+			lines = append(lines, "- "+item)
+		}
+	}
+	lines = append(lines,
+		"",
+		"## Dependencies",
+	)
+	if len(blockedBy) == 0 {
+		lines = append(lines, "- blocked by: none")
+	} else {
+		lines = append(lines, "- blocked by: "+strings.Join(blockedBy, ", "))
+	}
+	lines = append(lines,
+		"",
+		"## Readiness",
+	)
+	switch {
+	case exception != nil:
+		lines = append(lines, "- status: needs-refinement")
+	case brief.Readiness == ReadinessNeedsRefinement || brief.Readiness == ReadinessClarifying:
+		lines = append(lines, "- status: "+string(brief.Readiness))
+	case len(blockedBy) > 0:
+		lines = append(lines, "- status: blocked")
+	default:
+		lines = append(lines, "- status: ready")
+	}
+	if strings.TrimSpace(brief.ReadinessNote) != "" {
+		lines = append(lines, "- note: "+strings.TrimSpace(brief.ReadinessNote))
+	}
+	if exception != nil {
+		lines = append(lines,
+			"",
+			"## Refinement Gap",
+			exception.Gap,
+			"",
+			"## Why Not Ready",
+			exception.WhyNotReady,
+			"",
+			"## Recommended Clarification",
+			exception.RecommendedClarification,
+			"",
+			"## Exit Criteria",
+		)
+		for _, item := range exception.ExitCriteria {
+			lines = append(lines, "- "+item)
+		}
+	}
+	lines = append(lines,
+		"",
+		"## Source",
+	)
+	for _, link := range sourceLinks {
 		lines = append(lines, "- "+link)
 	}
 	return strings.TrimSpace(strings.Join(lines, "\n"))

--- a/internal/planning/collaboration_briefs.go
+++ b/internal/planning/collaboration_briefs.go
@@ -1,0 +1,216 @@
+package planning
+
+import (
+	"regexp"
+	"strconv"
+	"strings"
+
+	"plan/internal/notes"
+)
+
+type promotionSpecBrief struct {
+	Title              string
+	Problem            string
+	Purpose            string
+	Scope              string
+	AcceptanceCriteria []string
+	Verification       []string
+	Dependencies       []string
+	Readiness          ReadinessState
+	ReadinessNote      string
+}
+
+var (
+	promotionSpecHeadingPattern = regexp.MustCompile(`(?m)^###\s+Spec\s+([0-9]+)\s+(?:—|-)\s+(.+?)\s*$`)
+	promotionBriefFieldPattern  = regexp.MustCompile(`(?im)^(?:#{4}[ \t]+)?(problem|purpose|scope|acceptance criteria|verification|dependencies|readiness|approval note)[ \t]*:?[ \t]*(.*)$`)
+	promotionMilestonePattern   = regexp.MustCompile(`(?im)^Target milestone:[ \t]*(?:\*\*)?(.+?)(?:\*\*)?[ \t]*$`)
+)
+
+func parsePromotionMap(content string) (map[string]promotionSpecBrief, []string, string) {
+	section := strings.TrimSpace(notes.ExtractSection(content, "Promotion map"))
+	if section == "" {
+		return nil, nil, ""
+	}
+	milestoneTitle := ""
+	if match := promotionMilestonePattern.FindStringSubmatch(section); len(match) == 2 {
+		milestoneTitle = strings.TrimSpace(match[1])
+	}
+	matches := promotionSpecHeadingPattern.FindAllStringSubmatchIndex(section, -1)
+	if len(matches) == 0 {
+		return nil, nil, milestoneTitle
+	}
+
+	blocks := make([]string, 0, len(matches))
+	titles := make([]string, 0, len(matches))
+	for i, match := range matches {
+		title := strings.TrimSpace(section[match[4]:match[5]])
+		blockEnd := len(section)
+		if i+1 < len(matches) {
+			blockEnd = matches[i+1][0]
+		}
+		blocks = append(blocks, strings.TrimSpace(section[match[1]:blockEnd]))
+		titles = append(titles, title)
+	}
+
+	out := make(map[string]promotionSpecBrief, len(blocks))
+	for i, block := range blocks {
+		brief := parsePromotionSpecBrief(titles[i], block, titles)
+		out[normalizePromotionTitle(titles[i])] = brief
+	}
+	return out, titles, milestoneTitle
+}
+
+func parsePromotionSpecBrief(title, block string, titles []string) promotionSpecBrief {
+	fields := extractPromotionBriefFields(block)
+	purpose := strings.TrimSpace(fields["purpose"])
+	if purpose == "" {
+		purpose = strings.TrimSpace(fields["_lead"])
+	}
+	problem := strings.TrimSpace(fields["problem"])
+	scope := strings.TrimSpace(fields["scope"])
+	if scope == "" {
+		scope = purpose
+	}
+	acceptance := markdownBulletItems(fields["acceptance criteria"])
+	verification := markdownBulletItems(fields["verification"])
+	if len(verification) == 0 {
+		verification = append([]string(nil), acceptance...)
+	}
+	readinessNote := firstNonEmpty(fields["readiness"], fields["approval note"])
+	return promotionSpecBrief{
+		Title:              title,
+		Problem:            problem,
+		Purpose:            purpose,
+		Scope:              scope,
+		AcceptanceCriteria: acceptance,
+		Verification:       verification,
+		Dependencies:       parsePromotionBriefDependencies(fields["dependencies"], titles),
+		Readiness:          parsePromotionBriefReadiness(readinessNote),
+		ReadinessNote:      readinessNote,
+	}
+}
+
+func extractPromotionBriefFields(block string) map[string]string {
+	fields := map[string]string{}
+	matches := promotionBriefFieldPattern.FindAllStringSubmatchIndex(block, -1)
+	if len(matches) == 0 {
+		fields["_lead"] = strings.TrimSpace(block)
+		return fields
+	}
+	fields["_lead"] = strings.TrimSpace(block[:matches[0][0]])
+	for i, match := range matches {
+		key := strings.ToLower(strings.TrimSpace(block[match[2]:match[3]]))
+		value := strings.TrimSpace(block[match[4]:match[5]])
+		end := len(block)
+		if i+1 < len(matches) {
+			end = matches[i+1][0]
+		}
+		tail := strings.TrimSpace(block[match[1]:end])
+		fields[key] = strings.TrimSpace(strings.Join(nonEmptyStrings(value, tail), "\n"))
+	}
+	return fields
+}
+
+func parsePromotionBriefDependencies(raw string, titles []string) []string {
+	raw = strings.TrimSpace(raw)
+	if raw == "" || strings.Contains(strings.ToLower(raw), "none") {
+		return nil
+	}
+	numberPattern := regexp.MustCompile(`[0-9]+`)
+	var dependencies []string
+	for _, match := range numberPattern.FindAllString(raw, -1) {
+		number, err := strconv.Atoi(match)
+		if err == nil && number > 0 && number <= len(titles) {
+			dependencies = append(dependencies, titles[number-1])
+		}
+	}
+	for _, title := range titles {
+		if strings.Contains(strings.ToLower(raw), strings.ToLower(title)) {
+			dependencies = append(dependencies, title)
+		}
+	}
+	return dedupeTitles(dependencies)
+}
+
+func promotionBriefDependencyGuesses(titles []string, briefs map[string]promotionSpecBrief) []MaturityDependencyGuess {
+	out := make([]MaturityDependencyGuess, 0, len(titles))
+	for _, title := range titles {
+		brief := briefs[normalizePromotionTitle(title)]
+		out = append(out, MaturityDependencyGuess{
+			Spec:      title,
+			BlockedBy: append([]string(nil), brief.Dependencies...),
+		})
+	}
+	return out
+}
+
+func parsePromotionBriefReadiness(raw string) ReadinessState {
+	lower := strings.ToLower(strings.TrimSpace(raw))
+	switch {
+	case strings.Contains(lower, "reapproval"),
+		strings.Contains(lower, "unapproved"),
+		strings.Contains(lower, "needs-refinement"),
+		strings.Contains(lower, "needs refinement"):
+		return ReadinessNeedsRefinement
+	case strings.Contains(lower, "blocked"):
+		return ReadinessBlocked
+	case strings.Contains(lower, "approved"), strings.Contains(lower, "ready"):
+		return ReadinessReady
+	case lower != "":
+		return ReadinessClarifying
+	default:
+		return ""
+	}
+}
+
+func markdownBulletItems(section string) []string {
+	var out []string
+	for _, line := range strings.Split(strings.ReplaceAll(section, "\r\n", "\n"), "\n") {
+		item := strings.TrimSpace(line)
+		if !strings.HasPrefix(item, "- ") && !strings.HasPrefix(item, "* ") {
+			continue
+		}
+		item = strings.TrimSpace(item[2:])
+		if strings.HasPrefix(item, "[ ] ") {
+			item = strings.TrimSpace(item[4:])
+		} else if strings.HasPrefix(strings.ToLower(item), "[x] ") {
+			item = strings.TrimSpace(item[4:])
+		}
+		if item != "" {
+			out = append(out, item)
+		}
+	}
+	return dedupeExactStrings(out)
+}
+
+func dedupeExactStrings(items []string) []string {
+	seen := map[string]struct{}{}
+	out := make([]string, 0, len(items))
+	for _, item := range items {
+		item = strings.TrimSpace(item)
+		if item == "" {
+			continue
+		}
+		key := strings.ToLower(item)
+		if _, ok := seen[key]; ok {
+			continue
+		}
+		seen[key] = struct{}{}
+		out = append(out, item)
+	}
+	return out
+}
+
+func normalizePromotionTitle(title string) string {
+	return strings.ToLower(strings.TrimSpace(title))
+}
+
+func nonEmptyStrings(items ...string) []string {
+	out := make([]string, 0, len(items))
+	for _, item := range items {
+		if strings.TrimSpace(item) != "" {
+			out = append(out, strings.TrimSpace(item))
+		}
+	}
+	return out
+}

--- a/internal/planning/collaboration_reconcile.go
+++ b/internal/planning/collaboration_reconcile.go
@@ -1,0 +1,613 @@
+package planning
+
+import (
+	"fmt"
+	"regexp"
+	"sort"
+	"strings"
+
+	"plan/internal/workspace"
+)
+
+type promotionIssueCandidate struct {
+	issue        *GitHubIssue
+	record       *workspace.GitHubPlanningRecord
+	recordSource bool
+	score        int
+	identity     []string
+}
+
+type gitHubIssueRelationshipReader interface {
+	GetIssueRelationships(projectDir, repo string, issueNumber int) (*GitHubIssueRelationships, error)
+}
+
+func (m *Manager) reconcilePromotionDraft(data *collaborationSourceData, draft *PromotionDraft) error {
+	if draft == nil {
+		return nil
+	}
+	initializePromotionRelationshipPlan(draft)
+	if data == nil || data.source.Mode != CollaborationSourceGitHubDiscussion {
+		return nil
+	}
+
+	info, err := m.workspace.EnsureInitialized()
+	if err != nil {
+		return err
+	}
+	context, err := m.github.CurrentContext(info.ProjectDir)
+	if err != nil {
+		return err
+	}
+	state, err := m.workspace.ReadGitHubState()
+	if err != nil {
+		return err
+	}
+	initiatives, err := m.promotionCandidates(
+		info.ProjectDir,
+		context.Repo.Repo,
+		state,
+		"initiative",
+		planIssueInitiativeLabel,
+		data.source,
+	)
+	if err != nil {
+		return err
+	}
+	specs, err := m.promotionCandidates(
+		info.ProjectDir,
+		context.Repo.Repo,
+		state,
+		"spec",
+		planIssueSpecLabel,
+		data.source,
+	)
+	if err != nil {
+		return err
+	}
+
+	used := map[int]struct{}{}
+	var initiativeRelationships *GitHubIssueRelationships
+	if draft.ProposedInitiativeIssue != nil {
+		existing, identity, err := resolvePromotionIssue(*draft.ProposedInitiativeIssue, initiatives, nil, -1, used)
+		if err != nil {
+			return err
+		}
+		if existing != nil {
+			assignPromotionIssueIdentity(draft.ProposedInitiativeIssue, existing, identity)
+			used[existing.Number] = struct{}{}
+			initiativeRelationships, err = m.getIssueRelationships(info.ProjectDir, context.Repo.Repo, existing.Number)
+			if err != nil {
+				return fmt.Errorf("inspect initiative #%d relationships: %w", existing.Number, err)
+			}
+		}
+	}
+
+	parentPositions := map[int]int{}
+	if initiativeRelationships != nil {
+		for i, number := range initiativeRelationships.SubIssues {
+			parentPositions[number] = i
+		}
+	}
+	for i := range draft.ProposedSpecIssues {
+		existing, identity, err := resolvePromotionIssue(
+			draft.ProposedSpecIssues[i],
+			specs,
+			parentPositions,
+			i,
+			used,
+		)
+		if err != nil {
+			return err
+		}
+		if existing == nil {
+			continue
+		}
+		assignPromotionIssueIdentity(&draft.ProposedSpecIssues[i], existing, identity)
+		used[existing.Number] = struct{}{}
+	}
+
+	if err := m.reconcilePromotionMilestone(info.ProjectDir, context, state, data, draft); err != nil {
+		return err
+	}
+	classifyPromotionIssueActions(draft)
+	return m.reconcilePromotionRelationships(info.ProjectDir, context.Repo.Repo, draft, initiativeRelationships)
+}
+
+func initializePromotionRelationshipPlan(draft *PromotionDraft) {
+	draft.RelationshipPlan = nil
+	if draft.ProposedInitiativeIssue != nil {
+		for _, spec := range draft.ProposedSpecIssues {
+			draft.RelationshipPlan = append(draft.RelationshipPlan, PromotionRelationshipPlan{
+				Kind:         "parent_sub_issue",
+				Action:       PromotionActionCreate,
+				IssueTitle:   draft.ProposedInitiativeIssue.Title,
+				RelatedTitle: spec.Title,
+			})
+		}
+	}
+	for _, spec := range draft.ProposedSpecIssues {
+		for _, dependency := range spec.BlockedBy {
+			draft.RelationshipPlan = append(draft.RelationshipPlan, PromotionRelationshipPlan{
+				Kind:         "blocked_by",
+				Action:       PromotionActionCreate,
+				IssueTitle:   spec.Title,
+				RelatedTitle: dependency,
+			})
+		}
+	}
+}
+
+func (m *Manager) promotionCandidates(
+	projectDir, repo string,
+	state *workspace.GitHubState,
+	kind, label string,
+	source CollaborationSourceRef,
+) ([]promotionIssueCandidate, error) {
+	listed, err := m.github.ListIssuesByLabel(projectDir, repo, []string{label})
+	if err != nil {
+		return nil, err
+	}
+	byNumber := make(map[int]*GitHubIssue, len(listed))
+	for i := range listed {
+		copy := listed[i]
+		byNumber[copy.Number] = &copy
+	}
+	if state != nil {
+		for _, record := range state.Planning {
+			if record.Kind != kind || record.IssueNumber <= 0 || !planningRecordMatchesSource(record, source) {
+				continue
+			}
+			if _, ok := byNumber[record.IssueNumber]; ok {
+				continue
+			}
+			issue, err := m.github.GetIssue(projectDir, repo, record.IssueNumber)
+			if err != nil {
+				return nil, fmt.Errorf("inspect Plan metadata issue #%d: %w", record.IssueNumber, err)
+			}
+			byNumber[issue.Number] = issue
+		}
+	}
+
+	recordByIssue := map[int]*workspace.GitHubPlanningRecord{}
+	if state != nil {
+		for _, record := range state.Planning {
+			copy := record
+			if copy.Kind == kind && copy.IssueNumber > 0 {
+				recordByIssue[copy.IssueNumber] = &copy
+			}
+		}
+	}
+	numbers := make([]int, 0, len(byNumber))
+	for number := range byNumber {
+		numbers = append(numbers, number)
+	}
+	sort.Ints(numbers)
+	out := make([]promotionIssueCandidate, 0, len(numbers))
+	for _, number := range numbers {
+		out = append(out, promotionIssueCandidate{
+			issue:        byNumber[number],
+			record:       recordByIssue[number],
+			recordSource: recordByIssue[number] != nil && planningRecordMatchesSource(*recordByIssue[number], source),
+		})
+	}
+	return out, nil
+}
+
+func resolvePromotionIssue(
+	draft PromotionIssueDraft,
+	candidates []promotionIssueCandidate,
+	parentPositions map[int]int,
+	expectedPosition int,
+	used map[int]struct{},
+) (*GitHubIssue, []string, error) {
+	var ranked []promotionIssueCandidate
+	for _, candidate := range candidates {
+		if candidate.issue == nil {
+			continue
+		}
+		if _, ok := used[candidate.issue.Number]; ok {
+			continue
+		}
+		score, identity, strong := scorePromotionIssueCandidate(draft, candidate, parentPositions, expectedPosition)
+		if !strong {
+			continue
+		}
+		candidate.score = score
+		candidate.identity = identity
+		ranked = append(ranked, candidate)
+	}
+	if len(ranked) == 0 {
+		return nil, nil, nil
+	}
+	sort.SliceStable(ranked, func(i, j int) bool {
+		if ranked[i].score == ranked[j].score {
+			return ranked[i].issue.Number < ranked[j].issue.Number
+		}
+		return ranked[i].score > ranked[j].score
+	})
+	if len(ranked) > 1 && ranked[0].score == ranked[1].score {
+		return nil, nil, fmt.Errorf(
+			"ambiguous Plan identity for %s %q: issues #%d and #%d match equally; repair Plan metadata or source links before promotion",
+			draft.Kind,
+			draft.Title,
+			ranked[0].issue.Number,
+			ranked[1].issue.Number,
+		)
+	}
+	return ranked[0].issue, ranked[0].identity, nil
+}
+
+func scorePromotionIssueCandidate(
+	draft PromotionIssueDraft,
+	candidate promotionIssueCandidate,
+	parentPositions map[int]int,
+	expectedPosition int,
+) (int, []string, bool) {
+	issue := candidate.issue
+	if issue == nil {
+		return 0, nil, false
+	}
+	score := 0
+	var identity []string
+	recordSource := candidate.recordSource
+	sourceLink := issueBodyMatchesSource(issue.Body, draft.SourceLinks)
+	exactSlug := slugify(issue.Title) == draft.Slug
+	similarity := promotionTitleSimilarity(issue.Title, draft.Title)
+	planLabel := containsString(issue.Labels, planIssueInitiativeLabel) || containsString(issue.Labels, planIssueSpecLabel)
+
+	if candidate.record != nil && candidate.record.Slug == draft.Slug && recordSource {
+		score += 1000
+		identity = append(identity, "plan_metadata")
+	}
+	if recordSource {
+		score += 300
+		identity = appendIdentity(identity, "source_identity")
+	}
+	if sourceLink {
+		score += 250
+		identity = appendIdentity(identity, "source_link")
+	}
+	if exactSlug {
+		score += 200
+		identity = appendIdentity(identity, "stable_slug")
+	}
+	if similarity >= 0.35 {
+		score += int(similarity * 100)
+		identity = appendIdentity(identity, "title_similarity")
+	}
+	parentPosition, hasParent := parentPositions[issue.Number]
+	if hasParent {
+		score += 100
+		identity = appendIdentity(identity, "parent_sub_issue")
+	}
+	positionMatch := hasParent && expectedPosition >= 0 && parentPosition == expectedPosition
+	if positionMatch {
+		score += 75
+		identity = appendIdentity(identity, "parent_sub_issue_order")
+	}
+	if candidate.record != nil && candidate.record.ParentIssueNumber > 0 {
+		score += 50
+		identity = appendIdentity(identity, "parent_metadata")
+	}
+	strong := (recordSource || sourceLink) && (exactSlug || similarity >= 0.35 || positionMatch)
+	strong = strong || (exactSlug && planLabel)
+	strong = strong || (candidate.record != nil && candidate.record.Slug == draft.Slug && recordSource)
+	return score, identity, strong
+}
+
+func planningRecordMatchesSource(record workspace.GitHubPlanningRecord, source CollaborationSourceRef) bool {
+	if source.Discussion == nil {
+		return false
+	}
+	if record.SourceMode != "" && record.SourceMode != string(CollaborationSourceGitHubDiscussion) {
+		return false
+	}
+	if record.DiscussionNumber > 0 && record.DiscussionNumber == source.Discussion.Number {
+		return true
+	}
+	return strings.TrimSpace(record.DiscussionURL) != "" &&
+		strings.EqualFold(strings.TrimSpace(record.DiscussionURL), strings.TrimSpace(source.Discussion.URL))
+}
+
+func issueBodyMatchesSource(body string, sourceLinks []string) bool {
+	for _, link := range sourceLinks {
+		if strings.TrimSpace(link) != "" && strings.Contains(strings.ToLower(body), strings.ToLower(strings.TrimSpace(link))) {
+			return true
+		}
+	}
+	return false
+}
+
+func assignPromotionIssueIdentity(draft *PromotionIssueDraft, existing *GitHubIssue, identity []string) {
+	draft.IssueNumber = existing.Number
+	draft.IssueURL = existing.URL
+	draft.Identity = strings.Join(dedupeExactStrings(identity), ",")
+	draft.existing = existing
+}
+
+func (m *Manager) reconcilePromotionMilestone(
+	projectDir string,
+	context *GitHubContext,
+	state *workspace.GitHubState,
+	data *collaborationSourceData,
+	draft *PromotionDraft,
+) error {
+	if draft.MilestonePlan == nil {
+		return nil
+	}
+	var existing *GitHubMilestone
+	identity := ""
+	if draft.ProposedInitiativeIssue != nil && draft.ProposedInitiativeIssue.existing != nil &&
+		draft.ProposedInitiativeIssue.existing.Milestone != nil {
+		copy := *draft.ProposedInitiativeIssue.existing.Milestone
+		existing = &copy
+		identity = "initiative_milestone"
+	}
+	if existing == nil {
+		var common *GitHubMilestone
+		for i := range draft.ProposedSpecIssues {
+			issue := draft.ProposedSpecIssues[i].existing
+			if issue == nil || issue.Milestone == nil {
+				continue
+			}
+			if common == nil {
+				copy := *issue.Milestone
+				common = &copy
+				continue
+			}
+			if common.Number != issue.Milestone.Number {
+				return fmt.Errorf("ambiguous milestone identity: reconciled spec issues use milestones #%d and #%d", common.Number, issue.Milestone.Number)
+			}
+		}
+		if common != nil {
+			existing = common
+			identity = "spec_milestone"
+		}
+	}
+	if existing == nil && state != nil && draft.ProposedInitiativeIssue != nil {
+		if record, ok := state.Planning[draft.ProposedInitiativeIssue.Slug]; ok &&
+			planningRecordMatchesSource(record, data.source) &&
+			strings.TrimSpace(record.MilestoneTitle) != "" {
+			found, err := m.github.FindMilestone(projectDir, context.Repo.Repo, record.MilestoneTitle)
+			if err != nil {
+				return err
+			}
+			if found != nil {
+				existing = found
+				identity = "plan_metadata"
+			}
+		}
+	}
+	if existing == nil && strings.TrimSpace(data.milestoneTitle) != "" {
+		found, err := m.github.FindMilestone(projectDir, context.Repo.Repo, data.milestoneTitle)
+		if err != nil {
+			return err
+		}
+		if found != nil {
+			existing = found
+			identity = "source_identity"
+		}
+	}
+	if existing == nil {
+		draft.MilestonePlan.Action = PromotionActionCreate
+		draft.MilestonePlan.Create = true
+		return nil
+	}
+	draft.MilestonePlan.Action = PromotionActionReuse
+	draft.MilestonePlan.Create = false
+	draft.MilestonePlan.Title = existing.Title
+	draft.MilestonePlan.Number = existing.Number
+	draft.MilestonePlan.URL = strings.TrimRight(context.Repo.RepoURL, "/") + "/milestone/" + fmt.Sprint(existing.Number)
+	draft.MilestonePlan.Identity = identity
+	draft.MilestonePlan.existing = existing
+	return nil
+}
+
+func classifyPromotionIssueActions(draft *PromotionDraft) {
+	var milestone *GitHubMilestone
+	if draft.MilestonePlan != nil {
+		milestone = draft.MilestonePlan.existing
+	}
+	if draft.ProposedInitiativeIssue != nil {
+		classifyPromotionIssueAction(draft.ProposedInitiativeIssue, milestone)
+	}
+	for i := range draft.ProposedSpecIssues {
+		classifyPromotionIssueAction(&draft.ProposedSpecIssues[i], milestone)
+	}
+}
+
+func classifyPromotionIssueAction(draft *PromotionIssueDraft, milestone *GitHubMilestone) {
+	if draft == nil || draft.existing == nil {
+		draft.Action = PromotionActionCreate
+		return
+	}
+	existing := draft.existing
+	unchanged := strings.TrimSpace(existing.Title) == strings.TrimSpace(draft.Title) &&
+		strings.TrimSpace(existing.Body) == strings.TrimSpace(draft.Body) &&
+		promotionLabelsMatch(existing.Labels, draft.Labels)
+	if milestone != nil {
+		unchanged = unchanged && existing.Milestone != nil && existing.Milestone.Number == milestone.Number
+	}
+	if unchanged {
+		draft.Action = PromotionActionUnchanged
+	} else {
+		draft.Action = PromotionActionUpdate
+	}
+}
+
+func (m *Manager) applyPromotionIssue(
+	projectDir, repo string,
+	draft *PromotionIssueDraft,
+	milestone *GitHubMilestone,
+) (*GitHubIssue, error) {
+	if draft == nil {
+		return nil, fmt.Errorf("promotion issue draft is required")
+	}
+	if draft.Action == PromotionActionUnchanged || draft.Action == PromotionActionReuse {
+		if draft.existing == nil {
+			return nil, fmt.Errorf("promotion %s %q is classified %s without an existing issue", draft.Kind, draft.Title, draft.Action)
+		}
+		copy := *draft.existing
+		copy.Labels = append([]string(nil), draft.existing.Labels...)
+		return &copy, nil
+	}
+	input := GitHubIssueInput{
+		Title:  draft.Title,
+		Body:   draft.Body,
+		State:  "open",
+		Labels: append([]string(nil), draft.Labels...),
+	}
+	if milestone != nil {
+		input.Milestone = &milestone.Number
+	}
+	if draft.Action == PromotionActionUpdate {
+		if draft.existing == nil {
+			return nil, fmt.Errorf("promotion %s %q is classified update without an existing issue", draft.Kind, draft.Title)
+		}
+		input.State = draft.existing.State
+		input.Labels = reconcilePromotionLabels(draft.existing.Labels, draft.Labels)
+		return m.github.UpdateIssue(projectDir, repo, draft.existing.Number, input)
+	}
+	return m.github.CreateIssue(projectDir, repo, input)
+}
+
+func (m *Manager) reconcilePromotionRelationships(
+	projectDir, repo string,
+	draft *PromotionDraft,
+	initiativeRelationships *GitHubIssueRelationships,
+) error {
+	relationships := map[int]*GitHubIssueRelationships{}
+	if draft.ProposedInitiativeIssue != nil && draft.ProposedInitiativeIssue.IssueNumber > 0 && initiativeRelationships != nil {
+		relationships[draft.ProposedInitiativeIssue.IssueNumber] = initiativeRelationships
+	}
+	for i := range draft.ProposedSpecIssues {
+		number := draft.ProposedSpecIssues[i].IssueNumber
+		if number <= 0 {
+			continue
+		}
+		current, err := m.getIssueRelationships(projectDir, repo, number)
+		if err != nil {
+			return fmt.Errorf("inspect spec #%d relationships: %w", number, err)
+		}
+		relationships[number] = current
+	}
+	specByTitle := map[string]*PromotionIssueDraft{}
+	for i := range draft.ProposedSpecIssues {
+		specByTitle[normalizePromotionTitle(draft.ProposedSpecIssues[i].Title)] = &draft.ProposedSpecIssues[i]
+	}
+	for i := range draft.RelationshipPlan {
+		plan := &draft.RelationshipPlan[i]
+		switch plan.Kind {
+		case "parent_sub_issue":
+			if draft.ProposedInitiativeIssue == nil {
+				continue
+			}
+			spec := specByTitle[normalizePromotionTitle(plan.RelatedTitle)]
+			plan.IssueNumber = draft.ProposedInitiativeIssue.IssueNumber
+			if spec != nil {
+				plan.RelatedIssueNumber = spec.IssueNumber
+			}
+			if containsInt(relationships[plan.IssueNumber], plan.RelatedIssueNumber, true) {
+				plan.Action = PromotionActionReuse
+			}
+		case "blocked_by":
+			spec := specByTitle[normalizePromotionTitle(plan.IssueTitle)]
+			dependency := specByTitle[normalizePromotionTitle(plan.RelatedTitle)]
+			if spec != nil {
+				plan.IssueNumber = spec.IssueNumber
+			}
+			if dependency != nil {
+				plan.RelatedIssueNumber = dependency.IssueNumber
+			}
+			if containsInt(relationships[plan.IssueNumber], plan.RelatedIssueNumber, false) {
+				plan.Action = PromotionActionReuse
+			}
+		}
+	}
+	return nil
+}
+
+func (m *Manager) getIssueRelationships(projectDir, repo string, issueNumber int) (*GitHubIssueRelationships, error) {
+	reader, ok := m.github.(gitHubIssueRelationshipReader)
+	if !ok {
+		return nil, fmt.Errorf("GitHub client does not support read-only issue relationship inspection")
+	}
+	return reader.GetIssueRelationships(projectDir, repo, issueNumber)
+}
+
+func containsInt(relationships *GitHubIssueRelationships, number int, subIssue bool) bool {
+	if relationships == nil || number <= 0 {
+		return false
+	}
+	items := relationships.BlockedBy
+	if subIssue {
+		items = relationships.SubIssues
+	}
+	for _, item := range items {
+		if item == number {
+			return true
+		}
+	}
+	return false
+}
+
+func promotionLabelsMatch(existing, desired []string) bool {
+	effective := reconcilePromotionLabels(existing, desired)
+	if len(effective) != len(existing) {
+		return false
+	}
+	for _, item := range effective {
+		if !containsString(existing, item) {
+			return false
+		}
+	}
+	return true
+}
+
+func reconcilePromotionLabels(existing, desired []string) []string {
+	out := make([]string, 0, len(existing)+len(desired))
+	for _, label := range existing {
+		if label == planIssueInitiativeLabel ||
+			label == planIssueSpecLabel ||
+			label == planIssueReadyLabel ||
+			label == planIssueBlockedLabel {
+			continue
+		}
+		out = append(out, label)
+	}
+	return mergeLabels(out, desired)
+}
+
+func appendIdentity(items []string, item string) []string {
+	for _, existing := range items {
+		if existing == item {
+			return items
+		}
+	}
+	return append(items, item)
+}
+
+var promotionTitleTokenPattern = regexp.MustCompile(`[a-z0-9]+`)
+
+func promotionTitleSimilarity(left, right string) float64 {
+	leftTokens := promotionTitleTokenPattern.FindAllString(strings.ToLower(left), -1)
+	rightTokens := promotionTitleTokenPattern.FindAllString(strings.ToLower(right), -1)
+	if len(leftTokens) == 0 || len(rightTokens) == 0 {
+		return 0
+	}
+	leftSet := map[string]struct{}{}
+	rightSet := map[string]struct{}{}
+	for _, token := range leftTokens {
+		leftSet[token] = struct{}{}
+	}
+	for _, token := range rightTokens {
+		rightSet[token] = struct{}{}
+	}
+	intersection := 0
+	for token := range leftSet {
+		if _, ok := rightSet[token]; ok {
+			intersection++
+		}
+	}
+	return float64(2*intersection) / float64(len(leftSet)+len(rightSet))
+}

--- a/internal/planning/collaboration_test.go
+++ b/internal/planning/collaboration_test.go
@@ -3,6 +3,8 @@ package planning
 import (
 	"encoding/json"
 	"errors"
+	"os"
+	"path/filepath"
 	"strconv"
 	"strings"
 	"testing"
@@ -152,6 +154,12 @@ func TestAssessAndPromoteGitHubDiscussion(t *testing.T) {
 	}
 	if draft.MilestonePlan == nil || !draft.MilestonePlan.Create {
 		t.Fatalf("expected milestone plan: %+v", draft)
+	}
+	if draft.ProposedInitiativeIssue.Action != PromotionActionCreate ||
+		draft.ProposedSpecIssues[0].Action != PromotionActionCreate ||
+		draft.ProposedSpecIssues[1].Action != PromotionActionCreate ||
+		draft.MilestonePlan.Action != PromotionActionCreate {
+		t.Fatalf("expected fresh promotion to classify every artifact as create: %+v", draft)
 	}
 	if !draft.ConfirmationRequired {
 		t.Fatalf("expected explicit confirmation requirement: %+v", draft)
@@ -847,4 +855,319 @@ func TestExtractSpecCandidatesSupportsExplicitSpecIssuePatterns(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestVoltPromotionPreviewReconcilesExistingInitiativeSpecsAndMilestone(t *testing.T) {
+	manager, _, client := newVoltPromotionFixture(t)
+
+	draft, err := manager.BuildPromotionDraft(PromotionDraftInput{DiscussionRef: "1"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !draft.ConfirmationRequired || draft.ManualFallbackAllowed {
+		t.Fatalf("unexpected preview safety flags: %+v", draft)
+	}
+	if draft.ProposedInitiativeIssue == nil {
+		t.Fatalf("expected reconciled initiative: %+v", draft)
+	}
+	if draft.ProposedInitiativeIssue.IssueNumber != 2 || draft.ProposedInitiativeIssue.Action != PromotionActionUpdate {
+		t.Fatalf("expected initiative #2 update: %+v", draft.ProposedInitiativeIssue)
+	}
+	if draft.MilestonePlan == nil ||
+		draft.MilestonePlan.Action != PromotionActionReuse ||
+		draft.MilestonePlan.Create ||
+		draft.MilestonePlan.Number != 1 ||
+		draft.MilestonePlan.Title != "Volt v0 — Evidence-Ready Research Prototype" {
+		t.Fatalf("expected milestone #1 reuse: %+v", draft.MilestonePlan)
+	}
+
+	expected := []struct {
+		number  int
+		title   string
+		blocked []string
+	}{
+		{3, "Research evidence and evaluation protocol", nil},
+		{4, "Volt v0 language kernel and canonical syntax", []string{"Research evidence and evaluation protocol"}},
+		{5, "Reference interpreter, program graph, and DiagnosticV1 protocol", []string{"Research evidence and evaluation protocol", "Volt v0 language kernel and canonical syntax"}},
+		{6, "Benchmark corpus and controlled agent study", []string{"Research evidence and evaluation protocol", "Volt v0 language kernel and canonical syntax", "Reference interpreter, program graph, and DiagnosticV1 protocol"}},
+	}
+	if len(draft.ProposedSpecIssues) != len(expected) {
+		t.Fatalf("expected four specs: %+v", draft.ProposedSpecIssues)
+	}
+	bodies := map[string]struct{}{}
+	for i, want := range expected {
+		got := draft.ProposedSpecIssues[i]
+		if got.IssueNumber != want.number || got.Title != want.title || got.Action != PromotionActionUpdate {
+			t.Fatalf("unexpected spec %d reconciliation: %+v", i+1, got)
+		}
+		if !sameStrings(got.BlockedBy, want.blocked) {
+			t.Fatalf("unexpected dependencies for #%d: got=%v want=%v", got.IssueNumber, got.BlockedBy, want.blocked)
+		}
+		if !strings.Contains(got.Body, "## Acceptance Criteria") || !strings.Contains(got.Body, "## Verification") {
+			t.Fatalf("expected acceptance criteria and verification in #%d body:\n%s", got.IssueNumber, got.Body)
+		}
+		if _, duplicate := bodies[got.Body]; duplicate {
+			t.Fatalf("expected materially distinct spec bodies; duplicate body for #%d", got.IssueNumber)
+		}
+		bodies[got.Body] = struct{}{}
+	}
+	if !strings.Contains(draft.ProposedSpecIssues[0].Body, "Safe evolution remains explicitly unvalidated.") ||
+		!strings.Contains(draft.ProposedSpecIssues[3].Body, "Runs are reproducible from content-addressed pinned inputs.") {
+		t.Fatalf("expected per-spec acceptance criteria to survive rendering")
+	}
+	for _, relationship := range draft.RelationshipPlan {
+		if relationship.Action != PromotionActionReuse {
+			t.Fatalf("expected existing relationship reuse, got %+v", relationship)
+		}
+	}
+	if client.createIssueCalls != 0 || client.updateIssueCalls != 0 || len(client.labels) != 0 {
+		t.Fatalf("preview mutated GitHub stub: creates=%d updates=%d labels=%v", client.createIssueCalls, client.updateIssueCalls, client.labels)
+	}
+	if len(client.milestones) != 1 || len(client.subIssues) != 4 || len(client.blockedByEdges) != 6 {
+		t.Fatalf("preview changed existing artifacts or relationships")
+	}
+}
+
+func TestVoltPromotionApplyIsIdempotentAndPreservesDependencies(t *testing.T) {
+	manager, ws, client := newVoltPromotionFixture(t)
+
+	result, err := manager.ApplyPromotionDraft(PromotionApplyInput{
+		DiscussionRef: "1",
+		Confirm:       true,
+		TargetMode:    SourceOfTruthGitHub,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.Initiative == nil || result.Initiative.Number != 2 || len(result.Specs) != 4 {
+		t.Fatalf("unexpected reconciliation apply result: %+v", result)
+	}
+	if client.createIssueCalls != 0 || client.updateIssueCalls != 5 {
+		t.Fatalf("expected five existing issue updates and no creates: creates=%d updates=%d", client.createIssueCalls, client.updateIssueCalls)
+	}
+	if len(client.milestones) != 1 || len(client.subIssues) != 4 || len(client.blockedByEdges) != 6 {
+		t.Fatalf("apply duplicated milestone or relationships")
+	}
+	state, err := ws.ReadGitHubState()
+	if err != nil {
+		t.Fatal(err)
+	}
+	expectedBlocked := map[string][]string{
+		"research-evidence-and-evaluation-protocol":                     nil,
+		"volt-v0-language-kernel-and-canonical-syntax":                  {"research-evidence-and-evaluation-protocol"},
+		"reference-interpreter-program-graph-and-diagnosticv1-protocol": {"research-evidence-and-evaluation-protocol", "volt-v0-language-kernel-and-canonical-syntax"},
+		"benchmark-corpus-and-controlled-agent-study":                   {"research-evidence-and-evaluation-protocol", "volt-v0-language-kernel-and-canonical-syntax", "reference-interpreter-program-graph-and-diagnosticv1-protocol"},
+	}
+	for slug, blocked := range expectedBlocked {
+		if !sameStrings(state.Planning[slug].BlockedBy, blocked) {
+			t.Fatalf("unexpected mirrored dependencies for %s: got=%v want=%v", slug, state.Planning[slug].BlockedBy, blocked)
+		}
+	}
+
+	second, err := manager.ApplyPromotionDraft(PromotionApplyInput{
+		DiscussionRef: "1",
+		Confirm:       true,
+		TargetMode:    SourceOfTruthGitHub,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if client.createIssueCalls != 0 || client.updateIssueCalls != 5 {
+		t.Fatalf("repeated apply should not create or update unchanged issues: creates=%d updates=%d", client.createIssueCalls, client.updateIssueCalls)
+	}
+	if len(client.milestones) != 1 || len(client.subIssues) != 4 || len(client.blockedByEdges) != 6 {
+		t.Fatalf("repeated apply duplicated milestone or relationships")
+	}
+	if second.Draft.ProposedInitiativeIssue.Action != PromotionActionUnchanged {
+		t.Fatalf("expected second apply preview to classify initiative unchanged: %+v", second.Draft.ProposedInitiativeIssue)
+	}
+	for _, spec := range second.Draft.ProposedSpecIssues {
+		if spec.Action != PromotionActionUnchanged {
+			t.Fatalf("expected second apply preview to classify specs unchanged: %+v", spec)
+		}
+	}
+}
+
+func TestPromotionPreviewBlocksAmbiguousPlanIdentity(t *testing.T) {
+	manager, ws, client := newVoltPromotionFixture(t)
+	duplicate := *client.issues[2]
+	duplicate.Number = 20
+	duplicate.URL = "https://github.com/JimmyMcBride/volt/issues/20"
+	client.issues[20] = &duplicate
+	state, err := ws.ReadGitHubState()
+	if err != nil {
+		t.Fatal(err)
+	}
+	delete(state.Planning, "volt-language-thesis-and-minimum-semantic-core")
+	if err := ws.WriteGitHubState(*state); err != nil {
+		t.Fatal(err)
+	}
+
+	_, err = manager.BuildPromotionDraft(PromotionDraftInput{DiscussionRef: "1"})
+	if err == nil || !strings.Contains(err.Error(), "ambiguous Plan identity") {
+		t.Fatalf("expected blocking ambiguity error, got %v", err)
+	}
+	if client.createIssueCalls != 0 || client.updateIssueCalls != 0 {
+		t.Fatalf("ambiguous preview must not mutate GitHub")
+	}
+}
+
+func TestParsePromotionMapPreservesExplicitVerification(t *testing.T) {
+	content := strings.Join([]string{
+		"## Promotion map",
+		"",
+		"Target milestone: **Example milestone**",
+		"",
+		"### Spec 1 — Independent parser",
+		"",
+		"Parse one independent brief.",
+		"",
+		"Scope:",
+		"",
+		"Only this parser.",
+		"",
+		"Acceptance criteria:",
+		"",
+		"- Parser keeps the brief.",
+		"",
+		"Verification:",
+		"",
+		"- Run the parser fixture.",
+		"",
+		"Dependencies: none.",
+		"",
+		"Readiness: ready.",
+	}, "\n")
+	briefs, titles, milestone := parsePromotionMap(content)
+	if len(titles) != 1 || milestone != "Example milestone" {
+		t.Fatalf("unexpected promotion map parse: titles=%v milestone=%q", titles, milestone)
+	}
+	brief := briefs[normalizePromotionTitle(titles[0])]
+	if !sameStrings(brief.AcceptanceCriteria, []string{"Parser keeps the brief."}) ||
+		!sameStrings(brief.Verification, []string{"Run the parser fixture."}) ||
+		brief.Scope != "Only this parser." ||
+		brief.Readiness != ReadinessReady {
+		t.Fatalf("unexpected parsed brief: %+v", brief)
+	}
+}
+
+func newVoltPromotionFixture(t *testing.T) (*Manager, *workspace.Manager, *stubGitHubClient) {
+	t.Helper()
+	body, err := os.ReadFile(filepath.Join("..", "..", "testdata", "collaboration", "volt-discussion-1.md"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	milestone := &GitHubMilestone{Number: 1, Title: "Volt v0 — Evidence-Ready Research Prototype"}
+	sourceURL := "https://github.com/JimmyMcBride/volt/discussions/1"
+	issue := func(number int, title, kind string, labels ...string) *GitHubIssue {
+		return &GitHubIssue{
+			Number:    number,
+			URL:       "https://github.com/JimmyMcBride/volt/issues/" + strconv.Itoa(number),
+			Title:     title,
+			Body:      "## Existing " + kind + "\n\n## Source\n\n- [" + sourceURL + "](" + sourceURL + ")",
+			State:     "open",
+			Labels:    append([]string{"enhancement"}, labels...),
+			Milestone: &GitHubMilestone{Number: milestone.Number, Title: milestone.Title},
+		}
+	}
+	client := &stubGitHubClient{
+		preflight: &GitHubRepoInfo{
+			Repo:          "JimmyMcBride/volt",
+			RepoURL:       "https://github.com/JimmyMcBride/volt",
+			DefaultBranch: "main",
+		},
+		context: &GitHubContext{
+			Repo: GitHubRepoInfo{
+				Repo:          "JimmyMcBride/volt",
+				RepoURL:       "https://github.com/JimmyMcBride/volt",
+				DefaultBranch: "main",
+			},
+			CurrentBranch: "main",
+			CurrentSHA:    "abc123",
+		},
+		issues: map[int]*GitHubIssue{
+			2: issue(2, "Volt language thesis and minimum semantic core", "initiative", planIssueInitiativeLabel),
+			3: issue(3, "Research evidence and evaluation protocol", "spec", planIssueSpecLabel, planIssueReadyLabel),
+			4: issue(4, "Volt v0 language kernel and canonical syntax", "spec", planIssueSpecLabel),
+			5: issue(5, "Reference interpreter and DiagnosticV1 protocol", "spec", planIssueSpecLabel),
+			6: issue(6, "Benchmark corpus and controlled agent study", "spec", planIssueSpecLabel),
+		},
+		milestones: map[string]*GitHubMilestone{
+			milestone.Title: milestone,
+		},
+		discussions: map[int]*GitHubDiscussion{
+			1: {
+				Number: 1,
+				URL:    sourceURL,
+				Title:  "Volt language thesis and minimum semantic core",
+				Body:   string(body),
+			},
+		},
+		subIssues:      [][2]int{{2, 3}, {2, 4}, {2, 5}, {2, 6}},
+		blockedByEdges: [][2]int{{4, 3}, {5, 3}, {5, 4}, {6, 3}, {6, 4}, {6, 5}},
+		nextIssue:      7,
+	}
+	reset := SetGitHubClientFactoryForTesting(func() GitHubClient { return client })
+	t.Cleanup(reset)
+
+	root := t.TempDir()
+	ws := workspace.New(root)
+	if _, err := ws.Init(); err != nil {
+		t.Fatal(err)
+	}
+	meta, err := ws.ReadWorkspaceMeta()
+	if err != nil {
+		t.Fatal(err)
+	}
+	meta.SourceMode = workspace.SourceOfTruthGitHub
+	if err := ws.WriteWorkspaceMeta(*meta); err != nil {
+		t.Fatal(err)
+	}
+	planning := map[string]workspace.GitHubPlanningRecord{}
+	addRecord := func(slug, kind, title string, number, parent int) {
+		planning[slug] = workspace.GitHubPlanningRecord{
+			Slug:              slug,
+			Kind:              kind,
+			Title:             title,
+			IssueNumber:       number,
+			IssueURL:          "https://github.com/JimmyMcBride/volt/issues/" + strconv.Itoa(number),
+			RemoteState:       "open",
+			Readiness:         "ready",
+			OwnershipMode:     "github",
+			EntryMode:         "github_collaborative",
+			SourceMode:        "github_discussion",
+			DiscussionNumber:  1,
+			DiscussionURL:     sourceURL,
+			ParentIssueNumber: parent,
+			MilestoneNumber:   1,
+			MilestoneTitle:    milestone.Title,
+		}
+	}
+	addRecord("volt-language-thesis-and-minimum-semantic-core", "initiative", "Volt language thesis and minimum semantic core", 2, 0)
+	addRecord("research-evidence-and-evaluation-protocol", "spec", "Research evidence and evaluation protocol", 3, 2)
+	addRecord("volt-v0-language-kernel-and-canonical-syntax", "spec", "Volt v0 language kernel and canonical syntax", 4, 2)
+	addRecord("reference-interpreter-and-diagnosticv1-protocol", "spec", "Reference interpreter and DiagnosticV1 protocol", 5, 2)
+	addRecord("benchmark-corpus-and-controlled-agent-study", "spec", "Benchmark corpus and controlled agent study", 6, 2)
+	if err := ws.WriteGitHubState(workspace.GitHubState{
+		Repo:          "JimmyMcBride/volt",
+		RepoURL:       "https://github.com/JimmyMcBride/volt",
+		DefaultBranch: "main",
+		Stories:       map[string]workspace.GitHubStoryRecord{},
+		Planning:      planning,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	return New(ws), ws, client
+}
+
+func sameStrings(left, right []string) bool {
+	if len(left) != len(right) {
+		return false
+	}
+	for i := range left {
+		if left[i] != right[i] {
+			return false
+		}
+	}
+	return true
 }

--- a/internal/planning/github_backend_test.go
+++ b/internal/planning/github_backend_test.go
@@ -27,6 +27,9 @@ type stubGitHubClient struct {
 	projectItems        []GitHubProjectItemResult
 	projectValues       []stubProjectValue
 	projectAddNilValues bool
+	createIssueCalls    int
+	updateIssueCalls    int
+	relationshipReads   int
 	nextIssue           int
 	nextProject         int
 	lastCreate          GitHubIssueInput
@@ -61,6 +64,7 @@ func (s *stubGitHubClient) CreateIssue(projectDir, repo string, input GitHubIssu
 		return nil, s.createIssueErr
 	}
 	s.lastCreate = input
+	s.createIssueCalls++
 	if s.issues == nil {
 		s.issues = map[int]*GitHubIssue{}
 	}
@@ -94,6 +98,7 @@ func (s *stubGitHubClient) CreateIssue(projectDir, repo string, input GitHubIssu
 
 func (s *stubGitHubClient) UpdateIssue(projectDir, repo string, issueNumber int, input GitHubIssueInput) (*GitHubIssue, error) {
 	s.lastUpdate = input
+	s.updateIssueCalls++
 	issue, ok := s.issues[issueNumber]
 	if !ok {
 		panic("unexpected UpdateIssue call")
@@ -143,6 +148,22 @@ func (s *stubGitHubClient) ListIssuesByLabel(projectDir, repo string, labels []s
 				out = append(out, copy)
 				break
 			}
+		}
+	}
+	return out, nil
+}
+
+func (s *stubGitHubClient) GetIssueRelationships(projectDir, repo string, issueNumber int) (*GitHubIssueRelationships, error) {
+	s.relationshipReads++
+	out := &GitHubIssueRelationships{}
+	for _, edge := range s.subIssues {
+		if edge[0] == issueNumber {
+			out.SubIssues = append(out.SubIssues, edge[1])
+		}
+	}
+	for _, edge := range s.blockedByEdges {
+		if edge[0] == issueNumber {
+			out.BlockedBy = append(out.BlockedBy, edge[1])
 		}
 	}
 	return out, nil

--- a/internal/planning/github_client.go
+++ b/internal/planning/github_client.go
@@ -78,6 +78,11 @@ type GitHubIssue struct {
 	Milestone *GitHubMilestone
 }
 
+type GitHubIssueRelationships struct {
+	SubIssues []int
+	BlockedBy []int
+}
+
 type GitHubLabelInput struct {
 	Name        string
 	Color       string
@@ -347,6 +352,54 @@ func (c *cliGitHubClient) ListIssuesByLabel(projectDir, repo string, labels []st
 	return issues, nil
 }
 
+func (c *cliGitHubClient) GetIssueRelationships(projectDir, repo string, issueNumber int) (*GitHubIssueRelationships, error) {
+	readNumbers := func(path, relationship string) ([]int, error) {
+		out, err := c.api(projectDir, "GET", path, nil)
+		if err != nil {
+			return nil, err
+		}
+		var issues []struct {
+			Number  int    `json:"number"`
+			NodeID  string `json:"node_id"`
+			HTMLURL string `json:"html_url"`
+		}
+		if err := json.Unmarshal(out, &issues); err != nil {
+			return nil, fmt.Errorf("parse GitHub %s relationships for issue #%d: %w", relationship, issueNumber, err)
+		}
+		if len(issues) >= 100 {
+			return nil, fmt.Errorf("GitHub %s listing for issue #%d reached the 100-item safety limit; refusing to reconcile an incomplete relationship set", relationship, issueNumber)
+		}
+		numbers := make([]int, 0, len(issues))
+		for i := range issues {
+			c.cacheIssueNodeID(repo, &GitHubIssue{
+				Number: issues[i].Number,
+				NodeID: issues[i].NodeID,
+				URL:    issues[i].HTMLURL,
+			})
+			numbers = append(numbers, issues[i].Number)
+		}
+		return numbers, nil
+	}
+	subIssues, err := readNumbers(
+		fmt.Sprintf("repos/%s/issues/%d/sub_issues?per_page=100", repo, issueNumber),
+		"sub-issue",
+	)
+	if err != nil {
+		return nil, err
+	}
+	blockedBy, err := readNumbers(
+		fmt.Sprintf("repos/%s/issues/%d/dependencies/blocked_by?per_page=100", repo, issueNumber),
+		"blocked-by",
+	)
+	if err != nil {
+		return nil, err
+	}
+	return &GitHubIssueRelationships{
+		SubIssues: subIssues,
+		BlockedBy: blockedBy,
+	}, nil
+}
+
 func (c *cliGitHubClient) EnsureLabel(projectDir, repo string, input GitHubLabelInput) error {
 	args := []string{"label", "create", input.Name, "--repo", repo, "--force"}
 	if strings.TrimSpace(input.Color) != "" {
@@ -374,12 +427,16 @@ func (c *cliGitHubClient) FindMilestone(projectDir, repo, title string) (*GitHub
 	if err := json.Unmarshal(out, &milestones); err != nil {
 		return nil, fmt.Errorf("parse milestones: %w", err)
 	}
+	var match *GitHubMilestone
 	for _, milestone := range milestones {
 		if strings.EqualFold(strings.TrimSpace(milestone.Title), strings.TrimSpace(title)) {
-			return &GitHubMilestone{Number: milestone.Number, Title: milestone.Title}, nil
+			if match != nil {
+				return nil, fmt.Errorf("ambiguous GitHub milestone title %q matches milestones #%d and #%d", title, match.Number, milestone.Number)
+			}
+			match = &GitHubMilestone{Number: milestone.Number, Title: milestone.Title}
 		}
 	}
-	return nil, nil
+	return match, nil
 }
 
 func (c *cliGitHubClient) CreateMilestone(projectDir, repo string, input GitHubMilestoneInput) (*GitHubMilestone, error) {

--- a/skills/plan/SKILL.md
+++ b/skills/plan/SKILL.md
@@ -82,6 +82,14 @@ When a repo uses `plan`:
 - `brainstorm challenge` should pressure-test risk, no-gos, and overengineering before promotion.
 - `discuss assess` should produce an explicit maturity decision before a GitHub-backed promotion happens.
 - `discuss promote` should stay draft-first unless the task explicitly calls for `--apply --confirm`.
+- Treat promotion previews as reconciliation plans: inspect Plan metadata,
+  source links, stable slugs, parent/sub-issue grouping, dependencies, and
+  milestone metadata before proposing new artifacts.
+- Require explicit `create`, `update`, `reuse`, or `unchanged` actions in the
+  promotion JSON, and stop on ambiguous identity instead of title guessing.
+- Preserve each structured Promotion map spec brief independently, including
+  scope, acceptance criteria, verification, readiness, and dependencies.
+- Repeated confirmed promotion apply must remain idempotent.
 - In `github` or `hybrid` source mode, never create planning issues, labels, milestones, or project prompts with `gh` unless Plan emitted `manual_fallback_allowed=true`.
 - If Plan output disagrees with user intent, repair the Plan source with `plan discuss repair` and rerun assess/promote instead of filling the gap manually.
 - today, `discuss promote --apply` is implemented for `github` and `hybrid`; repo-backed local promotion still uses the legacy compatibility path

--- a/testdata/collaboration/volt-discussion-1.md
+++ b/testdata/collaboration/volt-discussion-1.md
@@ -1,0 +1,88 @@
+## Problem
+
+AI coding agents must coordinate changes across declarations, callers, matches, effects, modules, and tests, but existing language tooling often exposes these obligations only after partial failure.
+
+## Goals
+
+- Evaluate safe evolution of existing codebases as a primary use case.
+- Make required change impact explicit, deterministic, and machine-readable.
+- Preserve unrelated behavior and expose incomplete repository-wide propagation.
+
+## Non-goals
+
+- Production-grade language or ecosystem work in v0.
+- Automatic application of compiler repairs.
+
+## Constraints
+
+- GitHub Discussions, Issues, Milestones, and Projects remain canonical planning state.
+- The v0 kernel stays deliberately small.
+
+## Proposed Shape
+
+Use a small language kernel, deterministic reference interpreter, machine-readable diagnostics, and a controlled repository-level study.
+
+## Promotion map
+
+Target milestone: **Volt v0 — Evidence-Ready Research Prototype**
+
+### Spec 1 — Research evidence and evaluation protocol
+
+Update the evidence matrix, hypotheses, twelve-task repository-evolution workload, strict primary outcomes, fairness controls, six-endpoint analysis, power procedure, operational metrics, schemas, traceability, and falsification thresholds.
+
+Acceptance criteria:
+
+- Prior evidence, counterevidence, Volt hypotheses, and implementation directions are distinguished.
+- `repository_change_success_rate` has a reproducible all-criteria definition with no partial credit.
+- Expected impact surfaces and preservation assertions are frozen before confirmatory execution.
+- All eleven metrics have deterministic definitions and fixtures; no composite is authoritative.
+- The six-comparison Holm family, power rule, support rule, and falsification rule are machine-readable.
+- Safe evolution remains explicitly unvalidated.
+
+Dependencies: none.
+
+Approval note: this is a material amendment to existing Issue #3 and requires owner reapproval.
+
+### Spec 2 — Volt v0 language kernel and canonical syntax
+
+Specify grammar, static semantics, explicit imports and module boundaries, closed ADTs, exhaustiveness, `Result`, exact effect sets, accepted/rejected examples, canonical formatting, and feature boundaries. Add the deterministic impact-list rule for public type, contract, effect, and module-boundary changes without expanding the v0 feature set.
+
+Acceptance criteria:
+
+- Every required construct has one canonical spelling and parse shape.
+- Type, effect, match, import, and public-contract obligations are deterministic.
+- Public-change categories define stable affected-symbol and diagnostic obligations.
+- Accepted and rejected fixtures cover every v0 construct, exclusion, and supported public-change category.
+- The kernel supports all twelve maintenance tasks without deferred features.
+
+Dependencies: blocked by Spec 1.
+
+### Spec 3 — Reference interpreter, program graph, and DiagnosticV1 protocol
+
+Specify the compiler pipeline, stable symbol identity, complete program-graph node/edge coverage, repository-level impact analysis, CLI behavior, deterministic runtime capabilities, versioned `DiagnosticV1`, text/NDJSON parity, declarative repair surfaces, semantic-diff facts, and conformance tests.
+
+Acceptance criteria:
+
+- Definitions, references, imports, callers, public contracts, ADT variants, matches, effects, operations, and related tests are represented and queryable.
+- Public changes produce deterministic affected declarations, missing propagation sites, dependency reasons, and bounded repair surfaces.
+- Impact results never report unrelated modules for covered compiler-level fixtures.
+- `DiagnosticV1` remains backward-compatible, stable-ordered, source-located, and renderer-equivalent.
+- Semantic diff distinguishes public-contract, effect, ADT, match-coverage, and unexpected-surface facts without a composite score.
+- The interpreter runs benchmark capabilities deterministically without network access.
+
+Dependencies: blocked by Specs 1 and 2.
+
+### Spec 4 — Benchmark corpus and controlled agent study
+
+Build twelve existing-repository tasks, hidden requested-behavior and preservation tests, expected-impact manifests, causal ablations, descriptive TypeScript/Rust/Gleam baselines, pinned model and prompt manifests, randomized execution, pilot and six-endpoint power analysis, raw-result storage, and complete reporting.
+
+Acceptance criteria:
+
+- The corpus contains three tasks in each maintenance family and every task begins from a passing repository.
+- Every task freezes requested behavior, minimum repair surface, actual required propagation sites, preservation assertions, and mutation-checked hidden tests.
+- Hidden tests detect incomplete matches, forgotten callers, stale contracts, effect mistakes, weakened invariants, unrelated changes, and guarantee bypass.
+- The harness records first and final repository-change success plus every operational metric.
+- Causal and descriptive results are separated and all positive, negative, inconclusive, and falsifying results are reported.
+- Runs are reproducible from content-addressed pinned inputs.
+
+Dependencies: blocked by Specs 1, 2, and 3.


### PR DESCRIPTION
## Summary

- reconcile already-promoted GitHub Discussions with Plan-managed initiatives, specs, milestones, and relationships
- parse independent multi-spec briefs with distinct acceptance criteria, verification, dependencies, and readiness
- classify preview actions as create, update, reuse, or unchanged and block ambiguous identity
- keep preview non-mutating and apply idempotent
- document reconciliation fields and add a Volt Discussion #1 fixture

## Spec

- User-provided Volt Discussion #1 reconciliation contract

## Slices

- artifact identity and ambiguity-safe reconciliation
- per-spec Promotion map parsing and rendering
- relationship discovery and idempotent apply
- CLI documentation, JSON schema documentation, and Volt fixture coverage

## Tests

- `go test ./...`
- `go build ./...`
- `go test -race ./...`
- `go vet ./...`
- live non-applying preview against JimmyMcBride/volt Discussion #1

## Migrations / Seeds

None.

## Manual QA

The non-applying Volt preview resolves initiative Issue #2 for update, Milestone #1 for reuse, spec Issues #3–#6 for update, and all existing parent/sub-issue and blocked-by relationships for reuse. It reports `confirmation_required: true` and `manual_fallback_allowed: false`.

## Screenshots

None.
