### PR TITLE
Pin standalone Planning to Brain v0.1.21

### DIFF
--- a/.brain/context/architecture.md
+++ b/.brain/context/architecture.md
@@ -1,5 +1,5 @@
 ---
-updated: "2026-08-10T07:23:35Z"
+updated: "2026-09-01T14:51:24Z"
 ---
 # Architecture
 
@@ -32,4 +32,4 @@ Use this file for the structural shape of the repository.
   `.plan/` disk contract is unchanged.
 - GitHub, hybrid, legacy epic/story, unsupported guide checkpoints, and invalid
   legacy spec repair paths remain standalone fallbacks.
-- `go.mod` must pin a merged Brain revision without a local `replace` directive.
+- `go.mod` must pin a published stable Brain tag without a local `replace` directive.

--- a/.brain/context/current-state.md
+++ b/.brain/context/current-state.md
@@ -1,5 +1,5 @@
 ---
-updated: "2026-08-10T07:23:35Z"
+updated: "2026-09-01T14:51:24Z"
 ---
 # Current State
 
@@ -12,7 +12,7 @@ This file is a deterministic snapshot of the repository state at the last refres
 - Root: `.`
 - Runtime: `go`
 - Go module: `plan`
-- Current branch: `codex/plan-cli-compatibility-standalone-cutover`
+- Current branch: `develop`
 - Default branch: `main`
 - Remote: `https://github.com/JimmyMcBride/plan.git`
 - Go test files: `572`
@@ -43,8 +43,9 @@ Add repo-specific notes here. `brain context refresh` preserves content outside 
 - On May 16, 2026, the Linear integration brainstorm promoted into GitHub planning issue `#78` with spec issues `#79`-`#81` and milestone `Linear integration`; MVP direction is Linear source mode plus agent-mediated MCP promotion packets, with direct Linear API/auth, Linear Initiatives, status sync, reconcile, milestones, and sub-issues deferred.
 - On May 16, 2026, spec `#79` added the Linear source/config foundation: `linear` is a first-class source mode, `.plan/.meta/linear.json` stores minimum Linear workspace/team metadata, `plan source show` surfaces missing team guidance, and Linear promotion apply fails before handoff when no `team_id` or `team_key` is configured.
 - On May 16, 2026, PR `#82` review follow-up made Linear guide-packet apply actions explicitly blocked until the Linear MCP handoff flow lands and made `plan discuss promote --apply/--confirm` help text backend-neutral.
-- On August 10, 2026, the standalone compatibility cutover pinned Brain merge
-  `c2c71279030f` and routed compatible schema-v3 local planning commands through
-  Brain's public Planning packages. The standalone host retains presentation,
-  GitHub/hybrid ownership, and legacy repair behavior; its migration warning is
+- On September 1, 2026, the standalone compatibility cutover moved from the
+  temporary Brain merge pin to published Brain `v0.1.21`. Compatible schema-v3
+  local planning commands use Brain's public Planning packages without a local
+  replacement. The standalone host retains presentation, GitHub/hybrid
+  ownership, and legacy repair behavior; its migration warning remains
   interactive-only, stderr-only, and once per process.

--- a/.brain/context/workflows.md
+++ b/.brain/context/workflows.md
@@ -1,5 +1,5 @@
 ---
-updated: "2026-08-10T07:23:35Z"
+updated: "2026-09-01T14:51:24Z"
 ---
 # Workflows
 
@@ -70,7 +70,7 @@ After `brain adopt` creates starter context, the AI agent must scan the repo bef
 
 ### Brain Planning Compatibility
 
-- Verify delegated local commands against the pinned merged Brain revision and
+- Verify delegated local commands against the pinned stable Brain release and
   preserve standalone CLI output contracts.
 - Do not add a local `replace` directive for Brain.
 - Test the interactive warning and its JSON/noninteractive suppression before

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,5 +1,5 @@
 ---
-updated: "2026-08-10T07:23:35Z"
+updated: "2026-09-01T14:51:24Z"
 ---
 # Project Agent Contract
 
@@ -232,7 +232,7 @@ go run . check --project .
 
 ### Brain Planning Compatibility
 
-- Compatible schema-v3 local planning commands delegate to the pinned merged
+- Compatible schema-v3 local planning commands delegate to the pinned stable
   Brain Planning packages; standalone Plan remains the CLI presentation host.
 - Keep GitHub, hybrid, legacy, and unsupported paths on their existing
   standalone implementations until their migration slices are approved.

--- a/cmd/shared_planning_test.go
+++ b/cmd/shared_planning_test.go
@@ -13,7 +13,7 @@ import (
 	"plan/internal/workspace"
 )
 
-const pinnedBrainPlanningVersion = "github.com/JimmyMcBride/brain v0.1.15-0.20260810065410-c2c71279030f"
+const pinnedBrainPlanningVersion = "github.com/JimmyMcBride/brain v0.1.21"
 
 func TestBrainPlanningDependencyIsPinnedWithoutReplace(t *testing.T) {
 	raw, err := os.ReadFile(filepath.Join("..", "go.mod"))

--- a/docs/project-architecture.md
+++ b/docs/project-architecture.md
@@ -1,5 +1,5 @@
 ---
-updated: "2026-08-10T07:23:35Z"
+updated: "2026-09-01T14:51:24Z"
 ---
 # Project Architecture
 
@@ -33,5 +33,5 @@ Use this file for the structural shape of the repository.
   contract stays unchanged.
 - GitHub, hybrid, legacy epic/story, unsupported guide checkpoints, and invalid
   legacy spec repair paths remain standalone fallbacks.
-- Brain must be pinned to a merged revision in `go.mod`; local `replace`
+- Brain must be pinned to a published stable tag in `go.mod`; local `replace`
   directives are not allowed for the compatibility cutover.

--- a/docs/project-workflows.md
+++ b/docs/project-workflows.md
@@ -1,5 +1,5 @@
 ---
-updated: "2026-08-10T07:23:35Z"
+updated: "2026-09-01T14:51:24Z"
 ---
 # Project Workflows
 
@@ -78,7 +78,7 @@ After `brain adopt` creates starter context, the AI agent must scan the repo bef
 
 - When changing a delegated local workflow, verify both the standalone command
   contract and the pinned Brain package contract.
-- Keep the Brain module pin on a merged revision and reject local `replace`
+- Keep the Brain module pin on a published stable tag and reject local `replace`
   directives in tests.
 - Verify JSON/noninteractive warning suppression plus once-per-process
   interactive warning behavior before release.

--- a/docs/using-plan.md
+++ b/docs/using-plan.md
@@ -1,3 +1,6 @@
+---
+updated: "2026-09-01T14:51:24Z"
+---
 # Using `plan`
 
 This guide describes how to use `plan` as it exists right now.
@@ -27,7 +30,7 @@ still document legacy compatibility commands while the migration is in flight.
 
 ### Brain Planning compatibility cutover
 
-The standalone CLI pins a merged Brain revision and uses Brain's public
+The standalone CLI pins a stable Brain release and uses Brain's public
 Planning application and local-adapter packages for compatible local `doctor`,
 `status`, `check`, `roadmap`, `brainstorm`, `guide`, `discuss`, and `spec`
 operations. The standalone command layer remains responsible for flags,

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module plan
 go 1.26
 
 require (
-	github.com/JimmyMcBride/brain v0.1.15-0.20260810065410-c2c71279030f
+	github.com/JimmyMcBride/brain v0.1.21
 	github.com/mattn/go-isatty v0.0.20
 	github.com/spf13/cobra v1.10.1
 	gopkg.in/yaml.v3 v3.0.1

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,5 @@
-github.com/JimmyMcBride/brain v0.1.15-0.20260810065410-c2c71279030f h1:rkV6ZIPmnHxJBwUxnhoLX5xr85ScXymzFUpMA50yuqU=
-github.com/JimmyMcBride/brain v0.1.15-0.20260810065410-c2c71279030f/go.mod h1:3IX7jT1reTv/vPib2fv/IR61k0aBLS98jVj6cM1vtfI=
+github.com/JimmyMcBride/brain v0.1.21 h1:/V3KfRzHdvW8I/hFtiPAtICerDLPegruJU51XmXzN3M=
+github.com/JimmyMcBride/brain v0.1.21/go.mod h1:3IX7jT1reTv/vPib2fv/IR61k0aBLS98jVj6cM1vtfI=
 github.com/cpuguy83/go-md2man/v2 v2.0.6/go.mod h1:oOW0eioCTA6cOiMLiUPZOpcVxMig6NIQQ7OS05n1F4g=
 github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=
 github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=


### PR DESCRIPTION
## Summary

- Replace standalone Plan's temporary Brain pseudo-version with published Brain `v0.1.21`.
- Lock the stable package pin in tests and update compatibility architecture/workflow guidance.
- Preserve the merged Phase 4 local delegation behavior without workspace or output changes.

## Target Branch

- Normal work targets `develop`.

## Testing

- [x] `go test ./...`
- [x] `go test -race ./...`
- [x] `go vet ./...`
- [x] `go build ./...`
- [x] `GOOS=windows GOARCH=amd64 go build ./...`
- [x] Windows command-test compile
- [x] `go mod verify`
- [x] `go list -m github.com/JimmyMcBride/brain` → `v0.1.21`
- [x] `go run . check --project .` → 0 findings

## Workflow Readiness

- [x] `brain session finish` completed before this PR is marked ready or merged.
- [x] Required Brain durable notes, docs, and contract updates are committed in this PR.

## Release Notes

- User-facing change: Standalone Plan now consumes the stable Brain `v0.1.21` Planning packages instead of a temporary commit pseudo-version.
- Planning or workflow impact: No CLI or `.plan/` contract change; this completes the stable dependency portion of Phase 4 rollout.
- Follow-up work: Publish the next standalone Plan release, record final rollout verification in Brain, and close Phase 4.

## Planning

- Spec: [Plan CLI compatibility](https://github.com/JimmyMcBride/brain/blob/develop/.plan/specs/plan-cli-compatibility.md)
- Slice: Phase 4 slice 8, stable cross-repository rollout.
- Brain release: [v0.1.21](https://github.com/JimmyMcBride/brain/releases/tag/v0.1.21)
- Migrations: None.
- Manual QA: Full standalone compatibility suite against stable Brain tag.
- Screenshots: Not applicable.
