### PR TITLE
docs: pull diagram fix into v0.1.28

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # plan
 
-[Project planning breakdown diagram](docs/assets/plan-project-planning-breakdown.png)
+![Plan project planning breakdown diagram](docs/assets/plan-project-planning-breakdown.png)
 
 `plan` is a local-first-by-default, backend-flexible planning CLI for
 AI-assisted software work.


### PR DESCRIPTION
## Summary

- cherry-pick the README diagram rendering fix from merged develop PR #85
- update the v0.1.28 release candidate without bypassing release-branch protection

## Source

- Develop PR: #85
- Develop merge commit: `53ebd96bb954472d844651179bfe4e75baab96a0`
- Release cherry-pick: `dc08f6d`
- Original review: https://github.com/JimmyMcBride/plan/pull/84#discussion_r3653502130

## Impact

The planning breakdown diagram renders inline in README instead of appearing as a text link. No runtime behavior changes.

## Checks

- `go test ./...`
- `go build ./...`
- `git diff --check`
