### PR TITLE
docs: render planning diagram inline

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # plan
 
-[Project planning breakdown diagram](docs/assets/plan-project-planning-breakdown.png)
+![Plan project planning breakdown diagram](docs/assets/plan-project-planning-breakdown.png)
 
 `plan` is a local-first-by-default, backend-flexible planning CLI for
 AI-assisted software work.


### PR DESCRIPTION
## Summary

- render the project planning breakdown diagram inline in the README
- preserve the existing image path and add descriptive alt text

## Why

PR #84 review identified that the diagram used ordinary Markdown link syntax, so GitHub displayed a text link instead of the image.

Addresses https://github.com/JimmyMcBride/plan/pull/84#discussion_r3653502130

## Impact

The planning breakdown is visible directly beneath the README title. No runtime behavior changes.

## Checks

- `go test ./...`
- `go build ./...`
- `git diff --check`
- verified `docs/assets/plan-project-planning-breakdown.png` exists
